### PR TITLE
move setopt.c to common

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -716,13 +716,6 @@ TDNFFreeCachedRpmsArray(
     PTDNF_CACHED_RPM_LIST pArray
     );
 
-//memory.c
-void
-TDNFFreeCmdOpt(
-    PTDNF_CMD_OPT pCmdOpt
-    );
-
-
 //updateinfo.c
 uint32_t
 TDNFGetUpdateInfoPackages(

--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -4,6 +4,7 @@ libcommon_la_SOURCES = \
     memory.c \
     strings.c \
     configreader.c \
+    setopt.c \
     utils.c
 
 libcommon_la_CPPFLAGS = \

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -145,4 +145,25 @@ TDNFUtilsMakeDirs(
     const char* pszPath
     );
 
+//setopt.c
+uint32_t
+AddSetOpt(
+    PTDNF_CMD_ARGS pCmdArgs,
+    const char* pszOptArg
+    );
+
+uint32_t
+AddSetOptWithValues(
+    PTDNF_CMD_ARGS pCmdArgs,
+    int nType,
+    const char* pszOptArg,
+    const char* pszOptValue
+    );
+
+uint32_t
+GetOptionAndValue(
+    const char* pszOptArg,
+    PTDNF_CMD_OPT* ppCmdOpt
+    );
+
 #endif /* __COMMON_PROTOTYPES_H__ */

--- a/common/setopt.c
+++ b/common/setopt.c
@@ -21,6 +21,11 @@
 
 #include "includes.h"
 
+void
+TDNFFreeCmdOpt(
+    PTDNF_CMD_OPT pCmdOpt
+    );
+
 uint32_t
 AddSetOpt(
     PTDNF_CMD_ARGS pCmdArgs,
@@ -32,19 +37,19 @@ AddSetOpt(
 
     if(!pCmdArgs || IsNullOrEmptyString(pszOptArg))
     {
-        dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
-        BAIL_ON_CLI_ERROR(dwError);
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
     }
     dwError = GetOptionAndValue(pszOptArg, &pCmdOpt);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     if(!strcmp(pCmdOpt->pszOptName, "tdnf.conf"))
     {
-        TDNF_CLI_SAFE_FREE_MEMORY(pCmdArgs->pszConfFile);
+        TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszConfFile);
         dwError = TDNFAllocateString(
                       pCmdOpt->pszOptValue,
                       &pCmdArgs->pszConfFile);
-        BAIL_ON_CLI_ERROR(dwError);
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
 cleanup:
@@ -55,7 +60,7 @@ cleanup:
     return dwError;
 
 error:
-    TDNF_CLI_SAFE_FREE_MEMORY(pCmdArgs->pszConfFile);
+    TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszConfFile);
     goto cleanup;
 }
 
@@ -75,20 +80,20 @@ AddSetOptWithValues(
        IsNullOrEmptyString(pszOptArg) ||
        IsNullOrEmptyString(pszOptValue) || nType == CMDOPT_CURL_INIT_CB)
     {
-        dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
-        BAIL_ON_CLI_ERROR(dwError);
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     dwError = TDNFAllocateMemory(1, sizeof(TDNF_CMD_OPT), (void**)&pCmdOpt);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     pCmdOpt->nType = nType;
 
     dwError = TDNFAllocateString(pszOptArg, &pCmdOpt->pszOptName);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFAllocateString(pszOptValue, &pCmdOpt->pszOptValue);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     pSetOptTemp = pCmdArgs->pSetOpt;
     if(!pSetOptTemp)
@@ -129,23 +134,23 @@ GetOptionAndValue(
 
     if(IsNullOrEmptyString(pszOptArg) || !ppCmdOpt)
     {
-        dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
-        BAIL_ON_CLI_ERROR(dwError);
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     pszIndex = strstr(pszOptArg, EQUAL_SIGN);
     if(!pszIndex)
     {
-        dwError = ERROR_TDNF_CLI_SETOPT_NO_EQUALS;
-        BAIL_ON_CLI_ERROR(dwError);
+        dwError = ERROR_TDNF_SETOPT_NO_EQUALS;
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     dwError = TDNFAllocateMemory(1, sizeof(TDNF_CMD_OPT), (void**)&pCmdOpt);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     pCmdOpt->nType = CMDOPT_KEYVALUE;
     dwError = TDNFAllocateString(pszOptArg, &pCmdOpt->pszOptName);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     nEqualsPos = pszIndex - pszOptArg;
     pCmdOpt->pszOptName[nEqualsPos] = '\0';
@@ -153,7 +158,7 @@ GetOptionAndValue(
     pCmdOpt->nType = CMDOPT_KEYVALUE;
     dwError = TDNFAllocateString(pszOptArg+nEqualsPos+1,
                                  &pCmdOpt->pszOptValue);
-    BAIL_ON_CLI_ERROR(dwError);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     *ppCmdOpt = pCmdOpt;
 cleanup:

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -125,6 +125,7 @@ extern "C" {
 #define ERROR_TDNF_RPM_GPG_PARSE_FAILED      1513
 #define ERROR_TDNF_RPM_GPG_NO_MATCH          1514
 #define ERROR_TDNF_RPM_CHECK                 1515
+#define ERROR_TDNF_SETOPT_NO_EQUALS          1516
 
 //RPM Transaction
 #define ERROR_TDNF_TRANS_INCOMPLETE     1525

--- a/tools/cli/lib/Makefile.am
+++ b/tools/cli/lib/Makefile.am
@@ -12,7 +12,6 @@ libtdnfcli_la_SOURCES = \
     parselistargs.c \
     parserepolistargs.c \
     parseupdateinfo.c \
-    setopt.c \
     updateinfocmd.c
 
 libtdnfcli_la_LIBADD =  \

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -399,6 +399,10 @@ ParseOption(
             BAIL_ON_CLI_ERROR(dwError);
         }
         dwError = AddSetOpt(pCmdArgs, optarg);
+        if (dwError == ERROR_TDNF_SETOPT_NO_EQUALS)
+        {
+            dwError = ERROR_TDNF_CLI_SETOPT_NO_EQUALS;
+        }
         BAIL_ON_CLI_ERROR(dwError);
     }
 cleanup:

--- a/tools/cli/lib/prototypes.h
+++ b/tools/cli/lib/prototypes.h
@@ -104,24 +104,3 @@ TDNFCliValidateOptions(
     const char* pszArg,
     struct option* pKnownOptions
     );
-
-//setopt.c
-uint32_t
-AddSetOpt(
-    PTDNF_CMD_ARGS pCmdArgs,
-    const char* pszOptArg
-    );
-
-uint32_t
-AddSetOptWithValues(
-    PTDNF_CMD_ARGS pCmdArgs,
-    int nType,
-    const char* pszOptArg,
-    const char* pszOptValue
-    );
-
-uint32_t
-GetOptionAndValue(
-    const char* pszOptArg,
-    PTDNF_CMD_OPT* ppCmdOpt
-    );

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -337,24 +337,3 @@ void
 TDNFFreeListArgs(
     PTDNF_LIST_ARGS pListArgs
     );
-
-//setopt.c
-uint32_t
-AddSetOpt(
-    PTDNF_CMD_ARGS pCmdArgs,
-    const char* pszOptArg
-    );
-
-uint32_t
-AddSetOptWithValues(
-    PTDNF_CMD_ARGS pCmdArgs,
-    int nType,
-    const char* pszOptArg,
-    const char* pszOptValue
-    );
-
-uint32_t
-GetOptionAndValue(
-    const char* pszOptArg,
-    PTDNF_CMD_OPT* ppCmdOpt
-    );


### PR DESCRIPTION
 this is so that setopt/getopt can be used from all libs
 required for upcoming external gpgkey changes