### PR TITLE
return non zero error when interactive alter is aborted

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -220,4 +220,5 @@ typedef enum
     {ERROR_TDNF_SELF_ERASE, "ERROR_TDNF_SELF_ERASE", "The operation would result in removing the protected package : tdnf"},\
     {ERROR_TDNF_PERM, "ERROR_TDNF_PERM", "Operation not permitted. You have to be root."},\
     {ERROR_TDNF_OPT_NOT_FOUND, "ERROR_TDNF_OPT_NOT_FOUND", "A required option was not found"},\
+    {ERROR_TDNF_OPERATION_ABORTED, "ERROR_TDNF_OPERATION_ABORTED", "Operation aborted."},\
 };

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -63,6 +63,7 @@ extern "C" {
 #define ERROR_TDNF_METADATA_EXPIRE_PARSE    1029
 #define ERROR_TDNF_SELF_ERASE               1030
 #define ERROR_TDNF_ERASE_NEEDS_INSTALL      1031
+#define ERROR_TDNF_OPERATION_ABORTED        1032
 
 //curl errors
 #define ERROR_TDNF_CURL_INIT                1200

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -247,7 +247,8 @@ TDNFCliAlterCommand(
         }
         else
         {
-            printf("Exiting on user Command\n");
+            dwError = ERROR_TDNF_OPERATION_ABORTED;
+            BAIL_ON_CLI_ERROR(dwError);
         }
     }
 


### PR DESCRIPTION
- when --assumeno is provided in command line
- when user aborts interactive alter with input other than 'y'
- error message "Operation aborted"
- previously tdnf did not return an error. returns non-zero error now.