### PR TITLE
Fix stale solv cache issue

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -157,8 +157,7 @@ TDNFRemoveLastRefreshMarker(
 
 uint32_t
 TDNFRemoveTmpRepodata(
-    const char* pszTmpRepodataDir,
-    const char* pszTmpRepoMDFile
+    const char* pszTmpRepodataDir
     );
 
 uint32_t


### PR DESCRIPTION
This fix is to remove the old repomd , solv cache and lastrefresh
marker when there is a new repomd file downloaded. This fixes the issue
https://github.com/vmware/photon/issues/1008 

Signed-off-by: Keerthana K <keerthanak@vmware.com>