### PR TITLE
Fix free with install attempt of non-existent packages. Fix reinstall bug.

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -456,6 +456,12 @@ TDNFTransAddInstallPkgs(
     );
 
 uint32_t
+TDNFTransAddReInstallPkgs(
+    PTDNFRPMTS pTS,
+    PTDNF pTdnf
+    );
+
+uint32_t
 TDNFTransAddInstallPkg(
     PTDNFRPMTS pTS,
     PTDNF pTdnf,

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -248,6 +248,10 @@ TDNFGetSelector(
                 0);
     if(hy_possibilities_next_nevra(hPoss, &hNevra) == -1)
     {
+        //make sure that we reset on failure to avoid
+        //a potential double free
+        hNevra = NULL;
+
         dwError = ERROR_TDNF_NO_SEARCH_RESULTS;
         BAIL_ON_TDNF_ERROR(dwError);
     }


### PR DESCRIPTION
When attempting to find version of a non-existent package, after the call fails, null out out var so it wont be freed on exit.
Include reinstall packages in transaction.