### PR TITLE
Add metalink support

### DIFF
--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -7,6 +7,6 @@ RUN dnf -q -y upgrade
 RUN dnf -q -y install gcc make cmake libcurl-devel rpm-devel rpm-build libsolv-devel \
                       popt-devel sed createrepo_c glib2-devel libxml2 findutils \
                       python3-pytest python3-requests python3-urllib3 python3-pyOpenSSL \
-                      python3 python3-devel valgrind gpgme-devel
+                      python3 python3-devel valgrind gpgme-devel libmetalink-devel
 
 CMD ["/bin/bash"]

--- a/ci/Dockerfile.photon
+++ b/ci/Dockerfile.photon
@@ -8,7 +8,7 @@ RUN tdnf install -q -y --enablerepo=photon-debuginfo \
                        build-essential cmake curl-devel rpm-build libsolv-devel \
                        popt-devel sed createrepo_c glib libxml2 findutils \
                        python3 python3-pip python3-setuptools python3-devel \
-                       valgrind gpgme-devel glibc-debuginfo
+                       valgrind gpgme-devel glibc-debuginfo libmetalink-devel
 
 # python build/test dependencies
 RUN pip3 install -q requests urllib3 pyOpenSSL pytest

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,6 +8,8 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
+find_package(Metalink REQUIRED)
+
 #make config.h with
 #PACKAGE_NAME and PACKAGE_VERSION defined
 configure_file(
@@ -49,6 +51,7 @@ target_link_libraries(${LIB_TDNF}
     ${RPM_LIBRARIES}
     ${LibSolv_LIBRARIES}
     ${CURL_LIBRARIES}
+    ${METALINK_LIBRARIES}
 )
 
 set_target_properties(${LIB_TDNF} PROPERTIES

--- a/client/defines.h
+++ b/client/defines.h
@@ -136,7 +136,9 @@ typedef enum
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"
 #define TDNF_REPO_METADATA_FILE_PATH      "repodata/repomd.xml"
+#define TDNF_REPO_METALINK_FILE_PATH      "repodata/photon.metalink"
 #define TDNF_REPO_METADATA_FILE_NAME      "repomd.xml"
+#define TDNF_REPO_METALINK_FILE_NAME      "photon.metalink"
 
 //Repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
@@ -226,4 +228,5 @@ typedef enum
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_NO_GPGKEY_CONF_ENTRY,         "ERROR_TDNF_NO_GPGKEY_CONF_ENTRY",         "gpgkey entry is missing for this repo. please add gpgkey in repo file or use --nogpgcheck to ignore."}, \
+    {ERROR_TDNF_BASEURL_DOES_NOT_EXISTS, "ERROR_TDNF_BASEURL_DOES_NOT_EXISTS", "Base URL and Metalink URL not found in the repo file"},\
 };

--- a/client/includes.h
+++ b/client/includes.h
@@ -67,4 +67,7 @@
 #include "../common/prototypes.h"
 #include "prototypes.h"
 
+#include <metalink/metalink_parser.h>
+
+
 #endif /* __CLIENT_INCLUDES_H__ */

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -106,7 +106,12 @@ TDNFRepoGetBaseUrl(
     const char* pszRepo,
     char** ppszBaseUrl
     );
-
+uint32_t
+TDNFRepoSetBaseUrl(
+    PTDNF pTdnf,
+    const char* pszRepo,
+    char* pszBaseUrl
+    );
 uint32_t
 TDNFRepoGetUserPass(
     PTDNF pTdnf,
@@ -159,12 +164,20 @@ TDNFRepoApplyProxySettings(
 
 //remoterepo.c
 uint32_t
+TDNFParseAndGetURLFromMetalink(
+    PTDNF pTdnf,
+    const char *pszRepo,
+    const char *pszFile
+    );
+
+uint32_t
 TDNFDownloadFile(
     PTDNF pTdnf,
     const char *pszRepo,
     const char *pszFileUrl,
     const char *pszFile,
-    const char *pszProgressData
+    const char *pszProgressData,
+    int metalink
     );
 
 uint32_t
@@ -525,7 +538,7 @@ TDNFFreeRepoMetadata(
     );
 
 uint32_t
-TDNFReplaceRepoMDFile(
+TDNFReplaceFile(
     const char *pszSrcFile,
     const char *pszDstFile
     );

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -40,6 +40,54 @@ error:
 }
 
 uint32_t
+TDNFRepoSetBaseUrl(
+    PTDNF pTdnf,
+    const char* pszRepo,
+    char* pszBaseUrl
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+
+    if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pszBaseUrl)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    if(!pTdnf->pRepos)
+    {
+        dwError = ERROR_TDNF_NO_REPOS;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    pRepos = pTdnf->pRepos;
+
+    while(pRepos)
+    {
+        if(!strcmp(pszRepo, pRepos->pszId))
+        {
+            break;
+        }
+        pRepos = pRepos->pNext;
+    }
+
+    if(!pRepos)
+    {
+        dwError = ERROR_TDNF_REPO_NOT_FOUND;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    TDNF_SAFE_FREE_MEMORY(pRepos->pszBaseUrl);
+    dwError = TDNFAllocateString(pszBaseUrl, &pRepos->pszBaseUrl);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+
+cleanup:
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+uint32_t
 TDNFRepoGetBaseUrl(
     PTDNF pTdnf,
     const char* pszRepo,

--- a/cmake/FindMetalink.cmake
+++ b/cmake/FindMetalink.cmake
@@ -1,0 +1,17 @@
+# - Try to find metalink
+# Once done this will define
+#  METALINK_FOUND - System has metalink
+#  METALINK_INCLUDE_DIRS - The metalink include directories
+#  METALINK_LIBRARIES - The libraries needed to use metalink
+
+find_path(METALINK_INCLUDE_DIR metalink/metalink_parser.h)
+find_library(METALINK_LIBRARY NAMES libmetalink.so)
+
+# handle the QUIETLY and REQUIRED arguments and set METALINK_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(libmetalink DEFAULT_MSG
+                                  METALINK_LIBRARY METALINK_INCLUDE_DIR)
+
+
+set(METALINK_LIBRARIES ${METALINK_LIBRARY})
+set(METALINK_INCLUDE_DIRS ${METALINK_INCLUDE_DIR})

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -157,6 +157,8 @@ extern "C" {
 
 #define ERROR_TDNF_PLUGIN_BASE          2000
 
+#define ERROR_TDNF_BASEURL_DOES_NOT_EXISTS    2500
+
 #define CMD_INSTALL "install"
 
 #ifdef __cplusplus

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -65,6 +65,7 @@ cat << EOF > ${TEST_REPO_DIR}/yum.repos.d/photon-test.repo
 [photon-test]
 name=basic
 baseurl=file://${PUBLISH_PATH}
+#metalink=file://${PUBLISH_PATH}
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=0
 enabled=1
@@ -77,4 +78,17 @@ installonly_limit=3
 clean_requirements_on_remove=true
 repodir=${TEST_REPO_DIR}/yum.repos.d
 cachedir=${TEST_REPO_DIR}/cache/tdnf
+EOF
+
+cat << EOF > ${PUBLISH_PATH}/repodata/photon.metalink
+<?xml version="1.0" encoding="utf-8"?>
+<metalink version="3.0" xmlns="http://www.metalinker.org/" type="dynamic" pubdate="Wed, 05 Feb 2020 08:14:56 GMT">
+ <files>
+  <file name="repomd.xml">
+   <resources maxconnections="1">
+    <url protocol="file" type="file" location="IN" preference="100">file://${PUBLISH_PATH}</url>
+   </resources>
+  </file>
+ </files>
+</metalink>
 EOF

--- a/pytests/tests/test_metalink.py
+++ b/pytests/tests/test_metalink.py
@@ -1,0 +1,78 @@
+#
+# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Tapas Kundu <tkundu@vmware.com>
+
+import os
+import pytest
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+#while exiting, uncomment baseurl and comment metalink
+def teardown_test(utils):
+    tdnf_repo = os.path.join(utils.tdnf_config.get('main', 'repodir'), 'photon-test.repo')
+    set_baseurl(utils, True)
+    set_metalink(utils, False)
+
+def set_baseurl(utils, enabled):
+    tdnf_repo = os.path.join(utils.tdnf_config.get('main', 'repodir'), 'photon-test.repo')
+    if enabled:
+        utils.run([ 'sed', '-i', '/baseurl/s/^#//g', tdnf_repo ])
+    else:
+        utils.run([ 'sed', '-e', '/baseurl/ s/^#*/#/g', '-i', tdnf_repo ])
+
+def set_metalink(utils, enabled):
+    tdnf_repo = os.path.join(utils.tdnf_config.get('main', 'repodir'), 'photon-test.repo')
+    if enabled:
+        utils.run([ 'sed', '-i', '/metalink/s/^#//g', tdnf_repo ])
+    else:
+        utils.run([ 'sed', '-e', '/metalink/ s/^#*/#/g', '-i', tdnf_repo ])
+
+#uncomment metalink from repo file, so we have both url and metalink
+def test_with_metalink_and_url(utils):
+    set_metalink(utils, True)
+    set_baseurl(utils, True)
+    ret = utils.run([ 'tdnf', 'repolist'])
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname ])
+    assert(utils.check_package(pkgname) == True)
+
+#comment out baseurl
+def test_metalink_without_baseurl(utils):
+    set_baseurl(utils, False)
+    set_metalink(utils, True)
+    ret = utils.run([ 'tdnf', 'repolist'])
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname ])
+    assert(utils.check_package(pkgname) == True)
+
+#comment out metalink
+#uncomment baseurl
+def test_url_without_metalink(utils):
+    set_metalink(utils, False)
+    set_baseurl(utils, True)
+    ret = utils.run([ 'tdnf', 'repolist'])
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname ])
+    assert(utils.check_package(pkgname) == True)
+
+#comment out both metalink and baseurl
+def test_without_url_and_metalink(utils):
+    set_metalink(utils, False)
+    set_baseurl(utils, False)
+    ret = utils.run([ 'tdnf', 'repolist' ])
+    print(ret['stderr'][0])
+    assert(ret['stderr'][0].startswith('Error: Cannot find a valid base URL for repo'))

--- a/python/structs.h
+++ b/python/structs.h
@@ -24,5 +24,6 @@ typedef struct _PY_TDNF_REPODATA
     PyObject *id;
     PyObject *name;
     PyObject *baseurl;
+    PyObject *metalink;
     int enabled;
 }PY_TDNF_REPODATA, *PPY_TDNF_REPODATA;

--- a/python/tdnfpyrepodata.c
+++ b/python/tdnfpyrepodata.c
@@ -17,6 +17,7 @@ TDNFPyRepoDataFree(PY_TDNF_REPODATA *self)
     Py_XDECREF(self->id);
     Py_XDECREF(self->name);
     Py_XDECREF(self->baseurl);
+    Py_XDECREF(self->metalink);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -47,6 +48,11 @@ TDNFPyRepoDataNew(
             dwError = ERROR_TDNF_OUT_OF_MEMORY;
             BAIL_ON_TDNF_ERROR(dwError);
         }
+        if(!(self->metalink = PyBytes_FromString("")))
+        {
+            dwError = ERROR_TDNF_OUT_OF_MEMORY;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
     }
 
 cleanup:
@@ -69,12 +75,13 @@ TDNFPyRepoDataInit(
     PyObject *id = NULL;
     PyObject *name = NULL;
     PyObject *baseurl = NULL;
+    PyObject *metalink = NULL;
     PyObject *tmp = NULL;
 
-    static char *kwlist[] = {"id", "name", "baseurl", "enabled", NULL};
+    static char *kwlist[] = {"id", "name", "baseurl", "metalink", "enabled", NULL};
 
     if (! PyArg_ParseTupleAndKeywords(args, kwds, "|SSSI", kwlist,
-                                      &id, &name, &baseurl, &self->enabled))
+                                      &id, &name, &baseurl, &metalink, &self->enabled))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -99,6 +106,13 @@ TDNFPyRepoDataInit(
         tmp = self->baseurl;
         Py_INCREF(baseurl);
         self->baseurl = baseurl;
+        Py_XDECREF(tmp);
+    }
+    if (metalink)
+    {
+        tmp = self->metalink;
+        Py_INCREF(metalink);
+        self->metalink = metalink;
         Py_XDECREF(tmp);
     }
 
@@ -127,6 +141,7 @@ TDNFPyRepoDataRepr(
                   pRepoData->id ? PyBytes_AsString(pRepoData->id) : "",
                   pRepoData->name ? PyBytes_AsString(pRepoData->name) : "",
                   pRepoData->baseurl ? PyBytes_AsString(pRepoData->baseurl) : "",
+                  pRepoData->metalink ? PyBytes_AsString(pRepoData->metalink) : "",
                   pRepoData->enabled);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -178,6 +193,7 @@ TDNFPyMakeRepoData(
     pPyRepoData->id = PyBytes_FromString(pRepoData->pszId);
     pPyRepoData->name = PyBytes_FromString(pRepoData->pszName);
     pPyRepoData->baseurl = PyBytes_FromString(pRepoData->pszBaseUrl);
+    pPyRepoData->metalink = PyBytes_FromString(pRepoData->metalink);
     pPyRepoData->enabled = pRepoData->nEnabled;
 
     *ppPyRepoData = (PyObject *)pPyRepoData;
@@ -204,6 +220,8 @@ static PyMemberDef TDNFPyRepoDataMembers[] = {
      "repo name"},
     {"baseurl", T_OBJECT_EX, offsetof(PY_TDNF_REPODATA, baseurl), 0,
      "repo baseurl"},
+    {"metalink", T_OBJECT_EX, offsetof(PY_TDNF_REPODATA, metalink), 0,
+     "repo metalink"},
     {"enabled", T_INT, offsetof(PY_TDNF_REPODATA, enabled), 0,
      "repo enabled status"},
     {NULL}  /* Sentinel */


### PR DESCRIPTION
Added metalink support for repo files.

If metalink URL is present, we will get the URL with the highest priority.
Then we concat the metalink path to the url and download the metalink file.

Once metalink file is downloaded, we parse it and downlod the repomd.xml
file and then parse the xml to download repoMD parts.

Also, we set the BaseURL for the respective repo to the URL we got from
the metalink file for further package downloads.

Signed-off-by: Tapas Kundu <tkundu@vmware.com>