### PR TITLE
Handle obsoletes, add list/info on downgrades

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -689,7 +689,8 @@ TDNFResolve(
         pSolvedPkgInfo->pPkgsToDowngrade ||
         pSolvedPkgInfo->pPkgsToRemove  ||
         pSolvedPkgInfo->pPkgsUnNeeded ||
-        pSolvedPkgInfo->pPkgsToReinstall;
+        pSolvedPkgInfo->pPkgsToReinstall ||
+        pSolvedPkgInfo->pPkgsObsoleted;
 
     pSolvedPkgInfo->nNeedDownload =
         pSolvedPkgInfo->pPkgsToInstall ||

--- a/client/client.c
+++ b/client/client.c
@@ -61,6 +61,9 @@ TDNFApplyScopeFilter(
         case SCOPE_RECENT:
             hy_query_filter_latest_per_arch(hQuery, 1);
             break;
+        case SCOPE_DOWNGRADES:
+            hy_query_filter_downgrades(hQuery, 1);
+            break;
 
         default:
             break;

--- a/client/goal.c
+++ b/client/goal.c
@@ -38,6 +38,7 @@ TDNFGoal(
     PTDNF_PKG_INFO pPkgsToRemove = NULL;
     PTDNF_PKG_INFO pPkgsUnNeeded = NULL;
     PTDNF_PKG_INFO pPkgsToReinstall = NULL;
+    PTDNF_PKG_INFO pPkgsObsoleted = NULL;
 
     int nFlags = 0;
     int nRequirePkgList =
@@ -95,6 +96,7 @@ TDNFGoal(
         case ALTER_INSTALL:
             dwError = TDNFPackageGetLatest(hPkgList, &hPkg);
             BAIL_ON_TDNF_ERROR(dwError);
+
             dwError = hy_goal_install(hGoal, hPkg);
             BAIL_ON_TDNF_HAWKEY_ERROR(dwError);
             break;
@@ -157,6 +159,11 @@ TDNFGoal(
                   &pPkgsToRemove);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFGoalGetResultsIgnoreNoData(
+                  hy_goal_list_obsoleted(hGoal),
+                  &pPkgsObsoleted);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     if(nResolveFor == ALTER_AUTOERASE)
     {
         dwError = TDNFGoalGetResultsIgnoreNoData(
@@ -175,6 +182,7 @@ TDNFGoal(
     pInfo->pPkgsToRemove = pPkgsToRemove;
     pInfo->pPkgsUnNeeded = pPkgsUnNeeded;
     pInfo->pPkgsToReinstall = pPkgsToReinstall;
+    pInfo->pPkgsObsoleted = pPkgsObsoleted;
     pTdnf->hGoal = hGoal;
 
 cleanup:
@@ -209,6 +217,10 @@ error:
     if(pPkgsToReinstall)
     {
         TDNFFreePackageInfo(pPkgsToReinstall);
+    }
+    if(pPkgsObsoleted)
+    {
+        TDNFFreePackageInfo(pPkgsObsoleted);
     }
     goto cleanup;
 }

--- a/client/memory.c
+++ b/client/memory.c
@@ -134,6 +134,7 @@ TDNFFreeSolvedPackageInfo(
        TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsToRemove);
        TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsUnNeeded);
        TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsToReinstall);
+       TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsObsoleted);
     }
     TDNF_SAFE_FREE_MEMORY(pSolvedPkgInfo);
 }

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -468,6 +468,12 @@ TDNFTransAddErasePkgs(
     );
 
 uint32_t
+TDNFTransAddObsoletedPkgs(
+    PTDNFRPMTS pTS,
+    PTDNF pTdnf
+    );
+
+uint32_t
 TDNFTransAddErasePkg(
     PTDNFRPMTS pTS,
     HyPackage hPkg

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -56,7 +56,8 @@ typedef enum
     ALTER_REINSTALL,
     ALTER_UPGRADE,
     ALTER_UPGRADEALL,
-    ALTER_DISTRO_SYNC
+    ALTER_DISTRO_SYNC,
+    ALTER_OBSOLETED
 }TDNF_ALTERTYPE;
 
 typedef enum
@@ -163,6 +164,7 @@ typedef struct _TDNF_SOLVED_PKG_INFO
     PTDNF_PKG_INFO pPkgsToRemove;
     PTDNF_PKG_INFO pPkgsUnNeeded;
     PTDNF_PKG_INFO pPkgsToReinstall;
+    PTDNF_PKG_INFO pPkgsObsoleted;
 }TDNF_SOLVED_PKG_INFO, *PTDNF_SOLVED_PKG_INFO;
 
 typedef struct _TDNF_CMD_ARGS

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -82,7 +82,8 @@ typedef enum
     SCOPE_EXTRAS,
     SCOPE_OBSOLETES,
     SCOPE_RECENT,
-    SCOPE_UPGRADES
+    SCOPE_UPGRADES,
+    SCOPE_DOWNGRADES
 }TDNF_SCOPE;
 
 //availability - updateinfo

--- a/tools/cli/installcmd.c
+++ b/tools/cli/installcmd.c
@@ -227,6 +227,11 @@ TDNFCliAlterCommand(
         dwError = PrintAction(pSolvedPkgInfo->pPkgsToReinstall, ALTER_REINSTALL);
         BAIL_ON_CLI_ERROR(dwError);
     }
+    if(pSolvedPkgInfo->pPkgsObsoleted)
+    {
+        dwError = PrintAction(pSolvedPkgInfo->pPkgsObsoleted, ALTER_OBSOLETED);
+        BAIL_ON_CLI_ERROR(dwError);
+    }
 
     if(pSolvedPkgInfo->nNeedAction)
     {
@@ -355,19 +360,22 @@ PrintAction(
     switch(nAlterType)
     {
         case ALTER_INSTALL:
-            printf("Installing:");
+            printf("\nInstalling:");
             break;
         case ALTER_UPGRADE:
-            printf("Upgrading:");
+            printf("\nUpgrading:");
             break;
         case ALTER_ERASE:
-            printf("Removing:");
+            printf("\nRemoving:");
             break;
         case ALTER_DOWNGRADE:
-            printf("Downgrading:");
+            printf("\nDowngrading:");
             break;
         case ALTER_REINSTALL:
-            printf("Reinstalling:");
+            printf("\nReinstalling:");
+            break;
+        case ALTER_OBSOLETED:
+            printf("\nObsoleting:");
             break;
         default:
             dwError = ERROR_TDNF_INVALID_PARAMETER;

--- a/tools/cli/parselistargs.c
+++ b/tools/cli/parselistargs.c
@@ -110,7 +110,8 @@ ParseScope(
         {"obsoletes", SCOPE_OBSOLETES},
         {"recent",    SCOPE_RECENT},
         {"upgrades",  SCOPE_UPGRADES},
-        {"updates",   SCOPE_UPGRADES}
+        {"updates",   SCOPE_UPGRADES},
+        {"downgrades",SCOPE_DOWNGRADES}
     };
     int nCount = sizeof(stScopes)/sizeof(stScopes[0]);
     for(nIndex = 0; nIndex < nCount; ++nIndex)


### PR DESCRIPTION
obsoleted packages were not handled during resolution. This is handled now. 
being able to list available downgrades using list/info command is added (tdnf list downgrades / tdnf info downgrades)
Minor - Added a new line after each category in resolution (installing, upgrading etc) for readability