### PR TITLE
print rpm file name and path on rpm read errors

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -187,7 +187,7 @@ typedef enum
     {ERROR_TDNF_TRANS_INCOMPLETE,    "ERROR_TDNF_TRANS_INCOMPLETE",    "Incomplete rpm transaction"}, \
     {ERROR_TDNF_TRANS_PKG_NOT_FOUND, "ERROR_TDNF_TRANS_PKG_NOT_FOUND", "Failed to find rpm package"}, \
     {ERROR_TDNF_NO_SEARCH_RESULTS,   "ERROR_TDNF_NO_SEARCH_RESULTS",   "No matches found"}, \
-    {ERROR_TDNF_RPMRC_NOTFOUND,      "ERROR_TDNF_RPMRC_NOTFOUND",      "rpm generic error - not found"}, \
+    {ERROR_TDNF_RPMRC_NOTFOUND,      "ERROR_TDNF_RPMRC_NOTFOUND",      "rpm generic error - not found(possible corrupt rpm file"}, \
     {ERROR_TDNF_RPMRC_FAIL,          "ERROR_TDNF_RPMRC_FAIL",          "rpm generic failure"}, \
     {ERROR_TDNF_RPMRC_NOTTRUSTED,    "ERROR_TDNF_RPMRC_NOTTRUSTED",    "rpm signature is OK, but key is not trusted"}, \
     {ERROR_TDNF_RPMRC_NOKEY,         "ERROR_TDNF_RPMRC_NOKEY",         "public key is unavailable. install public key using rpm --import or use --nogpgcheck to ignore."}, \

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -370,5 +370,9 @@ cleanup:
     return dwError;
 
 error:
+    if (pszPkgFile)
+    {
+        fprintf(stderr, "Error verifying signature of: %s\n", pszPkgFile);
+    }
     goto cleanup;
 }

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -538,6 +538,7 @@ cleanup:
     return dwError;
 
 error:
+    fprintf(stderr, "Error processing package: %s\n", pszPackageLocation);
     TDNF_SAFE_FREE_MEMORY(pszFilePath);
     TDNF_SAFE_FREE_MEMORY(pRpmCache);
     goto cleanup;


### PR DESCRIPTION
- better error message
- hint bad/corrupt rpm with generic error message