### PR TITLE
Plugin to move running kernel while doing kernel upgrade

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -156,7 +156,7 @@ typedef enum
 #define TDNF_SETOPT_VALUE_DUMMY            "opt.dummy.value"
 /* plugin defines */
 #define TDNF_DEFAULT_PLUGINS_ENABLED      0
-#define TDNF_DEFAULT_PLUGIN_PATH          "SYSTEM_LIBDIR/tdnf-plugins"
+#define TDNF_DEFAULT_PLUGIN_PATH          SYSTEM_LIBDIR"/tdnf-plugins"
 #define TDNF_DEFAULT_PLUGIN_CONF_PATH     "/etc/tdnf/pluginconf.d"
 #define TDNF_PLUGIN_CONF_EXT              ".conf"
 #define TDNF_PLUGIN_CONF_EXT_LEN          5

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -119,6 +119,9 @@ _TDNFInitPlugins(
 
         dwError = pPlugin->stInterface.pFnEvent(pPlugin->pHandle, &stContext);
         BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = pPlugin->stInterface.pFnEventsNeeded(pPlugin->pHandle, &pPlugin->RegisterdEvts);
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
 cleanup:
@@ -126,7 +129,7 @@ cleanup:
     return dwError;
 
 error:
-    TDNFShowPluginError(pTdnf, dwError);
+    TDNFShowPluginError(pTdnf, pPlugin, dwError);
     goto cleanup;
 }
 
@@ -645,7 +648,8 @@ TDNFPluginRaiseEvent(
 
     for(pPlugin = pTdnf->pPlugins; pPlugin; pPlugin = pPlugin->pNext)
     {
-        if (pPlugin->nEnabled == 0)
+        if (!pPlugin->nEnabled ||
+            !(pPlugin->RegisterdEvts & PLUGIN_EVENT_TYPE(pContext->nEvent)))
         {
             continue;
         }
@@ -657,23 +661,25 @@ TDNFPluginRaiseEvent(
 cleanup:
     return dwError;
 error:
-    TDNFShowPluginError(pTdnf, dwError);
+    TDNFShowPluginError(pTdnf, pPlugin, dwError);
     goto cleanup;
 }
 
 void
 TDNFShowPluginError(
     PTDNF pTdnf,
+    PTDNF_PLUGIN pPlugin,
     uint32_t nErrorCode
     )
 {
     char *pszError = NULL;
-    if (!pTdnf || nErrorCode == 0)
+
+    if (!pTdnf || !nErrorCode || !pPlugin)
     {
         goto cleanup;
     }
 
-    if (!TDNFGetPluginErrorString(pTdnf, nErrorCode, &pszError))
+    if (!TDNFGetPluginErrorString(pTdnf, pPlugin, nErrorCode, &pszError))
     {
         fprintf(stderr, "Plugin error: %s\n", pszError);
     }
@@ -686,44 +692,37 @@ cleanup:
 uint32_t
 TDNFGetPluginErrorString(
     PTDNF pTdnf,
+    PTDNF_PLUGIN pPlugin,
     uint32_t nErrorCode,
     char **ppszError
     )
 {
-    uint32_t dwError = 0;
     char *pszError = 0;
-    PTDNF_PLUGIN pPlugin = NULL;
+    uint32_t dwError = 0;
 
-    if (!pTdnf || nErrorCode == 0 || !ppszError)
+    if (!pTdnf || !pPlugin || !nErrorCode || !ppszError)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    /* run till an enabled plugin returns error or all plugins queried */
-    for(pPlugin = pTdnf->pPlugins; pPlugin && !pszError; pPlugin = pPlugin->pNext)
+    dwError = pPlugin->stInterface.pFnGetErrorString(
+                    pPlugin->pHandle,
+                    nErrorCode,
+                    &pszError);
+    if (dwError == ERROR_TDNF_NO_PLUGIN_ERROR)
     {
-        if (pPlugin->nEnabled == 0)
-        {
-            continue;
-        }
-
-        dwError = pPlugin->stInterface.pFnGetErrorString(
-                      pPlugin->pHandle,
-                      nErrorCode,
-                      &pszError);
-        if (dwError == ERROR_TDNF_NO_PLUGIN_ERROR)
-        {
-            dwError = 0;
-        }
-        BAIL_ON_TDNF_ERROR(dwError);
+        dwError = 0;
     }
+    BAIL_ON_TDNF_ERROR(dwError);
+
     if (IsNullOrEmptyString(pszError))
     {
         dwError = ERROR_TDNF_NO_PLUGIN_ERROR;
         BAIL_ON_TDNF_ERROR(dwError);
     }
     *ppszError = pszError;
+
 cleanup:
     return dwError;
 

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -901,6 +901,7 @@ TDNFFreePlugins(
 void
 TDNFShowPluginError(
     PTDNF pTdnf,
+    PTDNF_PLUGIN pPlugin,
     uint32_t nErrorCode
     );
 /* eventdata.c */

--- a/client/structs.h
+++ b/client/structs.h
@@ -25,10 +25,11 @@ typedef struct _TDNF_PLUGIN_
     char *pszName;
     int nEnabled;
     void *pModule;
+    TDNF_PLUGIN_EVENT RegisterdEvts;
     PTDNF_PLUGIN_HANDLE pHandle;
     TDNF_PLUGIN_INTERFACE stInterface;
     struct _TDNF_PLUGIN_ *pNext;
-}TDNF_PLUGIN, *PTDNF_PLUGIN;
+} TDNF_PLUGIN, *PTDNF_PLUGIN;
 
 typedef struct _TDNF_REPO_DATA_INTERNAL_
 {
@@ -77,6 +78,7 @@ typedef struct _TDNF_RPM_TS_
     rpmprobFilterFlags      nProbFilterFlags;
     FD_t                    pFD;
     PTDNF_CACHED_RPM_LIST   pCachedRpmsArray;
+    PTDNF                   pTdnf;
 }TDNFRPMTS, *PTDNFRPMTS;
 
 typedef struct _TDNF_ENV_

--- a/include/tdnfplugineventmap.h
+++ b/include/tdnfplugineventmap.h
@@ -24,11 +24,12 @@ const char *
 TDNFPluginGetEventMapVersion(
     );
 
-#define TDNF_EVENT_ITEM_TDNF_HANDLE  "tdnf.handle"
-#define TDNF_EVENT_ITEM_REPO_SECTION "repo.section"
-#define TDNF_EVENT_ITEM_REPO_ID      "repo.id"
-#define TDNF_EVENT_ITEM_REPO_MD_URL  "repomd.url"
-#define TDNF_EVENT_ITEM_REPO_MD_FILE "repomd.file"
+#define TDNF_EVENT_ITEM_TDNF_HANDLE     "tdnf.handle"
+#define TDNF_EVENT_ITEM_REPO_SECTION    "repo.section"
+#define TDNF_EVENT_ITEM_REPO_ID         "repo.id"
+#define TDNF_EVENT_ITEM_REPO_MD_URL     "repomd.url"
+#define TDNF_EVENT_ITEM_REPO_MD_FILE    "repomd.file"
+#define TDNF_EVENT_ITEM_KERN_UPDATE     "kern.up"
 
 typedef enum
 {

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -7,3 +7,4 @@
 #
 
 add_subdirectory("repogpgcheck")
+add_subdirectory("mvkernel")

--- a/plugins/mvkernel/CMakeLists.txt
+++ b/plugins/mvkernel/CMakeLists.txt
@@ -1,0 +1,31 @@
+#
+# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+project(tdnfmvkernel VERSION 0.0.1 LANGUAGES C)
+
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
+#make config.h with
+#PACKAGE_NAME and PACKAGE_VERSION defined
+configure_file(
+    config.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.h @ONLY
+)
+
+add_library(${PROJECT_NAME} SHARED
+    api.c
+    mvkernel.c
+)
+
+target_link_libraries(${PROJECT_NAME}
+    ${LIB_TDNF}
+)
+
+set_target_properties(${PROJECT_NAME} PROPERTIES
+   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/plugins/lib/${PROJECT_NAME})
+install(TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR}/tdnf-plugins)

--- a/plugins/mvkernel/api.c
+++ b/plugins/mvkernel/api.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#include "includes.h"
+
+static uint32_t
+FreePluginHandle(
+    PTDNF_PLUGIN_HANDLE pHandle
+    );
+
+TDNF_PLUGIN_INTERFACE _interface = {0};
+
+const char *TDNFPluginGetVersion(void)
+{
+    return PLUGIN_VERSION;
+}
+
+const char *TDNFPluginGetName(void)
+{
+    return PLUGIN_NAME;
+}
+
+uint32_t
+TDNFPluginLoadInterface(
+    PTDNF_PLUGIN_INTERFACE pInterface
+    )
+{
+    if (!pInterface)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    pInterface->pFnEvent = TDNFMvKernelEvent;
+    pInterface->pFnInitialize = TDNFMvKernelInit;
+    pInterface->pFnCloseHandle = TDNFMvKernelClose;
+    pInterface->pFnGetErrorString = TDNFMvKernelGetErrStr;
+    pInterface->pFnEventsNeeded = TDNFMvKernelEventsNeeded;
+
+    return 0;
+}
+
+uint32_t
+TDNFMvKernelInit(
+    const char *pszConfig,
+    PTDNF_PLUGIN_HANDLE *ppHandle
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_PLUGIN_HANDLE pHandle = NULL;
+
+    /* plugin does not expect config */
+    if (!ppHandle)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    UNUSED(pszConfig);
+
+    dwError = TDNFAllocateMemory(sizeof(*pHandle), 1, (void **)&pHandle);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    *ppHandle = pHandle;
+
+error:
+    if (dwError && pHandle)
+    {
+        FreePluginHandle(pHandle);
+    }
+
+    return dwError;
+}
+
+static uint32_t
+FreePluginHandle(
+    PTDNF_PLUGIN_HANDLE pHandle
+    )
+{
+    if (!pHandle)
+    {
+        return 1;
+    }
+
+    TDNF_SAFE_FREE_MEMORY(pHandle);
+    return 0;
+}
+
+uint32_t
+TDNFMvKernelEventsNeeded(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    TDNF_PLUGIN_EVENT_TYPE *pnEvents
+    )
+{
+    if (!pHandle || !pnEvents)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+    *pnEvents = TDNF_PLUGIN_EVENT_TYPE_KERN_INSTL;
+
+    return 0;
+}
+
+uint32_t
+TDNFMvKernelEvent(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    PTDNF_EVENT_CONTEXT pContext
+    )
+{
+    uint32_t dwError = 0;
+    TDNF_PLUGIN_EVENT_TYPE nEventType;
+    TDNF_PLUGIN_EVENT_STATE nEventState;
+    TDNF_PLUGIN_EVENT_PHASE nEventPhase;
+
+    if (!pHandle || !pContext)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    nEventType = PLUGIN_EVENT_TYPE(pContext->nEvent);
+    nEventState = PLUGIN_EVENT_STATE(pContext->nEvent);
+    nEventPhase = PLUGIN_EVENT_PHASE(pContext->nEvent);
+
+    if (nEventType == TDNF_PLUGIN_EVENT_TYPE_INIT)
+    {
+        dwError = TDNFEventContextGetItemPtr(
+                      pContext,
+                      TDNF_EVENT_ITEM_TDNF_HANDLE,
+                      (const void **)&pHandle->pTdnf);
+    }
+    else if (nEventType == TDNF_PLUGIN_EVENT_TYPE_KERN_INSTL)
+    {
+        if (nEventState == TDNF_PLUGIN_EVENT_STATE_MOVE &&
+            nEventPhase == TDNF_PLUGIN_EVENT_PHASE_START)
+        {
+            char *pkgname = NULL;
+
+            dwError = TDNFEventContextGetItemString(
+                            pContext,
+                            TDNF_EVENT_ITEM_KERN_UPDATE,
+                            (const char **)&pkgname);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            dwError = mv_running_kernel(pkgname);
+        } else if (nEventState == TDNF_PLUGIN_EVENT_STATE_MOUNT &&
+                   nEventPhase == TDNF_PLUGIN_EVENT_PHASE_END)
+        {
+            dwError = bindmount();
+        }
+    }
+    else
+    {
+        fprintf(stderr, "Unexpected event %d in %s plugin\n",
+                pContext->nEvent, PLUGIN_NAME);
+        return ERR_TDNF_MVKERNEL_UNKNWN;
+    }
+
+error:
+    return dwError;
+}
+
+uint32_t
+TDNFMvKernelGetErrStr(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    uint32_t nErrorCode,
+    char **ppszError
+    )
+{
+    size_t i = 0;
+    uint32_t dwError = 0;
+    char *pszError = NULL;
+    char *pszErrorPre = NULL;
+    TDNF_ERROR_DESC arErrorDesc[] = MVKERNEL_ERR_TABLE;
+
+    if (!pHandle || !ppszError)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    for (i = 0; i < sizeof(arErrorDesc)/sizeof(arErrorDesc[0]); i++)
+    {
+        if (nErrorCode == (uint32_t)arErrorDesc[i].nCode)
+        {
+            pszErrorPre = arErrorDesc[i].pszDesc;
+            break;
+        }
+    }
+
+    if (!pszErrorPre)
+    {
+        pszErrorPre = "unknown error";
+    }
+
+    dwError = TDNFAllocateStringPrintf(&pszError, "%s: %s\n",
+                                       MVKERNEL_PLUGIN_ERR, pszErrorPre);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    *ppszError = pszError;
+
+error:
+    if (dwError)
+    {
+        TDNF_SAFE_FREE_MEMORY(pszError);
+    }
+
+    return dwError;
+}
+
+uint32_t
+TDNFMvKernelClose(
+    PTDNF_PLUGIN_HANDLE pHandle
+    )
+{
+    if (!pHandle)
+    {
+        return 1;
+    }
+
+    return FreePluginHandle(pHandle);
+}

--- a/plugins/mvkernel/config.h.in
+++ b/plugins/mvkernel/config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+
+#define PLUGIN_NAME    "@PROJECT_NAME@"
+#define PLUGIN_VERSION "@PROJECT_VERSION@"

--- a/plugins/mvkernel/defines.h
+++ b/plugins/mvkernel/defines.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#ifndef __PLUGINS_MVKERNEL_DEFINES_H__
+#define __PLUGINS_MVKERNEL_DEFINES_H__
+
+#define UNUSED(var) ((void)(var))
+
+typedef struct _TDNF_PLUGIN_HANDLE_
+{
+    PTDNF pTdnf;
+    uint32_t nError; /* last error set by this plugin */
+} TDNF_PLUGIN_HANDLE, *PTDNF_PLUGIN_HANDLE;
+
+#define ERR_TDNF_MVKERNEL_BASE_START        2000
+#define ERR_TDNF_MVKERNEL_MKDIR_FAILED      ERR_TDNF_MVKERNEL_BASE_START + 1
+#define ERR_TDNF_MVKERNEL_CP_FAILED         ERR_TDNF_MVKERNEL_BASE_START + 2
+#define ERR_TDNF_MVKERNEL_MOUNT_FAILED      ERR_TDNF_MVKERNEL_BASE_START + 3
+#define ERR_TDNF_MVKERNEL_GET_KERN_VER      ERR_TDNF_MVKERNEL_BASE_START + 4
+#define ERR_TDNF_MVKERNEL_WRNG_PATH         ERR_TDNF_MVKERNEL_BASE_START + 5
+#define ERR_TDNF_MVKERNEL_FTS_OP_FAILED     ERR_TDNF_MVKERNEL_BASE_START + 6
+#define ERR_TDNF_MVKERNEL_FOPS_FAILED       ERR_TDNF_MVKERNEL_BASE_START + 7
+#define ERR_TDNF_MVKERNEL_UNKNWN            ERR_TDNF_MVKERNEL_BASE_START + 8
+#define ERR_TDNF_MVKERNEL_ERR               ERR_TDNF_MVKERNEL_BASE_START + 9
+
+#define MVKERNEL_PLUGIN_ERR                 "mvkernel plugin error"
+
+#define MVKERNEL_ERR_TABLE \
+{ \
+    {ERR_TDNF_MVKERNEL_MKDIR_FAILED,    "ERR_TDNF_MVKERNEL_MKDIR_FAILED",   "failed to create directory"},      \
+    {ERR_TDNF_MVKERNEL_CP_FAILED,       "ERR_TDNF_MVKERNEL_CP_FAILED",      "failed to copy file"},             \
+    {ERR_TDNF_MVKERNEL_MOUNT_FAILED,    "ERR_TDNF_MVKERNEL_MOUNT_FAILED",   "mount operation failure"},         \
+    {ERR_TDNF_MVKERNEL_GET_KERN_VER,    "ERR_TDNF_MVKERNEL_GET_KERN_VER",   "failed to get kernel version"},    \
+    {ERR_TDNF_MVKERNEL_WRNG_PATH,       "ERR_TDNF_MVKERNEL_WRNG_PATH",      "provided path is wrong"},          \
+    {ERR_TDNF_MVKERNEL_FTS_OP_FAILED,   "ERR_TDNF_MVKERNEL_FTS_OP_FAILED",  "fts operation failed"},            \
+    {ERR_TDNF_MVKERNEL_FOPS_FAILED,     "ERR_TDNF_MVKERNEL_FOPS_FAILED",    "file system operation failed"},    \
+    {ERR_TDNF_MVKERNEL_UNKNWN,          "ERR_TDNF_MVKERNEL_UNKNWN",         "unknown error"},                   \
+    {ERR_TDNF_MVKERNEL_ERR,             "ERR_TDNF_MVKERNEL_ERR",            "failed to move kernel"},           \
+};
+
+#endif /* __PLUGINS_MVKERNEL_DEFINES_H__ */

--- a/plugins/mvkernel/includes.h
+++ b/plugins/mvkernel/includes.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#ifndef __PLUGINS_MVKERNEL_INCLUDES_H__
+#define __PLUGINS_MVKERNEL_INCLUDES_H__
+
+#define TMPDIR        "/tmp"
+#define LIBMODULESDIR "/lib/modules"
+
+#include <fts.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/errno.h>
+#include <sys/mount.h>
+#include <sys/utsname.h>
+
+#include <tdnf.h>
+#include <tdnfplugin.h>
+#include <tdnfplugineventmap.h>
+
+#include "config.h"
+#include "defines.h"
+#include "prototypes.h"
+
+#include "../../common/defines.h"
+#include "../../common/structs.h"
+#include "../../common/prototypes.h"
+
+#endif /* __PLUGINS_MVKERNEL_INCLUDES_H__ */

--- a/plugins/mvkernel/mvkernel.c
+++ b/plugins/mvkernel/mvkernel.c
@@ -1,0 +1,326 @@
+/*
+ * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#include "includes.h"
+
+static bool isKernMoved = false;
+
+static int32_t _bindmount(const char *src, const char *dst,
+                          unsigned long flags);
+
+int32_t get_kern_version(char *buf, int32_t bufsize)
+{
+    int32_t dwError = 0;
+    struct utsname st = {0};
+
+    if (!buf || bufsize < _UTSNAME_VERSION_LENGTH)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    dwError = uname(&st);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    snprintf(buf, bufsize, "%s", st.release);
+
+    return dwError;
+
+error:
+    return ERR_TDNF_MVKERNEL_GET_KERN_VER;
+}
+
+static int32_t _bindmount(const char *src, const char *dst,
+                          unsigned long flags)
+{
+    int32_t dwError = 0;
+    const unsigned long mntflags = flags;
+
+    if (IsNullOrEmptyString(src) || IsNullOrEmptyString(dst))
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    dwError = mkdir(dst, 0755);
+    BAIL_ON_TDNF_ERROR((dwError && dwError != EEXIST));
+
+    dwError = mount(src, dst, "", mntflags, "");
+    printf("Mount %s at %s - %s\n", src, dst, !dwError ? "success" : "failed");
+    if (dwError)
+    {
+        fprintf(stderr, "Reason: %s\n", strerror(errno));
+        goto error;
+    }
+
+    return dwError;
+
+error:
+    return ERR_TDNF_MVKERNEL_MOUNT_FAILED;
+}
+
+static int32_t fix_dst_path(const char *src, char *dst, int32_t dstsize)
+{
+    char *s = NULL;
+    char buf[dstsize];
+
+    if (IsNullOrEmptyString(src) || IsNullOrEmptyString(dst) || dstsize <= 0)
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    BAIL_ON_TDNF_ERROR(!(s = strrchr(src, '/')));
+
+    memset(buf, 0, dstsize);
+    snprintf(buf, dstsize, "%s/%s", dst, ++s);
+    strcpy(dst, buf);
+
+    return 0;
+
+error:
+    return ERR_TDNF_MVKERNEL_UNKNWN;
+}
+
+int32_t removedir(const char *path)
+{
+    FTS *ftsp = NULL;
+    FTSENT *ent = NULL;
+    int32_t dwError = 0;
+    char rpath[PATH_MAX] = {0};
+
+    if (IsNullOrEmptyString(path))
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    if (!realpath(path, rpath))
+    {
+        return ERR_TDNF_MVKERNEL_WRNG_PATH;
+    }
+
+    char *paths[] = { rpath, NULL };
+
+    ftsp = fts_open(paths, FTS_PHYSICAL, NULL);
+    if (!ftsp)
+    {
+        return ERR_TDNF_MVKERNEL_FTS_OP_FAILED;
+    }
+
+    errno = 0;
+    while ((ent = fts_read(ftsp)))
+    {
+        if (ent->fts_info & FTS_DP)
+        {
+            rmdir(ent->fts_path);
+        }
+        else if (ent->fts_info & FTS_F)
+        {
+            unlink(ent->fts_path);
+        }
+
+        if (errno)
+        {
+            dwError = ERR_TDNF_MVKERNEL_FOPS_FAILED;
+            fprintf(stderr, "Failed to delete: %s\n", ent->fts_path);
+            goto error;
+        }
+    }
+
+error:
+    if (fts_close(ftsp))
+    {
+         return ERR_TDNF_MVKERNEL_FTS_OP_FAILED;
+    }
+
+    return dwError;
+}
+
+int32_t copy_file(const char *src, const char *dst)
+{
+    size_t n = 0;
+    FILE *in = NULL;
+    FILE *out = NULL;
+    char rbuf[BUFSIZ] = {0};
+    int32_t dwError = ERR_TDNF_MVKERNEL_FOPS_FAILED;
+
+    if (IsNullOrEmptyString(src) || IsNullOrEmptyString(dst))
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    in = fopen(src, "rb");
+    out= fopen(dst, "wb");
+    BAIL_ON_TDNF_ERROR((!in || !out));
+
+    while ((n = fread(rbuf, 1, BUFSIZ, in)))
+    {
+        BAIL_ON_TDNF_ERROR((fwrite(rbuf, 1, n, out) != n));
+    }
+
+    BAIL_ON_TDNF_ERROR(!feof(in));
+
+    dwError = 0;
+
+error:
+    if ((in && fclose(in)) || (out && fclose(out)))
+    {
+        dwError = ERR_TDNF_MVKERNEL_FOPS_FAILED;
+    }
+
+    return dwError;
+}
+
+int32_t mvdir(const char *src, const char *dst)
+{
+    FTS *ftsp = NULL;
+    FTSENT *ent = NULL;
+    int32_t dwError = 0;
+    char srcpath[PATH_MAX] = {0};
+    char dstpath[PATH_MAX] = {0};
+
+    if (IsNullOrEmptyString(src) || IsNullOrEmptyString(dst))
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    if (!realpath(src, srcpath))
+    {
+        return ERR_TDNF_MVKERNEL_WRNG_PATH;
+    }
+
+    char *paths[] = { srcpath, NULL };
+
+    ftsp = fts_open(paths, FTS_PHYSICAL, NULL);
+    if (!ftsp)
+    {
+        return ERR_TDNF_MVKERNEL_FTS_OP_FAILED;
+    }
+
+    if (!realpath(dst, dstpath))
+    {
+        BAIL_ON_TDNF_ERROR((dwError = ERR_TDNF_MVKERNEL_WRNG_PATH));
+    }
+
+    while ((ent = fts_read(ftsp))) {
+        char *s = NULL;
+        char *cursrc = ent->fts_path;
+
+        if (ent->fts_info & FTS_D)
+        {
+            struct stat fstat = {0};
+
+            dwError = fix_dst_path(cursrc, dstpath, sizeof(dstpath));
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            if (stat(srcpath, &fstat) || mkdir(dstpath, fstat.st_mode))
+            {
+                if (errno != EEXIST)
+                {
+                    BAIL_ON_TDNF_ERROR((dwError = ERR_TDNF_MVKERNEL_MKDIR_FAILED));
+                }
+            }
+        }
+        else if (ent->fts_info & FTS_DP)
+        {
+            s = strrchr(dstpath, '/');
+            BAIL_ON_TDNF_ERROR(!s && (dwError = ERR_TDNF_MVKERNEL_UNKNWN));
+
+            *s = '\0';
+        }
+        else if (ent->fts_info & FTS_F)
+        {
+            dwError = fix_dst_path(cursrc, dstpath, sizeof(dstpath));
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            if (copy_file(cursrc, dstpath))
+            {
+                fprintf(stderr, "Unable to copy file: %s to destination %s\n",
+                        cursrc, dstpath);
+                goto error;
+            }
+            sync();
+
+            s = strrchr(dstpath, '/');
+            BAIL_ON_TDNF_ERROR(!s && (dwError = ERR_TDNF_MVKERNEL_UNKNWN));
+
+            *s = '\0';
+        }
+        else
+        {
+            /* We shouldn't reach here */
+            fprintf(stderr, "Other: %s\n", cursrc);
+        }
+    }
+
+    dwError = removedir(src);
+    if (dwError)
+    {
+        fprintf(stderr, "Deletion of %s failed\n", src);
+        goto error;
+    }
+
+error:
+    if (fts_close(ftsp))
+    {
+        dwError = ERR_TDNF_MVKERNEL_FTS_OP_FAILED;
+    }
+
+    printf("Move %s to %s - %s\n", srcpath, dstpath, !dwError ? "success" :
+            "failed");
+    if (!dwError)
+    {
+        isKernMoved = true;
+    }
+
+    return dwError;
+}
+
+int32_t mv_running_kernel(const char *pkgname)
+{
+    char src[PATH_MAX] = {0};
+    char kver[_UTSNAME_VERSION_LENGTH] = {0};
+
+    if (IsNullOrEmptyString(pkgname))
+    {
+        return ERROR_TDNF_INVALID_PARAMETER;
+    }
+
+    if (get_kern_version(kver, sizeof(kver)))
+    {
+        return ERR_TDNF_MVKERNEL_GET_KERN_VER;
+    }
+
+    if (!strstr(pkgname, kver))
+    {
+        return 0;
+    }
+
+    snprintf(src, sizeof(src), LIBMODULESDIR"/%s", kver);
+    return mvdir(src, TMPDIR);
+}
+
+int32_t bindmount(void)
+{
+    char src[PATH_MAX] = {0};
+    char dst[PATH_MAX] = {0};
+    char kver[_UTSNAME_VERSION_LENGTH] = {0};
+
+    if (!isKernMoved)
+    {
+        return ERR_TDNF_MVKERNEL_ERR;
+    }
+    isKernMoved = false;
+
+    if (get_kern_version(kver, sizeof(kver)))
+    {
+        return ERR_TDNF_MVKERNEL_GET_KERN_VER;
+    }
+
+    snprintf(src, sizeof(src), TMPDIR"/%s", kver);
+    snprintf(dst, sizeof(dst), LIBMODULESDIR"/%s", kver);
+
+    return _bindmount(src, dst, MS_BIND | MS_REC);
+}

--- a/plugins/mvkernel/prototypes.h
+++ b/plugins/mvkernel/prototypes.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#ifndef __PLUGINS_MVKERNEL_PROTOTYPES_H__
+#define __PLUGINS_MVKERNEL_PROTOTYPES_H__
+
+int32_t bindmount(void);
+int32_t removedir(const char *path);
+int32_t mv_running_kernel(const char *pkgname);
+int32_t mvdir(const char *src, const char *dst);
+int32_t copy_file(const char *src, const char *dst);
+int32_t get_kern_version(char *buf, int32_t bufsize);
+
+const char *TDNFPluginGetName(void);
+const char *TDNFPluginGetVersion(void);
+
+uint32_t
+TDNFPluginLoadInterface(
+    PTDNF_PLUGIN_INTERFACE pInterface
+    );
+
+uint32_t
+TDNFMvKernelInit(
+    const char *pszConfig,
+    PTDNF_PLUGIN_HANDLE *ppHandle
+    );
+
+uint32_t
+TDNFMvKernelEventsNeeded(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    TDNF_PLUGIN_EVENT_TYPE *pnEvents
+    );
+
+uint32_t
+TDNFMvKernelEvent(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    PTDNF_EVENT_CONTEXT pContext
+    );
+
+uint32_t
+TDNFMvKernelGetErrStr(
+    PTDNF_PLUGIN_HANDLE pHandle,
+    uint32_t nErrorCode,
+    char **ppszError
+    );
+
+uint32_t
+TDNFMvKernelClose(
+    PTDNF_PLUGIN_HANDLE pHandle
+    );
+
+#endif /* __PLUGINS_MVKERNEL_PROTOTYPES_H__ */


### PR DESCRIPTION
This plugin moves the running kernel to /tmp and does a bind mount of
the moved kernel under /lib/modules so that we won't lose the ability to
do a depmod/modprobe after upgrading the kernel.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>