### PR TITLE
Fix Error string when repodir is invalid

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -50,7 +50,7 @@ TDNFLoadRepoData(
     if(pDir == NULL)
     {
         dwError = ERROR_TDNF_REPO_DIR_OPEN;
-        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     while ((pEnt = readdir (pDir)) != NULL )

--- a/pytests/tests/test_config.py
+++ b/pytests/tests/test_config.py
@@ -46,4 +46,4 @@ def test_config_list_with_disable_repos(utils):
 def test_config_invaid_repodir(utils):
     utils.run([ 'sed', '-i', 's#repodir=/tmp/myrepo#repodir=/etc/invalid#g', '/tmp/myrepo/mytdnf.conf' ])
     ret = utils.run([ 'tdnf', '--config', '/tmp/myrepo/mytdnf.conf', 'list', 'tdnf-test-one' ])
-    assert(ret['retval'] == 2605)
+    assert(ret['retval'] == 1005)


### PR DESCRIPTION
Fix error string when repo directory provided is invalid. Currently tdnf displays "Error(2605) : Unknown error 1005" when the repodir configured is invalid. Correct Error should be "Error(1005) : Error opening repo dir. Check if the repodir configured in tdnf.conf exists (usually /etc/yum.repos.d)"