### PR TITLE
Allow alter type ALTER_UPGRADE to call SolvAddExcludes()

### DIFF
--- a/client/goal.c
+++ b/client/goal.c
@@ -464,7 +464,6 @@ TDNFAddGoal(
     char** ppszPackagesTemp = NULL;
     char* pszName = NULL;
     uint32_t dwCount = 0;
-    Queue queueJob = {0};
 
     if(!pQueueJobs || dwId == 0 || !pTdnf->pSack || !pTdnf->pSack->pPool)
     {
@@ -472,7 +471,6 @@ TDNFAddGoal(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    queue_init(&queueJob);
     if (nAlterType == ALTER_UPGRADE)
     {
         dwError = TDNFPkgsToExclude(pTdnf, &dwCount, &ppszExcludes);
@@ -500,6 +498,7 @@ TDNFAddGoal(
             }
         }
     }
+
     switch(nAlterType)
     {
         case ALTER_DOWNGRADEALL:
@@ -529,7 +528,6 @@ cleanup:
     TDNF_SAFE_FREE_MEMORY(pszPkg);
     TDNF_SAFE_FREE_STRINGARRAY(ppszExcludes);
     TDNF_SAFE_FREE_MEMORY(pszName);
-    queue_free(&queueJob);
     return dwError;
 
 error:
@@ -620,4 +618,3 @@ error:
     }
     goto cleanup;
 }
-

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -144,9 +144,10 @@ typedef enum
 // skip problem type mask
 typedef enum
 {
-    SKIPPROBLEM_NONE = 0,
-    SKIPPROBLEM_CONFLICTS = 0x1,
-    SKIPPROBLEM_OBSOLETES = 0x2,
+    SKIPPROBLEM_NONE      = 0x00,
+    SKIPPROBLEM_CONFLICTS = 0x01,
+    SKIPPROBLEM_OBSOLETES = 0x02,
+    SKIPPROBLEM_DISABLED  = 0x04,
 } TDNF_SKIPPROBLEM_TYPE;
 
 typedef struct _TDNF_ *PTDNF;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -141,7 +141,7 @@ typedef enum
     CMDOPT_DISABLEPLUGIN,
 }TDNF_CMDOPT_TYPE;
 
-// skip problem type
+// skip problem type mask
 typedef enum
 {
     SKIPPROBLEM_NONE = 0,

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1538,34 +1538,22 @@ SkipBasedOnType(
     TDNF_SKIPPROBLEM_TYPE dwSkipProblem
     )
 {
-    if (dwSkipProblem == SKIPPROBLEM_NONE)
+    bool result = false;
+
+    if (dwSkipProblem & SKIPPROBLEM_CONFLICTS)
     {
-        return false;
+        result = type == SOLVER_RULE_PKG_CONFLICTS ||
+                 type == SOLVER_RULE_PKG_SELF_CONFLICT;
     }
 
-    if (dwSkipProblem == SKIPPROBLEM_CONFLICTS)
+    if (dwSkipProblem & SKIPPROBLEM_OBSOLETES)
     {
-        return (type == SOLVER_RULE_PKG_CONFLICTS ||
-                type == SOLVER_RULE_PKG_SELF_CONFLICT);
+        result = type == SOLVER_RULE_PKG_OBSOLETES ||
+                 type == SOLVER_RULE_PKG_IMPLICIT_OBSOLETES ||
+                 type == SOLVER_RULE_PKG_INSTALLED_OBSOLETES;
     }
 
-    if (dwSkipProblem == SKIPPROBLEM_OBSOLETES)
-    {
-        return (type == SOLVER_RULE_PKG_OBSOLETES ||
-                type == SOLVER_RULE_PKG_IMPLICIT_OBSOLETES ||
-                type == SOLVER_RULE_PKG_INSTALLED_OBSOLETES);
-    }
-
-    if (dwSkipProblem == (SKIPPROBLEM_CONFLICTS | SKIPPROBLEM_OBSOLETES))
-    {
-        return (type == SOLVER_RULE_PKG_CONFLICTS ||
-                type == SOLVER_RULE_PKG_SELF_CONFLICT ||
-                type == SOLVER_RULE_PKG_OBSOLETES ||
-                type == SOLVER_RULE_PKG_IMPLICIT_OBSOLETES ||
-                type == SOLVER_RULE_PKG_INSTALLED_OBSOLETES);
-    }
-
-    return false;
+    return result;
 }
 
 static uint32_t


### PR DESCRIPTION
`TDNFPrepareAllPackages()` forces `nAlterType` to `ALTER_UPGRADE` for both `ALTER_UPGRADE` and `ALTER_UPGRADEALL` when `--security` is passed. Subsequently, when `TDNFGoal()` is called, the excludes are skipped from the job queue in `TDNFAddGoal()` but are not marked in solver map as excludes with a call to `SolvAddExcludes()` as it's gating condition only check for `nAlterType == ALTER_UPGRADEALL`.

Fix this by allowing `nAlterType == ALTER_UPGRADE` to also call `SolvAddExcludes()`.