### PR TITLE
Add an extra check to check the providers

### DIFF
--- a/client/goal.c
+++ b/client/goal.c
@@ -395,9 +395,12 @@ TDNFGoal(
     solver_set_flag(pSolv, SOLVER_FLAG_INSTALL_ALSO_UPDATES, 1);
 
     nProblems = solver_solve(pSolv, &queueJobs);
-    if(nProblems > 0)
+    if (nProblems > 0)
     {
-        dwError = ERROR_TDNF_SOLV_FAILED;
+        dwError = TDNFGetSkipProblemOption(pTdnf, &dwSkipProblem);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvReportProblems(pTdnf->pSack, pSolv, dwSkipProblem);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -438,11 +441,6 @@ cleanup:
     return dwError;
 
 error:
-    if(nProblems > 0 && pSolv)
-    {
-       TDNFGetSkipProblemOption(pTdnf, &dwSkipProblem);
-       SolvReportProblems(pSolv, dwSkipProblem);
-    }
     TDNF_SAFE_FREE_MEMORY(pInfoTemp);
     if(ppInfo)
     {

--- a/pytests/tests/test_check_skip.py
+++ b/pytests/tests/test_check_skip.py
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Shreenidhi Shedi <sshedi@vmware.com>
+
+import os
+import tempfile
+import pytest
+import shutil
+import subprocess
+
+isNotPhoton = -1
+try:
+    isNotPhoton = subprocess.check_call("uname -a | grep -i photon > /dev/null", shell = True)
+except Exception as e:
+    isNotPhoton = 1
+
+def run_cmd(utils, cmd, retval):
+    ret = utils.run(cmd)
+    if retval == 0:
+        assert(ret['retval'] == 0)
+    else:
+        assert(ret['retval'] != 0)
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    pass
+
+def test_check_skipconflicts(utils):
+    cmd = [ 'tdnf', '--config', '/etc/tdnf/tdnf.conf', 'check', '--skipconflicts']
+    if isNotPhoton == 1:
+        cmd.pop(1)
+        cmd.pop(1)
+
+    retval = 0 if isNotPhoton == 1 else 1
+    run_cmd(utils, cmd, retval)
+
+def test_check_skipobsoletes(utils):
+    cmd = [ 'tdnf', '--config', '/etc/tdnf/tdnf.conf', 'check', '--skipobsoletes']
+    if isNotPhoton == 1:
+        cmd.pop(1)
+        cmd.pop(1)
+
+    retval = 0 if isNotPhoton == 1 else 1
+    run_cmd(utils, cmd, retval)
+
+def test_check_providers(utils):
+    cmd = [ 'tdnf', '--config', '/etc/tdnf/tdnf.conf', 'check', '--skipconflicts', '--skipobsoletes']
+    if isNotPhoton == 1:
+        cmd.pop(1)
+        cmd.pop(1)
+
+    retval = 1 if isNotPhoton == 1 else 0
+    run_cmd(utils, cmd, 0)

--- a/solv/includes.h
+++ b/solv/includes.h
@@ -8,6 +8,8 @@
 #include <errno.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <stdbool.h>
+
 // libsolv
 #include <solv/evr.h>
 #include <solv/pool.h>

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -478,6 +478,7 @@ SolvLoadRepomdUpdateinfo(
 
 uint32_t
 SolvReportProblems(
+    PSolvSack pSack,
     Solver* pSolv,
     TDNF_SKIPPROBLEM_TYPE dwSkipProblem
     );


### PR DESCRIPTION
tdnf check currently has options to skip conflicts & obsoletes.
However it reports error on providers even though the required packages
are available. This will fix that issue by adding an extra check on
providers.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>