### PR TITLE
Support --releasever option

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1026,6 +1026,7 @@ TDNFFreeCmdArgs(
     }
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszInstallRoot);
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszConfFile);
+    TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszReleaseVer);
 
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->pSetOpt);
     TDNF_SAFE_FREE_MEMORY(pCmdArgs);

--- a/client/config.c
+++ b/client/config.c
@@ -207,6 +207,15 @@ TDNFConfigExpandVars(
     }
     pConf = pTdnf->pConf;
 
+    //Allow --releasever overrides
+    if(!pConf->pszVarReleaseVer &&
+       !IsNullOrEmptyString(pTdnf->pArgs->pszReleaseVer))
+    {
+        dwError = TDNFAllocateString(pTdnf->pArgs->pszReleaseVer,
+                      &pConf->pszVarReleaseVer);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     if(!pConf->pszVarReleaseVer &&
        !IsNullOrEmptyString(pConf->pszDistroVerPkg))
     {

--- a/client/init.c
+++ b/client/init.c
@@ -147,6 +147,13 @@ TDNFCloneCmdArgs(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if(!IsNullOrEmptyString(pCmdArgsIn->pszReleaseVer))
+    {
+        dwError = TDNFAllocateString(
+                      pCmdArgsIn->pszReleaseVer,
+                      &pCmdArgs->pszReleaseVer);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
     pCmdArgs->nCmdCount = pCmdArgsIn->nCmdCount;
     dwError = TDNFAllocateMemory(

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -199,6 +199,7 @@ typedef struct _TDNF_CMD_ARGS
     int nIPv6;             //resolve to IPv6 addresses only
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location
+    char* pszReleaseVer;   //Release version
 
     //Commands and args that do not fall in options
     char** ppszCmds;

--- a/tools/cli/parseargs.c
+++ b/tools/cli/parseargs.c
@@ -41,6 +41,7 @@ static struct option pstOptions[] =
     {"installroot",   required_argument, 0, 'i'},          //--installroot
     {"nogpgcheck",    no_argument, &_opt.nNoGPGCheck, 1},  //--nogpgcheck
     {"refresh",       no_argument, &_opt.nRefresh, 1},     //--refresh 
+    {"releasever",    required_argument, 0, 0},            //--releasever
     {"rpmverbosity",  required_argument, 0, 0},            //--rpmverbosity
     {"setopt",        required_argument, 0, 0},            //--set or override options
     {"showduplicates",required_argument, 0, 0},            //--showduplicates
@@ -93,6 +94,7 @@ TDNFCliParseArgs(
             switch (nOption)
             {
                 case 0:
+                case 'i':
                     dwError = ParseOption(
                                   pstOptions[nOptionIndex].name,
                                   optarg,
@@ -109,12 +111,6 @@ TDNFCliParseArgs(
                 break;
                 case 'h':
                     _opt.nShowHelp = 1;
-                break;
-                case 'i':
-                    dwError = TDNFAllocateString(
-                             optarg,
-                             &pCmdArgs->pszInstallRoot);
-                    BAIL_ON_CLI_ERROR(dwError);
                 break;
                 case 'r':
                 break;
@@ -302,42 +298,30 @@ ParseOption(
 
     if(!strcasecmp(pszName, "rpmverbosity"))
     {
-        if(!optarg)
-        {
-            dwError = ERROR_TDNF_CLI_OPTION_ARG_REQUIRED;
-            BAIL_ON_CLI_ERROR(dwError);
-        }
         dwError = ParseRpmVerbosity(
-                      optarg,
+                      pszArg,
                       &pCmdArgs->nRpmVerbosity);
         BAIL_ON_CLI_ERROR(dwError);
     }
     else if(!strcasecmp(pszName, "enablerepo"))
     {
-        if(!optarg)
-        {
-            dwError = ERROR_TDNF_CLI_OPTION_ARG_REQUIRED;
-            BAIL_ON_CLI_ERROR(dwError);
-        }
-        fprintf(stdout, "EnableRepo: %s\n", optarg);
     }
     else if(!strcasecmp(pszName, "disablerepo"))
     {
-        if(!optarg)
-        {
-            dwError = ERROR_TDNF_CLI_OPTION_ARG_REQUIRED;
-            BAIL_ON_CLI_ERROR(dwError);
-        }
-        fprintf(stdout, "DisableRepo: %s\n", optarg);
     }
     else if(!strcasecmp(pszName, "installroot"))
     {
-        if(!optarg)
-        {
-            dwError = ERROR_TDNF_CLI_OPTION_ARG_REQUIRED;
-            BAIL_ON_CLI_ERROR(dwError);
-        }
-        fprintf(stdout, "InstallRoot: %s\n", optarg);
+        dwError = TDNFAllocateString(
+                      optarg,
+                      &pCmdArgs->pszInstallRoot);
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+    else if(!strcasecmp(pszName, "releasever"))
+    {
+        dwError = TDNFAllocateString(
+                      optarg,
+                      &pCmdArgs->pszReleaseVer);
+        BAIL_ON_CLI_ERROR(dwError);
     }
     else if(!strcasecmp(pszName, "setopt"))
     {


### PR DESCRIPTION
--releasever helps to override releasever inferred from current environment. helpful in chroot installs and during system upgrades.