### PR TITLE
Add cmake check for openssl-devel

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -10,6 +10,8 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 
 find_package(Metalink REQUIRED)
 
+find_package(OpenSSL REQUIRED)
+
 #make config.h with
 #PACKAGE_NAME and PACKAGE_VERSION defined
 configure_file(
@@ -52,6 +54,7 @@ target_link_libraries(${LIB_TDNF}
     ${LibSolv_LIBRARIES}
     ${CURL_LIBRARIES}
     ${METALINK_LIBRARIES}
+    ${OPENSSL_LIBRARIES}
 )
 
 set_target_properties(${LIB_TDNF} PROPERTIES

--- a/cmake/FindOpenSSL.cmake
+++ b/cmake/FindOpenSSL.cmake
@@ -1,0 +1,13 @@
+# - Try to find openssl
+# Once done this will define
+#  OPENSSL_INCLUDE_DIRS - The openssl include directories
+#  OPENSSL_LIBRARIES - The libraries needed to use openssl-devel
+
+find_path(OPENSSL_INCLUDE_DIR openssl/sha.h)
+find_library(OPENSSL_LIBRARY NAMES libssl.so)
+
+find_package_handle_standard_args(libssl DEFAULT_MSG
+                                  OPENSSL_LIBRARY OPENSSL_INCLUDE_DIR)
+
+set(OPENSSL_LIBRARIES ${OPENSSL_LIBRARY})
+set(OPENSSL_INCLUDE_DIRS ${OPENSSL_INCLUDE_DIR})


### PR DESCRIPTION
We should check if system have openssl-devel installed
before building tdnf.

Signed-off-by: Tapas Kundu <tkundu@vmware.com>