### PR TITLE
Fix improper use of strncpy that allows memory over-read/run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ __pycache__/
 *.pc
 
 # build directory
-build/
+build*/

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -635,7 +635,6 @@ TDNFParseAndGetURLFromMetalink(
     int length = 0;
     int fd = -1, i = 0;
     uint32_t dwError = 0;
-    char pszBaseURLFromMetalink[256] = {0};
     char *resource_type [] = { "https", "http", "ftp", "ftps", "file", NULL };
 
     if(!pTdnf ||
@@ -748,11 +747,13 @@ TDNFParseAndGetURLFromMetalink(
             dwError = ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED;
             BAIL_ON_TDNF_ERROR(dwError);
         }
-        strncpy(pszBaseURLFromMetalink, (*resources)->url, strlen((*resources)->url));
-        dwError = TDNFTrimSuffix(pszBaseURLFromMetalink, TDNF_REPO_METADATA_FILE_PATH);
+
+        strncpy(buf, (*resources)->url, BUFSIZ-1);
+        buf[BUFSIZ-1] = '\0'; // force terminate
+        dwError = TDNFTrimSuffix(buf, TDNF_REPO_METADATA_FILE_PATH);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        dwError = TDNFRepoSetBaseUrl(pTdnf, pszRepo, pszBaseURLFromMetalink);
+        dwError = TDNFRepoSetBaseUrl(pTdnf, pszRepo, buf);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 cleanup:


### PR DESCRIPTION
strncpy was called with `len` parameter that could exceed the sizeof
`dst` in addition to not copying the terminating NULL char in `src`.
As always, the fix is trivial.

While at it,
  - resue an existing variable `buf` instead of creating another.
  - gitignore build*/ so all my build-xyz/ dirs are also ignored.

Signed-off-by: Siddharth Chandrasekaran <csiddharth@vmware.com>