### PR TITLE
when gpgcheck is enabled and gpgkey is missing in repo file,

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -225,4 +225,5 @@ typedef enum
     {ERROR_TDNF_OPERATION_ABORTED, "ERROR_TDNF_OPERATION_ABORTED", "Operation aborted."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
+    {ERROR_TDNF_NO_GPGKEY_CONF_ENTRY,         "ERROR_TDNF_NO_GPGKEY_CONF_ENTRY",         "gpgkey entry is missing for this repo. please add gpgkey in repo file or use --nogpgcheck to ignore."}, \
 };

--- a/client/repo.c
+++ b/client/repo.c
@@ -340,6 +340,11 @@ TDNFGetGPGSignatureCheck(
             nGPGSigCheck = pRepo->nGPGCheck;
             if(nGPGSigCheck)
             {
+                if (IsNullOrEmptyString(pRepo->pszUrlGPGKey))
+                {
+                    dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
+                    BAIL_ON_TDNF_ERROR(dwError);
+                }
                 dwError = TDNFAllocateString(
                              pRepo->pszUrlGPGKey,
                              &pszUrlGPGKey);

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -133,6 +133,7 @@ extern "C" {
 #define ERROR_TDNF_OPT_NOT_FOUND             1520
 #define ERROR_TDNF_PLUGIN_NO_MORE_EVENTS     1521
 #define ERROR_TDNF_NO_PLUGIN_ERROR           1522
+#define ERROR_TDNF_NO_GPGKEY_CONF_ENTRY      1523
 
 //RPM Transaction
 #define ERROR_TDNF_TRANS_INCOMPLETE     1525


### PR DESCRIPTION
https://github.com/vmware/tdnf/issues/123
installs used to fail with generic error. this was because
gpgkey lookup would fail with a null or empty string and a
generic error was returned.
it is a better user experience when the specific error is
bubbled up so that corrective action can be taken.