### PR TITLE
Fix unhandled error code message

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -163,7 +163,7 @@ typedef enum
     {ERROR_TDNF_TRANS_INCOMPLETE,    "ERROR_TDNF_TRANS_INCOMPLETE",    "Incomplete rpm transaction"}, \
     {ERROR_TDNF_TRANS_PKG_NOT_FOUND, "ERROR_TDNF_TRANS_PKG_NOT_FOUND", "Failed to find rpm package"}, \
     {ERROR_TDNF_NO_SEARCH_RESULTS,   "ERROR_TDNF_NO_SEARCH_RESULTS",   "No matches found"}, \
-    {ERROR_TDNF_RPMRC_NOTFOUND,      "ERROR_TDNF_RPMRC_NOTFOUND",      "rpm generic error - not found(possible corrupt rpm file"}, \
+    {ERROR_TDNF_RPMRC_NOTFOUND,      "ERROR_TDNF_RPMRC_NOTFOUND",      "rpm generic error - not found (possible corrupt rpm file)"}, \
     {ERROR_TDNF_RPMRC_FAIL,          "ERROR_TDNF_RPMRC_FAIL",          "rpm generic failure"}, \
     {ERROR_TDNF_RPMRC_NOTTRUSTED,    "ERROR_TDNF_RPMRC_NOTTRUSTED",    "rpm signature is OK, but key is not trusted"}, \
     {ERROR_TDNF_RPMRC_NOKEY,         "ERROR_TDNF_RPMRC_NOKEY",         "public key is unavailable. install public key using rpm --import or use --nogpgcheck to ignore."}, \

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -311,7 +311,7 @@ TDNFRunTransaction(
     }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_TEST);
     dwError = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
-    BAIL_ON_TDNF_ERROR(dwError);
+    BAIL_ON_TDNF_RPM_ERROR(dwError);
 
     //TODO do callbacks for output
     if(!nSilent)
@@ -320,7 +320,7 @@ TDNFRunTransaction(
     }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_NONE);
     dwError = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
-    BAIL_ON_TDNF_ERROR(dwError);
+    BAIL_ON_TDNF_RPM_ERROR(dwError);
 
 cleanup:
     return dwError;


### PR DESCRIPTION
An RPM error code was being returned as a TDNF error code causing it to
print a debug message. Fix this by calling the right BAIL_*() macro.

Signed-off-by: Siddharth Chandrasekaran <csiddharth@vmware.com>