### PR TITLE
Serve test-repo RPMs over a super simple http server

### DIFF
--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -64,8 +64,8 @@ echo ${GPG_PASS} | gpg --batch --passphrase-fd 0 \
 cat << EOF > ${TEST_REPO_DIR}/yum.repos.d/photon-test.repo
 [photon-test]
 name=basic
-baseurl=file://${PUBLISH_PATH}
-#metalink=file://${PUBLISH_PATH}/metalink
+baseurl=http://localhost:8080/photon-test
+#metalink=http://localhost:8080/photon-test/metalink
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=0
 enabled=1
@@ -88,7 +88,7 @@ cat << EOF > ${PUBLISH_PATH}/metalink
    <verification>
    </verification>
    <resources maxconnections="1">
-    <url protocol="file" type="file" location="IN" preference="100">file://${PUBLISH_PATH}/repodata/repomd.xml</url>
+    <url protocol="http" type="file" location="IN" preference="100">http://localhost:8080/photon-test/repodata/repomd.xml</url>
    </resources>
   </file>
  </files>

--- a/pytests/tests/test_downgrade.py
+++ b/pytests/tests/test_downgrade.py
@@ -22,15 +22,8 @@ def teardown_test(utils):
 
 
 def test_downgrade_no_arg(utils):
-    ret = utils.run(['tdnf', '--config', '/etc/tdnf/tdnf.conf', '--enablerepo=photon-debuginfo', '--assumeno', 'downgrade'])
-    try:
-        if os.environ['DIST'] != 'photon':
-            assert(ret['retval'] == 1602)
-        else:
-            assert(ret['retval'] == 8)
-    except Exception as e:
-        # Default to Photon
-        assert(ret['retval'] == 8)
+    ret = utils.run(['tdnf', 'downgrade'])
+    assert(ret['retval'] == 1011)
 
 
 def test_downgrade_install(utils):


### PR DESCRIPTION
Now, test-repo is served at http://localhost:8080/ on the test/dev
machine. Hopefully, this get tests closer to actual usage scenario.

Also, fix tests/test_downgrade.py: test_downgrade_no_arg() and add
new key "distribution" to utils.config so tests can perform some
distribution specifc tests (or outcome asserts).

Signed-off-by: Siddharth Chandrasekaran <csiddharth@vmware.com>