### PR TITLE
Use mmap instead of reading chunks

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -30,23 +30,6 @@ typedef enum
 
 #define IsNullOrEmptyString(str)    (!(str) || !(*str))
 
-#define BAIL_ON_TDNF_ERROR(dwError) \
-    do {                                                           \
-        if (dwError)                                               \
-        {                                                          \
-            goto error;                                            \
-        }                                                          \
-    } while(0)
-
-#define BAIL_ON_TDNF_SYSTEM_ERROR(dwError) \
-    do {                                                           \
-        if (dwError)                                               \
-        {                                                          \
-            dwError = ERROR_TDNF_SYSTEM_BASE + dwError;            \
-            goto error;                                            \
-        }                                                          \
-    } while(0)
-
 #define BAIL_ON_TDNF_SOLV_ERROR(dwError) \
     do {                                                           \
         if (dwError)                                               \

--- a/common/includes.h
+++ b/common/includes.h
@@ -16,6 +16,11 @@
 #include <stdarg.h>
 #include <string.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <sys/types.h>
 
 #include <tdnftypes.h>
 #include <tdnferror.h>

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -142,6 +142,15 @@ TDNFFileReadAllText(
     char **ppszText
     );
 
+uint32_t TDNFMapFile(
+    const char *pszFileName,
+    PFileMapInfo pfMap
+    );
+
+void TDNFUnMapFile(
+    PFileMapInfo pfMap;
+    );
+
 const char *
 TDNFLeftTrim(
     const char *pszStr

--- a/common/structs.h
+++ b/common/structs.h
@@ -5,20 +5,27 @@ typedef struct _KEYVALUE_
     char *pszKey;
     char *pszValue;
     struct _KEYVALUE_ *pNext;
-}KEYVALUE, *PKEYVALUE;
+} KEYVALUE, *PKEYVALUE;
 
 typedef struct _CONF_SECTION_
 {
     char *pszName;
     PKEYVALUE pKeyValues;
     struct _CONF_SECTION_ *pNext;
-}CONF_SECTION, *PCONF_SECTION;
+} CONF_SECTION, *PCONF_SECTION;
 
 typedef struct _CONF_DATA_
 {
     char *pszConfFile;
     PCONF_SECTION pSections;
-}CONF_DATA, *PCONF_DATA;
+} CONF_DATA, *PCONF_DATA;
+
+typedef struct _FileMapInfo
+{
+    char *fData;
+    size_t fSize;
+    const char *fName;
+} FileMapInfo, *PFileMapInfo;
 
 typedef uint32_t
 (*PFN_CONF_SECTION_CB)(

--- a/solv/defines.h
+++ b/solv/defines.h
@@ -15,12 +15,4 @@
         }                                                          \
     } while(0)
 
-#define BAIL_ON_TDNF_ERROR(dwError) \
-    do {                                                           \
-        if (dwError)                                               \
-        {                                                          \
-            goto error;                                            \
-        }                                                          \
-    } while(0)
-
 #endif /* __SOLV_DEFINES_H__ */


### PR DESCRIPTION
Use the TDNFFileReadAllText function instead of doing whole open-read-close in few places.
Removed some duplicate macros
Minor code improvements in few places

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>