### PR TITLE
fix error in distroverpkg lookup

### DIFF
--- a/client/utils.c
+++ b/client/utils.c
@@ -340,7 +340,7 @@ TDNFRawGetPackageVersion(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    pIter = rpmtsInitIterator(pTS, RPMTAG_NAME, pszPkg, 0);
+    pIter = rpmtsInitIterator(pTS, RPMTAG_PROVIDES, pszPkg, 0);
     if(!pIter)
     {
         dwError = ERROR_TDNF_NO_DISTROVERPKG;


### PR DESCRIPTION
- change RPMTAG_NAME to RPMTAG_PROVIDES
- required as system-release is provided by photon-release