### PR TITLE
client: Search for distroverpkg providing 'system-release'

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -134,7 +134,7 @@ typedef enum
 //Repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
 #define TDNF_DEFAULT_CACHE_LOCATION       "/var/cache/tdnf"
-#define TDNF_DEFAULT_DISTROVERPKG         "photon-release"
+#define TDNF_DEFAULT_DISTROVERPKG         "system-release"
 #define TDNF_DEFAULT_DISTROARCHPKG        "x86_64"
 #define TDNF_RPM_CACHE_DIR_NAME           "rpms"
 #define TDNF_REPODATA_DIR_NAME            "repodata"


### PR DESCRIPTION
`fedora-release` and `mageia-release` offer generic `system-release` Provides that can be used to determine the release version of the distribution.

Derivatives of Fedora (including RHEL) also offer this generic capability in their distribution release packages.

This is dependent on https://github.com/vmware/photon/pull/963.