### PR TITLE
Fix TDNF build configuration to use pkgconfig data to find dependencies

### DIFF
--- a/client/Makefile.am
+++ b/client/Makefile.am
@@ -26,6 +26,5 @@ libtdnf_la_LIBADD =  \
     @top_builddir@/solv/libtdnfsolv.la \
     $(top_builddir)/common/libcommon.la \
     @LIBCURL_LIBS@ \
-    -lrpm  \
-    -lsolv \
-    -lsolvext
+    @RPM_LIBS@ \
+    @LIBSOLVEXT_LIBS@

--- a/configure.ac
+++ b/configure.ac
@@ -2,42 +2,44 @@ AC_INIT(tdnf, 2.0.0)
 AC_MSG_NOTICE([tdnf configuration])
 
 AC_CANONICAL_SYSTEM
-AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+AM_INIT_AUTOMAKE([-Wall foreign])
 
 AC_CONFIG_TESTDIR(tests)
 
 AM_PROG_AR
 
 AC_PROG_CC
+
 #LT_INIT
 AC_PROG_LIBTOOL
 
 CPPFLAGS="$CPPFLAGS -D_REENTRANT -D_GNU_SOURCE -fPIC"
 
 AM_CPPFLAGS="$AM_CPPFLAGS -I${top_srcdir}/include"
-AM_CFLAGS="$AM_CFLAGS -Wall -Werror -fno-strict-aliasing"
+AM_CFLAGS="$AM_CFLAGS -std=gnu99 -Wall -fno-strict-aliasing"
 
 CPPFLAGS="$CPPFLAGS -D_REENTRANT -D_GNU_SOURCE -fPIC"
 AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(AM_CFLAGS)
 
 #libsolv
-echo "Looking for libsolv headers"
-AC_CHECK_HEADERS(solv/pool.h)
+PKG_CHECK_MODULES([LIBSOLV], [libsolv], [have_libsolv=yes], [have_libsolv=no])
+PKG_CHECK_MODULES([LIBSOLVEXT], [libsolvext], [have_libsolvext=yes], [have_libsolvext=no])
+AM_CONDITIONAL([LIBSOLV],  [test "$have_libsolv" = "yes"])
+AM_CONDITIONAL([LIBSOLVEXT],  [test "$have_libsolvext" = "yes"])
 
-echo "Looking for libsolv libs"
-AC_CHECK_LIB(solv, pool_create)
-
-#licurl
+#libcurl
 PKG_CHECK_MODULES([LIBCURL], [libcurl], [have_libcurl=yes], [have_libcurl=no])
 AM_CONDITIONAL([LIBCURL],  [test "$have_libcurl" = "yes"])
 
 #rpm
-echo "Looking for librpm headers"
-AC_CHECK_HEADERS(rpm/rpmlib.h)
+PKG_CHECK_MODULES([RPM], [rpm], [have_rpm=yes], [have_rpm=no])
+AM_CONDITIONAL([RPM], [test "$have_rpm" = "yes"])
 
-echo "Looking for librpm libs"
-AC_CHECK_LIB(rpm, rpmtsCreate)
+# test to prove rpm.org rpm
+echo "Looking for rpm.org librpm headers"
+AC_CHECK_HEADERS(rpm/header.h)
+
 
 #makefiles
 AC_CONFIG_FILES([Makefile

--- a/solv/Makefile.am
+++ b/solv/Makefile.am
@@ -10,5 +10,5 @@ libtdnfsolv_la_SOURCES = \
     
 libtdnfsolv_la_LDFLAGS =  \
     -static \
-    -lrpm  \
-    -lsolv
+    @RPM_LIBS@ \
+    @LIBSOLV_LIBS@

--- a/tdnf-cli-libs.pc.in
+++ b/tdnf-cli-libs.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@/tdnf
 Name: tdnf-cli-libs
 Description: tdnf cli libs
 Version: @VERSION@
-Requires:
+Requires: tdnf
 Libs: -L${libdir} -ltdnfcli
 Cflags: -I${includedir}

--- a/tdnf.pc.in
+++ b/tdnf.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@/tdnf
 Name: tdnf
 Description: tiny dandified yum
 Version: @VERSION@
-Requires:libsolv rpm
+Requires: libsolv libsolvext rpm libcurl
 Libs: -L${libdir} -ltdnf
 Cflags: -I${includedir}


### PR DESCRIPTION
With the notable exception of identifying that we're using rpm.org rpm, all the configuration of how to use dependencies to compile and link TDNF and its libraries should come from pkgconfig. That way, TDNF will reliably build across more platforms.

In addition, trivial changes to drop `-Werror` and specify that `-std=gnu99` is required for the build are included so that it will compile properly on compilers that do not default to newer C standards and not make assumptions about what is coerced from a warning to an error by default.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>