### PR TITLE
Exit with status 0 when result is nothing todo

### DIFF
--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -116,6 +116,11 @@ cleanup:
 
 error:
     PrintError(dwError);
+    if (dwError == ERROR_TDNF_CLI_NOTHING_TO_DO)
+    {
+        // Nothing to do should not return an error code
+        dwError = 0;
+    }
     goto cleanup;
 }
 


### PR DESCRIPTION
Nothing to do doesn't mean an error with an operation.