### PR TITLE
Handle already installed packages faster.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,10 @@ Makefile.in
 *.log
 *.pc
 *.spec
+*.patch
+*.diff
 
+tags
 
 # autoconf
 /autom4te.cache

--- a/client/goal.c
+++ b/client/goal.c
@@ -312,7 +312,7 @@ TDNFGoal(
 
     int nFlags = 0;
     int i = 0;
-    Id  dwId = 0; 
+    Id  dwId = 0;
     int nProblems = 0;
     char** ppszExcludes = NULL;
     uint32_t dwCount = 0;
@@ -324,7 +324,7 @@ TDNFGoal(
     }
 
     queue_init(&queueJobs);
-    if(nAlterType == ALTER_UPGRADEALL)
+    if (nAlterType == ALTER_UPGRADEALL)
     {
         dwError = SolvAddUpgradeAllJob(&queueJobs);
         BAIL_ON_TDNF_ERROR(dwError);
@@ -336,7 +336,13 @@ TDNFGoal(
     }
     else
     {
-        for(i = 0; i < pQueuePkgList->count; i++)
+        if (pQueuePkgList->count == 0)
+        {
+            dwError = ERROR_TDNF_ALREADY_INSTALLED;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+
+        for (i = 0; i < pQueuePkgList->count; i++)
         {
             dwId = pQueuePkgList->elements[i];
             TDNFAddGoal(pTdnf, nAlterType, &queueJobs, dwId);

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -510,7 +510,7 @@ cleanup:
     return dwError;
 
 error:
-    fprintf(stderr, "Error: %d dlerror: %s\n", dwError, dlerror());
+    fprintf(stderr, "Error: %u dlerror: %s\n", dwError, dlerror());
     if (pPlugin)
     {
         if (pPlugin->pModule)

--- a/client/repo.c
+++ b/client/repo.c
@@ -630,7 +630,7 @@ cleanup:
     return dwError;
 
 error:
-    fprintf(stderr, "Error: %s %d\n", __FUNCTION__, dwError);
+    fprintf(stderr, "Error: %s %u\n", __FUNCTION__, dwError);
     TDNFFreeRepoMetadata(pRepoMD);
     goto cleanup;
 }

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -314,7 +314,8 @@ TDNFPrepareSinglePkg(
 
     //Check if this is a known package. If not add to unresolved
     dwError = SolvCountPkgByName(pSack, pszPkgName, &dwCount);
-    if(dwError || dwCount == 0)
+    BAIL_ON_TDNF_ERROR(dwError);
+    if (dwCount == 0)
     {
         dwError = ERROR_TDNF_NO_SEARCH_RESULTS;
         BAIL_ON_TDNF_ERROR(dwError);

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -44,12 +44,7 @@ TDNFRpmExecTransaction(
                   1,
                   sizeof(TDNF_CACHED_RPM_LIST),
                   (void**)&ts.pCachedRpmsArray);
-
-    if(!ts.pCachedRpmsArray)
-    {
-        dwError = ERROR_TDNF_OUT_OF_MEMORY;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
+    BAIL_ON_TDNF_ERROR(dwError);
 
     rpmSetVerbosity(TDNFConfGetRpmVerbosity(pTdnf));
 

--- a/client/utils.c
+++ b/client/utils.c
@@ -33,7 +33,6 @@ TDNFGetErrorString(
     int nCount = 0;
     uint32_t dwActualError = 0;
 
-
     //Allow mapped error strings to override
     TDNF_ERROR_DESC arErrorDesc[] = TDNF_ERROR_TABLE;
 
@@ -48,7 +47,6 @@ TDNFGetErrorString(
             break;
         }
     }
-
 
     //Get system error
     if(!pszError && TDNFIsSystemError(dwErrorCode))

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -218,7 +218,7 @@ cleanup:
     return dwError;
 
 error:
-    fprintf(stderr, "Error: %s %d\n", __FUNCTION__, dwError);
+    fprintf(stderr, "Error: %s %u\n", __FUNCTION__, dwError);
     goto cleanup;
 }
 

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -281,12 +281,9 @@ SolvApplyPackageFilter(
     }
 
     ppszTmpNames = ppszPackageNames;
-    while(*ppszTmpNames)
+    while (ppszTmpNames && *ppszTmpNames)
     {
-        if(!IsNullOrEmptyString(ppszTmpNames))
-        {
-            dwPkgs++;
-        }
+        dwPkgs++;
         ppszTmpNames++;
     }
 

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -258,6 +258,11 @@ cleanup:
     return dwError;
 
 error:
+    if (dwError == ERROR_TDNF_ALREADY_INSTALLED)
+    {
+        dwError = ERROR_TDNF_CLI_NOTHING_TO_DO;
+    }
+
     goto cleanup;
 }
 

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -134,6 +134,7 @@ int main(int argc, char* argv[])
 
                 dwError = arCmdMap[nCommandCount].pFnCmd(&_context, pCmdArgs);
                 BAIL_ON_CLI_ERROR(dwError);
+
                 break;
             }
         };
@@ -161,11 +162,13 @@ cleanup:
 
 error:
     TDNFCliPrintError(dwError);
-    if (dwError == ERROR_TDNF_CLI_NOTHING_TO_DO || dwError == ERROR_TDNF_NO_DATA)
+    if (dwError == ERROR_TDNF_CLI_NOTHING_TO_DO ||
+        dwError == ERROR_TDNF_NO_DATA)
     {
         // Nothing to do should not return an error code
         dwError = 0;
     }
+
     goto cleanup;
 }
 
@@ -177,25 +180,32 @@ TDNFCliPrintError(
     uint32_t dwError = 0;
     char* pszError = NULL;
 
-    if(dwErrorCode < ERROR_TDNF_BASE)
+    if (!dwErrorCode)
+    {
+        return dwError;
+    }
+
+    if (dwErrorCode < ERROR_TDNF_BASE)
     {
         dwError = TDNFCliGetErrorString(dwErrorCode, &pszError);
-        BAIL_ON_CLI_ERROR(dwError);
     }
     else
     {
         dwError = TDNFGetErrorString(dwErrorCode, &pszError);
-        BAIL_ON_CLI_ERROR(dwError);
     }
-    if(dwErrorCode == ERROR_TDNF_CLI_NOTHING_TO_DO || dwErrorCode == ERROR_TDNF_NO_DATA)
+    BAIL_ON_CLI_ERROR(dwError || !pszError);
+
+    if (dwErrorCode == ERROR_TDNF_CLI_NOTHING_TO_DO ||
+        dwErrorCode == ERROR_TDNF_NO_DATA)
     {
         dwErrorCode = 0;
     }
-    if(dwErrorCode)
+
+    if (dwErrorCode)
     {
         fprintf(stderr, "Error(%u) : %s\n", dwErrorCode, pszError);
     }
-    else if(!nQuiet)
+    else if (!nQuiet)
     {
         fprintf(stderr, "%s\n", pszError);
     }
@@ -205,11 +215,9 @@ cleanup:
     return dwError;
 
 error:
-    fprintf(
-        stderr,
-        "Retrieving error string for %u failed with %u\n",
-        dwErrorCode,
-        dwError);
+    fprintf(stderr, "Retrieving error string for %u failed with %u\n",
+            dwErrorCode, dwError);
+
     goto cleanup;
 }
 


### PR DESCRIPTION
At present, tdnf install -y 'package-which-is-already-installed' takes a bit of time to finish, this change makes it faster.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>