### PR TITLE
Fix compilation issues on Fedora 22 & newer libhawkey

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -77,7 +77,7 @@ TDNFCheckLocalPackages(
     }
     fprintf(stdout, "Checking all packages from: %s\n", pszLocalPath);
 
-    hSack = hy_sack_create(NULL, NULL, NULL, 0);
+    hSack = hy_sack_create(NULL, NULL, NULL, NULL, 0);
     if(!hSack)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
@@ -106,7 +106,7 @@ TDNFCheckLocalPackages(
 
         if(!hPkg)
         {
-            dwError = ERROR_TDNF_INVALID_PARAMETER; 
+            dwError = ERROR_TDNF_INVALID_PARAMETER;
             BAIL_ON_TDNF_ERROR(dwError);
         }
         hy_packagelist_push(hPkgList, hPkg);
@@ -851,7 +851,7 @@ TDNFSearchCommand(
         }
     }
 
-    hSack = hy_sack_create(NULL, NULL, NULL, 0);
+    hSack = hy_sack_create(NULL, NULL, NULL, NULL, 0);
     if(!hSack)
     {
         unError = HY_E_IO;

--- a/client/init.c
+++ b/client/init.c
@@ -69,7 +69,7 @@ TDNFInitSack(
 
     pszHawkeyCacheDir = pTdnf->pConf->pszCacheDir;
 
-    hSack = hy_sack_create(pszHawkeyCacheDir, NULL, "/", 0);
+    hSack = hy_sack_create(pszHawkeyCacheDir, NULL, NULL, "/", 0);
     if(!hSack)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;

--- a/configure.ac
+++ b/configure.ac
@@ -17,14 +17,17 @@ AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(AM_CFLAGS)
 
 #hawkey lib
+PKG_CHECK_MODULES([HAWKEY], [hawkey])
+CPPFLAGS="$CPPFLAGS $HAWKEY_CFLAGS"
 echo "Looking for hawkey headers"
 AC_CHECK_HEADERS(hawkey/sack.h)
 
 echo "Looking for hawkey libs"
 AC_CHECK_LIB(hawkey, hy_sack_count)
 
-CPPFLAGS="-I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include"
 #glib
+PKG_CHECK_MODULES([GLIB], [glib-2.0])
+CPPFLAGS="$CPPFLAGS $GLIB_CFLAGS"
 echo "Looking for glib headers"
 AC_CHECK_HEADERS(glib.h)
 AC_CHECK_HEADERS(glibconfig.h)

--- a/tools/cli/help.c
+++ b/tools/cli/help.c
@@ -55,6 +55,7 @@ TDNFCliShowHelp(
     printf("makecache                 Generate the metadata cache\n");
     printf("provides                  Find what package provides the given value\n");
     printf("reinstall                 reinstall a package\n");
+    printf("remove                    Remove a package or packages from your system\n");
     printf("repolist                  Display the configured software repositories\n");
     printf("repository-packages       Run commands on top of all packages in given repository\n");
     printf("search                    Search package details for the given string\n");


### PR DESCRIPTION
* Minor changes to configure.ac in order to rely on pkgconfig and not hardcoded paths
* hawkey changed signatures in sack.h, fixed it

Tested in Fedora 21/22 and rawhide and works as a drop-in replacement to dnf for basic usage.