### PR TITLE
Install plugins into the correct architecture-specific library directory

### DIFF
--- a/client/config.h.in
+++ b/client/config.h.in
@@ -2,3 +2,6 @@
 
 #define PACKAGE_NAME    "@PROJECT_NAME@"
 #define PACKAGE_VERSION "@PROJECT_VERSION@"
+
+/* Platform defines */
+#define SYSTEM_LIBDIR "@CMAKE_INSTALL_FULL_LIBDIR@"

--- a/client/defines.h
+++ b/client/defines.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "config.h"
+
 typedef enum
 {
     DETAIL_LIST,
@@ -154,7 +156,7 @@ typedef enum
 #define TDNF_SETOPT_VALUE_DUMMY            "opt.dummy.value"
 /* plugin defines */
 #define TDNF_DEFAULT_PLUGINS_ENABLED      0
-#define TDNF_DEFAULT_PLUGIN_PATH          "/usr/lib/tdnf-plugins"
+#define TDNF_DEFAULT_PLUGIN_PATH          "SYSTEM_LIBDIR/tdnf-plugins"
 #define TDNF_DEFAULT_PLUGIN_CONF_PATH     "/etc/tdnf/pluginconf.d"
 #define TDNF_PLUGIN_CONF_EXT              ".conf"
 #define TDNF_PLUGIN_CONF_EXT_LEN          5

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -14,7 +14,7 @@ To enable plugins, the config file should have
 ## plugin discovery
 tdnf will look in ```/etc/tdnf/pluginconf.d``` by default for plugin configurations.
 For all config files with ```enabled=1``` set, tdnf will look for a corresponding
-shared library in ```/usr/lib/tdnf-plugins/<plugin>/lib<plugin>.so```.
+shared library in ```<libdir>/tdnf-plugins/<plugin>/lib<plugin>.so```.
 ```pluginpath``` and ```pluginconfpath``` are config settings to change default paths.
 
 ## overriding plugin load

--- a/plugins/repogpgcheck/CMakeLists.txt
+++ b/plugins/repogpgcheck/CMakeLists.txt
@@ -32,4 +32,4 @@ target_link_libraries(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
    LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/lib/${PROJECT_NAME})
-install(TARGETS ${PROJECT_NAME} DESTINATION lib/tdnf-plugins)
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/tdnf-plugins)


### PR DESCRIPTION
Most Linux distributions following the FHS have 64-bit binaries in
`/usr/lib64` and 32-bit binaries in `/usr/lib`. This change adjusts
plugins to be installed and detected in the correct directory for
libraries.

Signed-off-by: Neal Gompa <ngompa13@gmail.com>