### PR TITLE
tdnf clean all command updates

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -430,6 +430,12 @@ TDNFClean(
             dwError = TDNFRemoveSolvCache(pTdnf, *ppszReposUsed);
             BAIL_ON_TDNF_ERROR(dwError);
 
+            if (!pTdnf->pConf->nKeepCache)
+            {
+                dwError = TDNFRemoveRpmCache(pTdnf, *ppszReposUsed);
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+
             ++ppszReposUsed;
         }
     }

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -128,6 +128,12 @@ TDNFRepoRemoveCache(
     );
 
 uint32_t
+TDNFRemoveRpmCache(
+    PTDNF pTdnf,
+    const char* pszRepoId
+    );
+
+uint32_t
 TDNFRemoveLastRefreshMarker(
     PTDNF pTdnf,
     const char* pszRepoId


### PR DESCRIPTION
tdnf clean all does not delete cache rpms. Fix to delete
the cached rpms if keepcache is not set.
Fixes #832

Signed-off-by: Keerthana K <keerthanak@vmware.com>