### PR TITLE
Fix tdnf install with quiet enabled

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -780,12 +780,13 @@ TDNFDownloadFile(
     /* lStatus reads CURLINFO_RESPONSE_CODE. Must be long */
     long lStatus = 0;
 
+    //If TDNF install is invoked with quiet argument,
+    //pszProgressData will be NULL
     if(!pTdnf ||
        !pTdnf->pArgs ||
        IsNullOrEmptyString(pszFileUrl) ||
        IsNullOrEmptyString(pszFile) ||
-       IsNullOrEmptyString(pszRepo) ||
-       IsNullOrEmptyString(pszProgressData))
+       IsNullOrEmptyString(pszRepo))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);


### PR DESCRIPTION
- In TDNFDownloadFile API, we were checking
  pszProgressData for NULL. But in case we
  invoke "tdnf install" with "-q" then
  pszProgressData is passed as NULL. Hence,
  we should not error in pszProgressData is
  NULL, instead we should use this variable
  to decide whether we should show progress in
  console or be quiet.

Signed-off-by: Tapas Kundu <tkundu@vmware.com>