### PR TITLE
Minor fixes all over the place.

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -270,7 +270,7 @@ TDNFCheckLocalPackages(
         dwError = errno;
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
-    fprintf(stdout, "Checking all packages from: %s\n", pszLocalPath);
+    printf("Checking all packages from: %s\n", pszLocalPath);
 
     pCmdLinePool = pool_create();
     pool_set_rootdir(pCmdLinePool, pTdnf->pArgs->pszInstallRoot);
@@ -313,7 +313,7 @@ TDNFCheckLocalPackages(
         pszRPMPath = NULL;
     }
     repo_internalize(pCmdlineRepo);
-    fprintf(stdout, "Found %d packages\n", dwPackagesFound);
+    printf("Found %u packages\n", dwPackagesFound);
 
     pSolv = solver_create(pCmdLinePool);
     if(pSolv == NULL)
@@ -500,8 +500,8 @@ TDNFInfo(
     PTDNF_PKG_INFO pPkgInfo = NULL;
     PSolvPackageList pPkgList = NULL;
 
-    if(!pTdnf || !pTdnf->pSack ||!pdwCount || !ppPkgInfo || 
-       !ppszPackageNameSpecs || !pTdnf->pSack)
+    if(!pTdnf || !pTdnf->pSack ||!pdwCount || !ppPkgInfo ||
+       !ppszPackageNameSpecs)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -875,8 +875,8 @@ error:
     goto cleanup;
 }
 
-//Resolve alter command before presenting 
-//the goal steps to user for approval 
+//Resolve alter command before presenting
+//the goal steps to user for approval
 uint32_t
 TDNFResolve(
     PTDNF pTdnf,
@@ -898,7 +898,7 @@ TDNFResolve(
     }
 
     queue_init(&queueGoal);
-    
+
     if(nAlterType == ALTER_AUTOERASE)
     {
         dwError = ERROR_TDNF_AUTOERASE_UNSUPPORTED;
@@ -944,7 +944,7 @@ TDNFResolve(
     dwError = TDNFCheckProtectedPkgs(pSolvedPkgInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    pSolvedPkgInfo->nNeedAction = 
+    pSolvedPkgInfo->nNeedAction =
         pSolvedPkgInfo->pPkgsToInstall ||
         pSolvedPkgInfo->pPkgsToUpgrade ||
         pSolvedPkgInfo->pPkgsToDowngrade ||
@@ -1040,7 +1040,7 @@ TDNFSearchCommand(
                   (void**)&pPkgInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    for(nIndex = 0; nIndex < unCount; nIndex++)
+    for(nIndex = 0; (uint32_t)nIndex < unCount; nIndex++)
     {
         PTDNF_PKG_INFO pPkg = &pPkgInfo[nIndex];
 
@@ -1093,8 +1093,6 @@ error:
 uint32_t
 TDNFUpdateInfo(
     PTDNF pTdnf,
-    TDNF_SCOPE nScope,
-    TDNF_AVAIL nAvail,
     char** ppszPackageNameSpecs,
     PTDNF_UPDATEINFO* ppUpdateInfo
     )
@@ -1171,7 +1169,7 @@ TDNFUpdateInfo(
         dwError = SolvGetPackageListSize(pUpdateAdvPkgList, &nCount);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        for(iAdv = 0; iAdv < nCount; iAdv++)
+        for(iAdv = 0; (uint32_t)iAdv < nCount; iAdv++)
         {
             dwError = SolvGetPackageId(pUpdateAdvPkgList, iAdv, &dwAdvId);
             BAIL_ON_TDNF_ERROR(dwError);
@@ -1199,8 +1197,7 @@ TDNFUpdateInfo(
 
     if(!pUpdateInfos)
     {
-        printf(
-           "\n%d updates.\n", nUpdates);
+        printf("\n%d updates.\n", nUpdates);
         dwError = ERROR_TDNF_NO_DATA;
         BAIL_ON_TDNF_ERROR(dwError);
     }

--- a/client/config.c
+++ b/client/config.c
@@ -371,7 +371,7 @@ TDNFReadKeyValue(
     char* pszVal = NULL;
     char* pszValue = NULL;
     PKEYVALUE pKeyValues = NULL;
-    
+
     if(!pSection || !pszKeyName || !ppszValue)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
@@ -434,7 +434,7 @@ TDNFFreeConfig(
         TDNF_SAFE_FREE_MEMORY(pConf->pszDistroVerPkg);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarReleaseVer);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarBaseArch);
-        TDNF_SAFE_FREE_MEMORY(pConf);
+        TDNFFreeMemory(pConf);
     }
 }
 

--- a/client/defines.h
+++ b/client/defines.h
@@ -26,8 +26,7 @@ typedef enum
     DETAIL_INFO
 }TDNF_PKG_DETAIL;
 
-
-#define IsNullOrEmptyString(str) (!(str) || !(*str))
+#define IsNullOrEmptyString(str)    (!(str) || !(*str))
 
 #define BAIL_ON_TDNF_ERROR(dwError) \
     do {                                                           \

--- a/client/includes.h
+++ b/client/includes.h
@@ -18,6 +18,12 @@
  * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
  */
 
+#ifndef __CLIENT_INCLUDES_H__
+#define __CLIENT_INCLUDES_H__
+
+/* Use this to get rid of variable/parameter unused warning */
+#define UNUSED(var) ((void)(var))
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -59,3 +65,4 @@
 #include "../common/prototypes.h"
 #include "prototypes.h"
 
+#endif /* __CLIENT_INCLUDES_H__ */

--- a/client/init.c
+++ b/client/init.c
@@ -250,8 +250,7 @@ TDNFRefreshSack(
                     if(pTempRepo->nSkipIfUnavailable)
                     {
                         pTempRepo->nEnabled = 0;
-                        fprintf(stdout,
-                                "Disabling Repo: '%s'\n",
+                        printf("Disabling Repo: '%s'\n",
                                 pTempRepo->pszName);
 
                         dwError = 0;

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -118,7 +118,7 @@ TDNFPopulatePkgInfoArray(
                   (void**)&pPkgInfos);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    for (dwPkgIndex = 0; dwPkgIndex < dwCount; dwPkgIndex++)
+    for (dwPkgIndex = 0; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
     {
         pPkgInfo = &pPkgInfos[dwPkgIndex];
 
@@ -270,7 +270,7 @@ TDNFPackageGetDowngrade(
     dwError = SolvGetPackageListSize(pAvailabePkgList, &dwCount);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    for(dwPkgIndex = 0; dwPkgIndex < dwCount; dwPkgIndex++)
+    for(dwPkgIndex = 0; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
     {
         dwError = SolvGetPackageId( pAvailabePkgList,
                                     dwPkgIndex,
@@ -396,7 +396,7 @@ TDNFAddPackagesForErase(
     dwError = SolvGetPackageListSize(pInstalledPkgList, &dwCount);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    for(dwPkgIndex = 0; dwPkgIndex < dwCount; dwPkgIndex++)
+    for(dwPkgIndex = 0; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
     {
         dwError = SolvGetPackageId(
                       pInstalledPkgList,
@@ -752,7 +752,7 @@ TDNFPopulatePkgInfos(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    for (dwPkgIndex = 0; dwPkgIndex < dwCount; dwPkgIndex++)
+    for (dwPkgIndex = 0; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
     {
         dwError = SolvGetPackageId(pPkgList, dwPkgIndex, &dwPkgId);
         BAIL_ON_TDNF_ERROR(dwError);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -18,6 +18,9 @@
  * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
  */
 
+#ifndef __CLIENT_PROTOTYPES_H__
+#define __CLIENT_PROTOTYPES_H__
+
 //clean.c
 uint32_t
 TDNFCopyEnabledRepos(
@@ -296,7 +299,7 @@ TDNFGoalGetAllResultsIgnoreNoData(
 uint32_t
 TDNFGetPackagesWithSpecifiedType(
     Transaction* pTrans,
-    PTDNF pTdnf, 
+    PTDNF pTdnf,
     PTDNF_PKG_INFO* pPkgInfo,
     Id dwType
     );
@@ -548,7 +551,6 @@ TDNFReplaceRepoMDFile(
 //repolist.c
 uint32_t
 TDNFLoadReposFromFile(
-    PTDNF pTdnf,
     char* pszRepoFile,
     PTDNF_REPO_DATA_INTERNAL* ppRepos
     );
@@ -595,7 +597,6 @@ TDNFPrepareAllPackages(
 uint32_t
 TDNFPrepareAndAddPkg(
     PTDNF pTdnf,
-    int nIsGlobExpanded,
     const char* pszPkgName,
     TDNF_ALTERTYPE nAlterType,
     char** ppszPkgsNotResolved,
@@ -605,7 +606,6 @@ TDNFPrepareAndAddPkg(
 uint32_t
 TDNFPrepareSinglePkg(
     PTDNF pTdnf,
-    int nIsGlobExpanded,
     const char* pszPkgName,
     TDNF_ALTERTYPE nAlterType,
     char** ppszPkgsNotResolved,
@@ -660,7 +660,6 @@ TDNFTransAddErasePkgs(
 uint32_t
 TDNFTransAddObsoletedPkgs(
     PTDNFRPMTS pTS,
-    PTDNF pTdnf,
     PTDNF_PKG_INFO pInfo
     );
 
@@ -905,3 +904,5 @@ TDNFGetSkipProblemOption(
     PTDNF pTdnf,
     TDNF_SKIPPROBLEM_TYPE *pdwSkipProblem
     );
+
+#endif /* __CLIENT_PROTOTYPES_H__ */

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -31,27 +31,22 @@ progress_cb(
 {
     double dPercent;
 
-    if(dlTotal > 0)
-    {
-        dPercent = ((double)dlNow / (double)dlTotal) * 100.0;
-        if(!isatty(STDOUT_FILENO))
-        {
-            fprintf(stdout, "%s %3.0f%% %ld\n",
-                (char*)pUserData,
-                dPercent,
-                dlNow);
-        }
-        else
-        {
-            fprintf(
-                stdout,
-                "%-35s %10ld  %5.0f%%\r",
-                (char*)pUserData,
-                dlNow,
-                dPercent);
-        }
-        fflush(stdout);
+    UNUSED(ulNow);
+    UNUSED(ulTotal);
+
+    if (dlTotal <= 0) {
+        return 0;
     }
+
+    dPercent = ((double)dlNow / (double)dlTotal) * 100.0;
+    if (!isatty(STDOUT_FILENO)) {
+        printf("%s %3.0f%% %ld\n", (char *)pUserData, dPercent, dlNow);
+    } else {
+        printf("%-35s %10ld %5.0f%%\r", (char *)pUserData, dlNow, dPercent);
+    }
+
+    fflush(stdout);
+
     return 0;
 }
 
@@ -232,7 +227,7 @@ error:
     {
         uint32_t nCurlError = dwError - ERROR_TDNF_CURL_BASE;
         fprintf(stderr,
-                "curl#%d: %s\n",
+                "curl#%u: %s\n",
                 nCurlError,
                 curl_easy_strerror(nCurlError));
     }
@@ -255,7 +250,7 @@ TDNFDownloadPackage(
     char *pszPackageFile = NULL;
     char *pszCopyOfPackageLocation = NULL;
 
-    if(!pTdnf || 
+    if(!pTdnf ||
        !pTdnf->pArgs ||
        IsNullOrEmptyString(pszPackageLocation) ||
        IsNullOrEmptyString(pszPkgName) ||
@@ -296,7 +291,7 @@ TDNFDownloadPackage(
 
     if(!nSilent)
     {
-        fprintf(stdout, "\n");
+        printf("\n");
     }
 
 cleanup:

--- a/client/repo.c
+++ b/client/repo.c
@@ -162,7 +162,7 @@ TDNFInitRepoFromMetadata(
                   pRepoMD->pszPrimary,
                   pRepoMD->pszFileLists,
                   pRepoMD->pszUpdateInfo);
-cleanup: 
+cleanup:
     return dwError;
 
 error:
@@ -527,8 +527,7 @@ TDNFGetRepoMD(
         }
         if(!pTdnf->pArgs->nQuiet)
         {
-           fprintf(stdout,
-                   "Refreshing metadata for: '%s'\n",
+           printf("Refreshing metadata for: '%s'\n",
                     pRepoData->pszName);
         }
         dwError = TDNFUtilsMakeDirs(pszRepoDataDir);
@@ -802,8 +801,7 @@ TDNFParseRepoMD(
     dwError = repo_add_repomdxml(pRepo, fp, 0);
     if(dwError)
     {
-        fprintf(stdout,
-                "Error(%d) parsing repomd: %s\n",
+        printf("Error(%u) parsing repomd: %s\n",
                 dwError,
                 pool_errstr(pPool));
     }

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -70,7 +70,7 @@ TDNFLoadRepoData(
                       pEnt->d_name);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        dwError = TDNFLoadReposFromFile(pTdnf, pszRepoFilePath, &pRepos);
+        dwError = TDNFLoadReposFromFile(pszRepoFilePath, &pRepos);
         BAIL_ON_TDNF_ERROR(dwError);
 
         TDNF_SAFE_FREE_MEMORY(pszRepoFilePath);
@@ -123,15 +123,13 @@ error:
 
 uint32_t
 TDNFLoadReposFromFile(
-    PTDNF pTdnf,
     char* pszRepoFile,
     PTDNF_REPO_DATA_INTERNAL* ppRepos
     )
 {
+    char *pszRepo = NULL;
     uint32_t dwError = 0;
-
-    char* pszRepo = NULL;
-    char* pszMetadataExpire = NULL;
+    char *pszMetadataExpire = NULL;
 
     PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
     PTDNF_REPO_DATA_INTERNAL pRepo = NULL;

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -79,7 +79,7 @@ TDNFRepoGetBaseUrl(
 
     dwError = TDNFAllocateString(pRepos->pszBaseUrl, &pszBaseUrl);
     BAIL_ON_TDNF_ERROR(dwError);
-    
+
     *ppszBaseUrl = pszBaseUrl;
 
 cleanup:

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -113,11 +113,10 @@ TDNFPrepareAllPackages(
         *pAlterType = ALTER_UPGRADE;
         dwError = TDNFGetUpdatePkgs(pTdnf, &ppszPkgArray, &dwCount);
         BAIL_ON_TDNF_ERROR(dwError);
-        for(nPkgIndex = 0; nPkgIndex < dwCount; ++nPkgIndex)
+        for(nPkgIndex = 0; (uint32_t)nPkgIndex < dwCount; ++nPkgIndex)
         {
             dwError = TDNFPrepareAndAddPkg(
                           pTdnf,
-                          0,
                           ppszPkgArray[nPkgIndex],
                           *pAlterType,
                           ppszPkgsNotResolved,
@@ -156,7 +155,6 @@ TDNFPrepareAllPackages(
 
                        dwError = TDNFPrepareAndAddPkg(
                                      pTdnf,
-                                     1,
                                      pszName,
                                      nAlterType,
                                      ppszPkgsNotResolved,
@@ -171,7 +169,6 @@ TDNFPrepareAllPackages(
            {
                dwError = TDNFPrepareAndAddPkg(
                              pTdnf,
-                             0,
                              pszPkgName,
                              nAlterType,
                              ppszPkgsNotResolved,
@@ -235,7 +232,6 @@ TDNFFilterPackages(
 
         dwError = TDNFPrepareAndAddPkg(
                       pTdnf,
-                      0,
                       pszName,
                       nAlterType,
                       ppszPkgsNotResolved,
@@ -260,7 +256,6 @@ error:
 uint32_t
 TDNFPrepareAndAddPkg(
     PTDNF pTdnf,
-    int nIsGlobExpanded,
     const char* pszPkgName,
     TDNF_ALTERTYPE nAlterType,
     char** ppszPkgsNotResolved,
@@ -279,7 +274,6 @@ TDNFPrepareAndAddPkg(
 
     dwError = TDNFPrepareSinglePkg(
                   pTdnf,
-                  nIsGlobExpanded,
                   pszPkgName,
                   nAlterType,
                   ppszPkgsNotResolved,
@@ -295,7 +289,6 @@ error:
 uint32_t
 TDNFPrepareSinglePkg(
     PTDNF pTdnf,
-    int nIsGlobExpanded,
     const char* pszPkgName,
     TDNF_ALTERTYPE nAlterType,
     char** ppszPkgsNotResolved,

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -169,7 +169,7 @@ TDNFPopulateTransaction(
                       pTS,
                       pTdnf,
                       pSolvedInfo->pPkgsToReinstall);
-        BAIL_ON_TDNF_ERROR(dwError);    
+        BAIL_ON_TDNF_ERROR(dwError);
     }
     if(pSolvedInfo->pPkgsToUpgrade)
     {
@@ -190,7 +190,6 @@ TDNFPopulateTransaction(
     {
         dwError = TDNFTransAddObsoletedPkgs(
                       pTS,
-                      pTdnf,
                       pSolvedInfo->pPkgsObsoleted);
         BAIL_ON_TDNF_ERROR(dwError);
     }
@@ -292,7 +291,7 @@ TDNFRunTransaction(
     //TODO do callbacks for output
     if(!nSilent)
     {
-        fprintf(stdout, "Testing transaction\n");
+        printf("Testing transaction\n");
     }
 
     if (pTdnf->pArgs->nNoGPGCheck)
@@ -322,7 +321,7 @@ TDNFRunTransaction(
     //TODO do callbacks for output
     if(!nSilent)
     {
-        fprintf(stdout, "Running transaction\n");
+        printf("Running transaction\n");
     }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_NONE);
     dwError = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
@@ -438,7 +437,7 @@ TDNFTransAddInstallPkg(
         if(errno != ENOENT)
         {
             dwError = errno;
-        } 
+        }
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
 
         dwError = TDNFUtilsMakeDirs(pszDownloadCacheDir);
@@ -583,16 +582,17 @@ error:
 uint32_t
 TDNFTransAddObsoletedPkgs(
     PTDNFRPMTS pTS,
-    PTDNF pTdnf,
     PTDNF_PKG_INFO pInfo
     )
 {
     uint32_t dwError = 0;
+
     if(!pInfo)
     {
         dwError = ERROR_TDNF_NO_DATA;
         BAIL_ON_TDNF_ERROR(dwError);
     }
+
     while(pInfo)
     {
         dwError = TDNFTransAddErasePkg(pTS, pInfo->pszName);
@@ -665,6 +665,9 @@ TDNFRpmCB(
     char* pszFileName = (char*)key;
     PTDNFRPMTS pTS = (PTDNFRPMTS)data;
 
+    UNUSED(total);
+    UNUSED(amount);
+
     switch (what)
     {
         case RPMCALLBACK_INST_OPEN_FILE:
@@ -689,15 +692,15 @@ TDNFRpmCB(
                 break;
             if(what == RPMCALLBACK_INST_START)
             {
-                fprintf(stdout, "%s", "Installing/Updating: ");
+                printf("%s", "Installing/Updating: ");
             }
             else
             {
-                fprintf(stdout, "%s", "Removing: ");
+                printf("%s", "Removing: ");
             }
             {
                 char* pszNevra = headerGetAsString(pPkgHeader, RPMTAG_NEVRA);
-                fprintf(stdout, "%s\n", pszNevra);
+                printf("%s\n", pszNevra);
                 free(pszNevra);
                 (void)fflush(stdout);
             }

--- a/client/updateinfo.c
+++ b/client/updateinfo.c
@@ -23,7 +23,6 @@
 uint32_t
 TDNFUpdateInfoSummary(
     PTDNF pTdnf,
-    TDNF_AVAIL nAvail,
     char** ppszPackageNameSpecs,
     PTDNF_UPDATEINFO_SUMMARY* ppSummary
     )
@@ -104,7 +103,7 @@ TDNFUpdateInfoSummary(
         dwError = SolvGetPackageListSize(pUpdateAdvPkgList, &nCount);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        for(iAdv = 0; iAdv < nCount; iAdv++)
+        for(iAdv = 0; (uint32_t)iAdv < nCount; iAdv++)
         {
             dwError = SolvGetPackageId(pUpdateAdvPkgList, iAdv, &dwAdvId);
             BAIL_ON_TDNF_ERROR(dwError);
@@ -525,7 +524,7 @@ TDNFGetUpdatePkgs(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFUpdateInfo(pTdnf, 0, 0, &pszPkgName, &pUpdateInfo);
+    dwError = TDNFUpdateInfo(pTdnf, &pszPkgName, &pUpdateInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pInfo = pUpdateInfo;

--- a/client/utils.c
+++ b/client/utils.c
@@ -32,7 +32,7 @@ TDNFGetErrorString(
     int i = 0;
     int nCount = 0;
     uint32_t dwActualError = 0;
-    
+
 
     //Allow mapped error strings to override
     TDNF_ERROR_DESC arErrorDesc[] = TDNF_ERROR_TABLE;
@@ -41,7 +41,7 @@ TDNFGetErrorString(
 
     for(i = 0; i < nCount; i++)
     {
-        if (dwErrorCode == arErrorDesc[i].nCode)
+        if (dwErrorCode == (uint32_t)arErrorDesc[i].nCode)
         {
             dwError = TDNFAllocateString(arErrorDesc[i].pszDesc, &pszError);
             BAIL_ON_TDNF_ERROR(dwError);
@@ -50,7 +50,7 @@ TDNFGetErrorString(
     }
 
 
-    //Get system error 
+    //Get system error
     if(!pszError && TDNFIsSystemError(dwErrorCode))
     {
         dwActualError = TDNFGetSystemError(dwErrorCode);
@@ -69,7 +69,7 @@ TDNFGetErrorString(
         dwError = TDNFAllocateString(TDNF_UNKNOWN_ERROR_STRING, &pszError);
         BAIL_ON_TDNF_ERROR(dwError);
     }
- 
+
     *ppszError = pszError;
 cleanup:
     return dwError;
@@ -121,13 +121,13 @@ TDNFIsGlob(
     while(*pszString)
     {
         char ch = *pszString;
-        
+
         if(ch == '*' || ch == '?' || ch == '[')
         {
             nResult = 1;
             break;
         }
-        
+
         pszString++;
     }
     return nResult;
@@ -212,7 +212,7 @@ TDNFUtilsMakeDirs(
     }
     dwError = TDNFUtilsMakeDir(pszTempPath);
     BAIL_ON_TDNF_ERROR(dwError);
-    
+
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszTempPath);
     return dwError;
@@ -443,7 +443,7 @@ TDNFParseMetadataExpire(
     long lMetadataExpire = -1;
     char* pszError = NULL;
 
-    if(!lMetadataExpire || IsNullOrEmptyString(pszMetadataExpire))
+    if(!plMetadataExpire || IsNullOrEmptyString(pszMetadataExpire))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);

--- a/common/configreader.c
+++ b/common/configreader.c
@@ -31,16 +31,16 @@ TDNFPrintConfigData(
     PKEYVALUE pKeyValue = NULL;
     if(!pData) return;
 
-    fprintf(stdout, "File: %s\n", pData->pszConfFile);
+    printf("File: %s\n", pData->pszConfFile);
 
     pSection = pData->pSections;
     while(pSection)
     {
-        fprintf(stdout, "[%s]\n", pSection->pszName);
+        printf("[%s]\n", pSection->pszName);
         pKeyValue = pSection->pKeyValues;
         while(pKeyValue)
         {
-            fprintf(stdout, "%s=%s\n", pKeyValue->pszKey, pKeyValue->pszValue);
+            printf("%s=%s\n", pKeyValue->pszKey, pKeyValue->pszValue);
             pKeyValue = pKeyValue->pNext;
         }
         pSection = pSection->pNext;
@@ -56,8 +56,8 @@ TDNFGetSectionBoundaries(
     )
 {
     uint32_t dwError = 0;
-    const char *pszStart = NULL;
     const char *pszEnd = NULL;
+    const char *pszStart = NULL;
 
     pszStart = strchr(pszLine, '[');
     if(!pszStart)

--- a/common/defines.h
+++ b/common/defines.h
@@ -20,8 +20,8 @@
 
 #pragma once
 
-#define MAX_CONFIG_LINE_LENGTH 1024
-#define IsNullOrEmptyString(str) (!(str) || !(*str))
+#define MAX_CONFIG_LINE_LENGTH      1024
+#define IsNullOrEmptyString(str)    (!(str) || !(*str))
 
 #define BAIL_ON_TDNF_ERROR(dwError) \
     do {                                                           \

--- a/common/includes.h
+++ b/common/includes.h
@@ -6,6 +6,9 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
+#ifndef __COMMON_INCLUDES_H__
+#define __COMMON_INCLUDES_H__
+
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -20,3 +23,5 @@
 #include "defines.h"
 #include "structs.h"
 #include "prototypes.h"
+
+#endif /* __COMMON_INCLUDES_H__ */

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -11,12 +11,15 @@
  *
  * Abstract :
  *
- *            commonlib 
+ *            commonlib
  *
  *            common library
  *
  * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
  */
+
+#ifndef __COMMON_PROTOTYPES_H__
+#define __COMMON_PROTOTYPES_H__
 
 //memory.c
 uint32_t
@@ -141,3 +144,5 @@ uint32_t
 TDNFUtilsMakeDirs(
     const char* pszPath
     );
+
+#endif /* __COMMON_PROTOTYPES_H__ */

--- a/common/strings.c
+++ b/common/strings.c
@@ -96,7 +96,7 @@ TDNFAllocateStringPrintf(
     )
 {
     uint32_t dwError = 0;
-    size_t nSize = 0;
+    int32_t nSize = 0;
     char* pszDst = NULL;
     char chDstTest = '\0';
     va_list argList;
@@ -117,7 +117,7 @@ TDNFAllocateStringPrintf(
         dwError = errno;
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
-    nSize = nSize + 1;
+    nSize++;
 
     if(nSize > TDNF_DEFAULT_MAX_STRING_LEN)
     {

--- a/common/utils.c
+++ b/common/utils.c
@@ -162,14 +162,14 @@ TDNFFreePackageInfoArray(
     uint32_t unLength
     )
 {
-    uint32_t unIndex = 0;
-    if(pPkgInfoArray && unLength > 0)
-    {
-        for(unIndex = 0; unIndex < unLength; ++unIndex)
-        {
-            TDNFFreePackageInfoContents(&pPkgInfoArray[unIndex]);
-        }
+  if (!pPkgInfoArray) {
+      return;
     }
+
+    while ((int32_t)--unLength >= 0) {
+      TDNFFreePackageInfoContents(&pPkgInfoArray[unLength]);
+    }
+
     TDNF_SAFE_FREE_MEMORY(pPkgInfoArray);
 }
 
@@ -294,7 +294,7 @@ TDNFFreeUpdateInfo(
 
         TDNFFreeUpdateInfoReferences(pUpdateInfo->pReferences);
         TDNFFreeUpdateInfoPackages(pUpdateInfo->pPackages);
-        TDNF_SAFE_FREE_MEMORY(pUpdateInfo);
+        TDNFFreeMemory(pUpdateInfo);
     }
 }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,5 @@
 AC_INIT(tdnf, 2.0.0)
+AM_SILENT_RULES([yes])
 AC_MSG_NOTICE([tdnf configuration])
 
 AC_CANONICAL_SYSTEM

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -23,7 +23,7 @@ uint32_t
 TDNFInit(
     );
 
-//Open a handle using initial args 
+//Open a handle using initial args
 //args can define a command, have config overrides
 uint32_t
 TDNFOpenHandle(
@@ -40,7 +40,7 @@ TDNFCheckUpdates(
     uint32_t* pdwCount
     );
 
-//clean local cache. all is the only type 
+//clean local cache. all is the only type
 //currently supported.
 uint32_t
 TDNFClean(
@@ -92,7 +92,7 @@ TDNFCheckPackages(
     );
 
 //check all packages in a local directory
-//using the local directory contents 
+//using the local directory contents
 //for dep resolution.
 uint32_t
 TDNFCheckLocalPackages(
@@ -108,12 +108,10 @@ TDNFProvides(
     PTDNF_PKG_INFO* ppPkgInfo
     );
 
-//Show update info for specified scope 
+//Show update info for specified scope
 uint32_t
 TDNFUpdateInfo(
     PTDNF pTdnf,
-    TDNF_SCOPE nScope,
-    TDNF_AVAIL nAvail,
     char** ppszPackageNameSpecs,
     PTDNF_UPDATEINFO* ppUpdateInfo
     );
@@ -122,7 +120,6 @@ TDNFUpdateInfo(
 uint32_t
 TDNFUpdateInfoSummary(
     PTDNF pTdnf,
-    TDNF_AVAIL nAvail,
     char** ppszPackageNameSpecs,
     PTDNF_UPDATEINFO_SUMMARY* ppSummary
     );
@@ -141,7 +138,7 @@ TDNFGetVersion(
     );
 
 //Search installed and available packages for keywords
-//in description, name 
+//in description, name
 uint32_t
 TDNFSearchCommand(
     PTDNF pTdnf,
@@ -165,17 +162,17 @@ TDNFResolve(
 
 //This function will alter the current
 //install state.
-//install/update/erase/downgrade are 
+//install/update/erase/downgrade are
 //represented as altertype.
 uint32_t
 TDNFAlterCommand(
     PTDNF pTdnf,
     TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedInfo
-    ); 
+    );
 
 //Show a descriptive error message
-//divided into different areas like 
+//divided into different areas like
 //solv, repo, rpm and generic tdnf errors.
 uint32_t
 TDNFGetErrorString(

--- a/include/tdnfclierror.h
+++ b/include/tdnfclierror.h
@@ -6,6 +6,9 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
+#ifndef __TDNF_CLI_ERR_H__
+#define __TDNF_CLI_ERR_H__
+
 #define ERROR_TDNF_CLI_BASE                    900
 #define ERROR_TDNF_CLI_NO_MATCH                (ERROR_TDNF_CLI_BASE + 1)
 #define ERROR_TDNF_CLI_INVALID_ARGUMENT        (ERROR_TDNF_CLI_BASE + 2)
@@ -18,3 +21,5 @@
 #define ERROR_TDNF_CLI_OPTION_ARG_REQUIRED     (ERROR_TDNF_CLI_BASE + 9)
 #define ERROR_TDNF_CLI_OPTION_ARG_UNEXPECTED   (ERROR_TDNF_CLI_BASE + 10)
 #define ERROR_TDNF_CLI_SETOPT_NO_EQUALS        (ERROR_TDNF_CLI_BASE + 11)
+
+#endif /* __TDNF_CLI_ERR_H__ */

--- a/python/includes.h
+++ b/python/includes.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+
 #include <Python.h>
 #include <structmember.h>
 #include <tdnf.h>

--- a/python/tdnfpyrepodata.c
+++ b/python/tdnfpyrepodata.c
@@ -106,7 +106,7 @@ cleanup:
     return dwError > 0 ? -1 : 0;
 
 error:
-    fprintf(stderr, "Error = %d\n", dwError);
+    fprintf(stderr, "Error = %u\n", dwError);
     goto cleanup;
 }
 
@@ -115,10 +115,10 @@ TDNFPyRepoDataRepr(
     PyObject *self
     )
 {
+    char *pszRepr = NULL;
     uint32_t dwError = 0;
     PyObject *pyRepr = Py_None;
     PPY_TDNF_REPODATA pRepoData = NULL;
-    char *pszRepr = NULL;
 
     pRepoData = (PPY_TDNF_REPODATA)self;
     dwError = TDNFAllocateStringPrintf(
@@ -138,7 +138,7 @@ cleanup:
     return pyRepr;
 
 error:
-    printf("Error = %d\n", dwError);
+    printf("Error = %u\n", dwError);
     pyRepr = Py_None;
     goto cleanup;
 

--- a/solv/defines.h
+++ b/solv/defines.h
@@ -1,3 +1,6 @@
+#ifndef __SOLV_DEFINES_H__
+#define __SOLV_DEFINES_H__
+
 #define SYSTEM_REPO_NAME "@System"
 #define CMDLINE_REPO_NAME "@commandline"
 #define SOLV_COOKIE_IDENT "tdnf"
@@ -19,3 +22,5 @@
             goto error;                                            \
         }                                                          \
     } while(0)
+
+#endif /* __SOLV_DEFINES_H__ */

--- a/solv/includes.h
+++ b/solv/includes.h
@@ -1,3 +1,6 @@
+#ifndef __SOLV_INCLUDES_H__
+#define __SOLV_INCLUDES_H__
+
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/utsname.h>
@@ -31,3 +34,5 @@
 #include "../common/structs.h"
 #include "../common/prototypes.h"
 #include "prototypes.h"
+
+#endif /* __SOLV_INCLUDES_H__ */

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -7,6 +7,7 @@
  */
 
 #pragma once
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -111,7 +112,7 @@ SolvGetPkgUrlFromId(
     uint32_t dwPkgId,
     char** ppszUrl);
 
-uint32_t 
+uint32_t
 SolvGetPkgLocationFromId(
     PSolvSack pSack,
     uint32_t dwPkgId,

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -769,7 +769,7 @@ SolvGetPackageId(
     )
 {
     uint32_t dwError = 0;
-    if(!pPkgList || dwPkgIndex >= pPkgList->queuePackages.count)
+    if(!pPkgList || dwPkgIndex >= (uint32_t)pPkgList->queuePackages.count)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
@@ -857,7 +857,7 @@ SolvGetLatest(
 
     pszName1 = pool_id2str(pSack->pPool, pSolv1->name);
     pszEvr1 = solvable_lookup_str(pSolv1, SOLVABLE_EVR);
-    for( ; dwPkgIter < pPkgList->count;  dwPkgIter++)
+    for( ; dwPkgIter < (uint32_t)pPkgList->count;  dwPkgIter++)
     {
         pSolv2 = pool_id2solvable(pSack->pPool, pPkgList->elements[dwPkgIter]);
         if(!pSolv2)
@@ -1237,7 +1237,7 @@ SolvFindHighestAvailable(
     dwError = SolvGetPackageListSize(pAvailabePkgList, &dwCount);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    for(dwPkgIndex = 1; dwPkgIndex < dwCount; dwPkgIndex++)
+    for(dwPkgIndex = 1; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
     {
         dwError = SolvGetPackageId(
                       pAvailabePkgList,
@@ -1362,7 +1362,7 @@ SolvFindHighestOrLowestInstalled(
         dwError = SolvGetPackageListSize(pInstalledPkgList, &dwCount);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        for(dwPkgIndex = 1; dwPkgIndex < dwCount; dwPkgIndex++)
+        for(dwPkgIndex = 1; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
         {
             dwError = SolvGetPackageId(
                           pInstalledPkgList,
@@ -1616,7 +1616,7 @@ SolvReportProblems(
 
     if(nCount > 0)
     {
-        fprintf(stderr, "Found %d problem(s) while resolving\n", nCount - dwSkipProbCount);
+        fprintf(stderr, "Found %u problem(s) while resolving\n", nCount - dwSkipProbCount);
         for( i = 1; i <= nCount; ++i)
         {
             dwProblemId = solver_findproblemrule(pSolv, i);

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -321,7 +321,7 @@ SolvApplyPackageFilter(
     pQuery->ppszPackageNames = ppszCopyOfPkgNames;
 
 cleanup:
-  
+
     return dwError;
 error:
     if(dwError == ERROR_TDNF_NO_DATA)
@@ -516,7 +516,7 @@ SolvRunSolv(
     int nJob = 0;
     Solver *pSolv = NULL;
 
-    if(!queueJobs->count && (dwMainMode == MODE_UPDATE || 
+    if(!queueJobs->count && (dwMainMode == MODE_UPDATE ||
        dwMainMode == MODE_DISTUPGRADE ||
        dwMainMode == MODE_VERIFY))
     {
@@ -526,7 +526,7 @@ SolvRunSolv(
     for (nJob = 0; nJob < queueJobs->count; nJob += 2)
     {
         queueJobs->elements[nJob] |= dwMode;
-        if (dwMode == SOLVER_UPDATE && 
+        if (dwMode == SOLVER_UPDATE &&
             pool_isemptyupdatejob(
                 pQuery->pSack->pPool,
                 queueJobs->elements[nJob],
@@ -671,7 +671,7 @@ SolvApplyListQuery(
         for (nIndex = 0; nIndex < pQuery->queueJob.count ; nIndex += 2)
         {
             queue_empty(&queueTmp);
-            Id p, pp, how, what;
+            Id p = 0, pp = 0, how = 0, what = 0;
             what = pQuery->queueJob.elements[nIndex + 1];
             how = SOLVER_SELECTMASK & pQuery->queueJob.elements[nIndex];
             Pool *pool = pQuery->pSack->pPool;
@@ -687,9 +687,10 @@ SolvApplyListQuery(
             else if (how == SOLVER_SOLVABLE_REPO)
             {
                Repo *repo = pool_id2repo(pool, what);
-               Solvable *s;
                if (repo)
                {
+                   Solvable *s = NULL;
+
 	           FOR_REPO_SOLVABLES(repo, p, s)
                    {
                       if (is_pseudo_package(pool, &pool->solvables[p]))

--- a/tests/specs/tdnf-test-multiversion-1.0.1.spec
+++ b/tests/specs/tdnf-test-multiversion-1.0.1.spec
@@ -23,5 +23,5 @@ Part of tdnf test spec. Basic install/remove/upgrade test
 %files
 
 %changelog
-*       Fri Apr 22 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0.1
--       Initial build.  First version
+*       Wed Apr 22 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0.1
+-       Initial build. First version

--- a/tests/specs/tdnf-test-multiversion-1.0.2.spec
+++ b/tests/specs/tdnf-test-multiversion-1.0.2.spec
@@ -23,5 +23,5 @@ Part of tdnf test spec. Basic install/remove/upgrade test
 %files
 
 %changelog
-*       Fri Apr 22 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0.2
+*       Wed Apr 22 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0.2
 -       Initial build.  First version

--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-
 #define ENABLEREPO        "enablerepo"
 #define DISABLEREPO       "disablerepo"
 

--- a/tools/cli/includes.h
+++ b/tools/cli/includes.h
@@ -19,6 +19,12 @@
  *
  */
 
+#ifndef __CLI_INCLUDES_H__
+#define __CLI_INCLUDES_H__
+
+/* Use this to get rid of variable/parameter unused warning */
+#define UNUSED(var) ((void)(var))
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -35,3 +41,5 @@
 #include "prototypes.h"
 #include "../common/structs.h"
 #include "../common/prototypes.h"
+
+#endif /* __CLI_INCLUDES_H__ */

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -26,14 +26,14 @@ TDNFCliGetErrorString(
     char* pszError = NULL;
     int i = 0;
     int nCount = 0;
-    
+
     TDNF_ERROR_DESC arErrorDesc[] = TDNF_CLI_ERROR_TABLE;
 
     nCount = sizeof(arErrorDesc)/sizeof(arErrorDesc[0]);
 
     for(i = 0; i < nCount; i++)
     {
-        if (dwErrorCode == arErrorDesc[i].nCode)
+        if (dwErrorCode == (uint32_t)arErrorDesc[i].nCode)
         {
             dwError = TDNFAllocateString(arErrorDesc[i].pszDesc, &pszError);
             BAIL_ON_CLI_ERROR(dwError);
@@ -67,7 +67,7 @@ TDNFCliCleanCommand(
 
     dwError = TDNFCliParseCleanArgs(pCmdArgs, &nCleanType);
     BAIL_ON_CLI_ERROR(dwError);
-  
+
     dwError = pContext->pFnClean(pContext, nCleanType, &pTDNFCleanInfo);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -106,7 +106,9 @@ TDNFCliCountCommand(
 {
     uint32_t dwError = 0;
     uint32_t dwCount = 0;
- 
+
+    UNUSED(pCmdArgs);
+
     if(!pContext || !pContext->hTdnf || !pContext->pFnCount)
     {
         dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
@@ -116,7 +118,7 @@ TDNFCliCountCommand(
     dwError = pContext->pFnCount(pContext, &dwCount);
     BAIL_ON_CLI_ERROR(dwError);
 
-    printf("Package count = %d\n", dwCount);
+    printf("Package count = %u\n", dwCount);
 
 cleanup:
     return dwError;
@@ -142,7 +144,7 @@ TDNFCliListCommand(
     char szNameAndArch[MAX_COL_LEN] = {0};
     char szVersionAndRelease[MAX_COL_LEN] = {0};
 
-    #define COL_COUNT 3 
+    #define COL_COUNT 3
     //Name.Arch | Version-Release | Repo
     int nColPercents[COL_COUNT] = {55, 25, 15};
     int nColWidths[COL_COUNT] = {0};
@@ -222,7 +224,7 @@ TDNFCliInfoCommand(
     )
 {
     uint32_t dwError = 0;
-  
+
     char* pszFormattedSize = NULL;
 
     PTDNF_PKG_INFO pPkgInfo = NULL;
@@ -265,10 +267,10 @@ TDNFCliInfoCommand(
 
         dwTotalSize += pPkg->dwInstallSizeBytes;
     }
-  
+
     dwError = TDNFUtilsFormatSize(dwTotalSize, &pszFormattedSize);
     BAIL_ON_CLI_ERROR(dwError);
-  
+
     if(dwCount > 0)
     {
         printf("\nTotal Size: %s (%lu)\n", pszFormattedSize, dwTotalSize);
@@ -394,7 +396,7 @@ TDNFCliCheckLocalCommand(
     dwError = pContext->pFnCheckLocal(pContext, pCmdArgs->ppszCmds[1]);
     BAIL_ON_CLI_ERROR(dwError);
 
-    fprintf(stdout, "Check completed without issues\n");
+    printf("Check completed without issues\n");
 
 cleanup:
     return dwError;
@@ -441,7 +443,7 @@ TDNFCliProvidesCommand(
             pPkgInfo->pszRelease,
             pPkgInfo->pszArch,
             pPkgInfo->pszSummary);
-        fprintf(stdout, "Repo\t : %s\n", pPkgInfo->pszRepoName);
+        printf("Repo\t : %s\n", pPkgInfo->pszRepoName);
         pPkgInfo = pPkgInfo->pNext;
     }
 
@@ -525,7 +527,7 @@ TDNFCliMakeCacheCommand(
     //Empty as refresh flag is set for makecache command
     //and will execute refresh on all enabled repos
 
-    fprintf(stdout, "Metadata cache created.\n");
+    printf("Metadata cache created.\n");
 
 cleanup:
     return dwError;
@@ -551,7 +553,7 @@ TDNFCliCheckCommand(
     dwError = pContext->pFnCheck(pContext);
     BAIL_ON_CLI_ERROR(dwError);
 
-    fprintf(stdout, "Check completed without issues\n");
+    printf("Check completed without issues\n");
 cleanup:
     return dwError;
 

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -99,6 +99,9 @@ TDNFCliHelpCommand(
     PTDNF_CMD_ARGS pCmdArgs
     )
 {
+    UNUSED(pContext);
+    UNUSED(pCmdArgs);
     TDNFCliShowHelp();
+
     return 0;
 }

--- a/tools/cli/lib/includes.h
+++ b/tools/cli/lib/includes.h
@@ -19,6 +19,12 @@
  *
  */
 
+#ifndef __CLI_LIB_INCLUDES_H__
+#define __CLI_LIB_INCLUDES_H__
+
+/* Use this to get rid of variable/parameter unused warning */
+#define UNUSED(var) ((void)(var))
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -35,3 +41,5 @@
 #include "prototypes.h"
 #include "../common/structs.h"
 #include "../common/prototypes.h"
+
+#endif /* __CLI_LIB_INCLUDES_H__ */

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -46,7 +46,7 @@ TDNFCliEraseCommand(
     )
 {
     uint32_t dwError = 0;
-    
+
     dwError = TDNFCliAlterCommand(pContext, pCmdArgs, ALTER_ERASE);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -112,7 +112,7 @@ TDNFCliDowngradeCommand(
     {
         nAlterType = ALTER_DOWNGRADEALL;
     }
-    
+
     dwError = TDNFCliAlterCommand(pContext, pCmdArgs, nAlterType);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -130,7 +130,7 @@ TDNFCliAutoEraseCommand(
     )
 {
     uint32_t dwError = 0;
-    
+
     dwError = TDNFCliAlterCommand(pContext, pCmdArgs, ALTER_AUTOERASE);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -231,7 +231,7 @@ TDNFCliAlterCommand(
         {
             if(!nSilent && pSolvedPkgInfo->nNeedDownload)
             {
-                fprintf(stdout, "\nDownloading:\n");
+                printf("\nDownloading:\n");
             }
 
             dwError = pContext->pFnAlter(
@@ -242,7 +242,7 @@ TDNFCliAlterCommand(
 
             if(!nSilent)
             {
-                fprintf(stdout, "\nComplete!\n");
+                printf("\nComplete!\n");
             }
         }
         else

--- a/tools/cli/lib/updateinfocmd.c
+++ b/tools/cli/lib/updateinfocmd.c
@@ -33,13 +33,13 @@ TDNFGetUpdateInfoType(
     {
         case UPDATE_SECURITY:
             pszType = "Security";
-            break; 
+            break;
         case UPDATE_BUGFIX:
             pszType = "Bugfix";
-            break; 
+            break;
         case UPDATE_ENHANCEMENT:
             pszType = "Enhancement";
-            break; 
+            break;
     }
 
     return pszType;
@@ -52,7 +52,7 @@ TDNFCliUpdateInfoCommand(
     )
 {
     uint32_t dwError = 0;
-  
+
     PTDNF_UPDATEINFO pUpdateInfo = NULL;
     PTDNF_UPDATEINFO_ARGS pInfoArgs = NULL;
 
@@ -169,11 +169,10 @@ TDNFCliUpdateInfoList(
         pPkg = pInfo->pPackages;
         while(pPkg)
         {
-            fprintf(stdout, "%s %s %s\n",
-                pInfo->pszID,
-                TDNFGetUpdateInfoType(pInfo->nType),
-                pPkg->pszFileName);
-            
+            printf("%s %s %s\n", pInfo->pszID,
+                    TDNFGetUpdateInfoType(pInfo->nType),
+                    pPkg->pszFileName);
+
             pPkg = pPkg->pNext;
         }
         pInfo = pInfo->pNext;
@@ -205,18 +204,18 @@ TDNFCliUpdateInfoInfo(
         pPkg = pInfo->pPackages;
         while(pPkg)
         {
-            fprintf(stdout, "       Name : %s\n",
-                pPkg->pszFileName);
-            fprintf(stdout, "  Update ID : %s\n",
-                pInfo->pszID);
-            fprintf(stdout, "       Type : %s\n",
-                TDNFGetUpdateInfoType(pInfo->nType));
-            fprintf(stdout, "    Updated : %s\n",
-                pInfo->pszDate);
-            fprintf(stdout, "Needs Reboot: %d\n",
-                pInfo->nRebootRequired);
-            fprintf(stdout, "Description : %s\n",
-                pInfo->pszDescription);
+            printf("       Name : %s\n"
+                   "  Update ID : %s\n"
+                   "       Type : %s\n"
+                   "    Updated : %s\n"
+                   "Needs Reboot: %d\n"
+                   "Description : %s\n",
+                        pPkg->pszFileName,
+                        pInfo->pszID,
+                        TDNFGetUpdateInfoType(pInfo->nType),
+                        pInfo->pszDate,
+                        pInfo->nRebootRequired,
+                        pInfo->pszDescription);
 
             pPkg = pPkg->pNext;
         }

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 {
     uint32_t dwError = 0;
     PTDNF_CMD_ARGS pCmdArgs = NULL;
-    TDNF_CLI_CMD_MAP arCmdMap[] = 
+    TDNF_CLI_CMD_MAP arCmdMap[] =
     {
         {"autoerase",          TDNFCliAutoEraseCommand},
         {"autoremove",         TDNFCliAutoEraseCommand},
@@ -193,7 +193,7 @@ TDNFCliPrintError(
     }
     if(dwErrorCode)
     {
-        fprintf(stderr, "Error(%d) : %s\n", dwErrorCode, pszError);
+        fprintf(stderr, "Error(%u) : %s\n", dwErrorCode, pszError);
     }
     else if(!nQuiet)
     {
@@ -207,7 +207,7 @@ cleanup:
 error:
     fprintf(
         stderr,
-        "Retrieving error string for %d failed with %d\n",
+        "Retrieving error string for %u failed with %u\n",
         dwErrorCode,
         dwError);
     goto cleanup;
@@ -217,7 +217,7 @@ void
 TDNFCliShowVersion(
     )
 {
-    fprintf(stdout, "%s: %s\n", PACKAGE_NAME, TDNFGetVersion());
+    printf("%s: %s\n", PACKAGE_NAME, TDNFGetVersion());
 }
 
 uint32_t
@@ -237,10 +237,10 @@ TDNFCliVerboseShowEnv(
     pOpt = pCmdArgs->pSetOpt;
     if(pOpt)
     {
-        fprintf(stdout, "Setting options:\n");
+        printf("Setting options:\n");
         while(pOpt)
         {
-            fprintf(stdout, "\t%s = %s\n", pOpt->pszOptName, pOpt->pszOptValue);
+            printf("\t%s = %s\n", pOpt->pszOptName, pOpt->pszOptValue);
             pOpt = pOpt->pNext;
         }
     }
@@ -392,8 +392,6 @@ TDNFCliInvokeUpdateInfo(
 {
     return TDNFUpdateInfo(
                pContext->hTdnf,
-               pInfoArgs->nMode,
-               pInfoArgs->nScope,
                pInfoArgs->ppszPackageNameSpecs,
                ppUpdateInfo);
 }
@@ -406,9 +404,10 @@ TDNFCliInvokeUpdateInfoSummary(
     PTDNF_UPDATEINFO_SUMMARY *ppSummary
     )
 {
+    UNUSED(nAvail);
+
     return TDNFUpdateInfoSummary(
                pContext->hTdnf,
-               nAvail,
                pInfoArgs->ppszPackageNameSpecs,
                ppSummary);
 }

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -21,7 +21,6 @@
 
 #pragma once
 
-
 //invoke tdnf library methods
 uint32_t
 TDNFCliInvokeAlter(


### PR DESCRIPTION
Changes include:
1. Fix build warnings like unused parameters, sign mismatch while comparing.
2. Using printf instead of fprintf(stdout, ...).
3. Added header guard in few .h files.
4. Added a rule for silent build in configure.ac
5. Removal of trailing spaces, my vim does it automatically

PR looks big but all are minor fixes, hope it's okay and reviewing won't be a headache :)

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>