### PR TITLE
Add support for excludepkgs option in tdnf.conf

### DIFF
--- a/client/client.c
+++ b/client/client.c
@@ -77,7 +77,7 @@ TDNFPkgsToExclude(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if (pTdnf->pConf->ppszExcludes)
+    if (!pTdnf->pArgs->nDisableExcludes && pTdnf->pConf->ppszExcludes)
     {
         if (!pTdnf->pArgs->nQuiet)
         {
@@ -115,7 +115,7 @@ TDNFPkgsToExclude(
         BAIL_ON_TDNF_ERROR(dwError);
 
         nIndex = 0;
-        if (pTdnf->pConf->ppszExcludes)
+        if (!pTdnf->pArgs->nDisableExcludes && pTdnf->pConf->ppszExcludes)
         {
             while (pTdnf->pConf->ppszExcludes[nIndex])
             {

--- a/client/client.c
+++ b/client/client.c
@@ -77,6 +77,24 @@ TDNFPkgsToExclude(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if (pTdnf->pConf->ppszExcludes)
+    {
+        if (!pTdnf->pArgs->nQuiet)
+        {
+            printf("Warning: The following packages are excluded "
+                   "from tdnf.conf:\n");
+        }
+        while (pTdnf->pConf->ppszExcludes[nIndex])
+        {
+            if (!pTdnf->pArgs->nQuiet)
+            {
+                printf("  %s\n", pTdnf->pConf->ppszExcludes[nIndex]);
+            }
+            dwCount++;
+            nIndex++;
+        }
+    }
+
     pSetOpt = pTdnf->pArgs->pSetOpt;
     while(pSetOpt)
     {
@@ -95,6 +113,20 @@ TDNFPkgsToExclude(
                       sizeof(char*),
                       (void**)&ppszExcludes);
         BAIL_ON_TDNF_ERROR(dwError);
+
+        nIndex = 0;
+        if (pTdnf->pConf->ppszExcludes)
+        {
+            while (pTdnf->pConf->ppszExcludes[nIndex])
+            {
+                dwError = TDNFAllocateString(pTdnf->pConf->ppszExcludes[nIndex],
+                                             &ppszExcludes[nIndex]);
+                BAIL_ON_TDNF_ERROR(dwError);
+                dwCount++;
+                nIndex++;
+            }
+        }
+
         pSetOpt = pTdnf->pArgs->pSetOpt;
         while(pSetOpt)
         {
@@ -105,7 +137,6 @@ TDNFPkgsToExclude(
                       pSetOpt->pszOptValue,
                       &ppszExcludes[nIndex++]);
                 BAIL_ON_TDNF_ERROR(dwError);
-
             }
             pSetOpt = pSetOpt->pNext;
         }

--- a/client/client.c
+++ b/client/client.c
@@ -71,6 +71,7 @@ TDNFPkgsToExclude(
     uint32_t dwCount = 0;
     char**   ppszExcludes = NULL;
     int nIndex = 0;
+
     if(!pTdnf || !pTdnf->pArgs || !pdwCount || !pppszExcludes)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;

--- a/client/config.c
+++ b/client/config.c
@@ -121,6 +121,12 @@ TDNFReadConfig(
                   &pConf->pszDistroVerPkg);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFReadKeyValueStringArray(
+                  pSection,
+                  TDNF_CONF_KEY_EXCLUDE,
+                  &pConf->ppszExcludes);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFConfigReadProxySettings(
                   pSection,
                   pConf);

--- a/client/defines.h
+++ b/client/defines.h
@@ -79,6 +79,7 @@ typedef enum
 #define TDNF_CONF_KEY_PLUGIN_PATH         "pluginpath"
 #define TDNF_CONF_KEY_PLUGIN_CONF_PATH    "pluginconfpath"
 #define TDNF_PLUGIN_CONF_KEY_ENABLED      "enabled"
+#define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"
 #define TDNF_REPO_KEY_ENABLED             "enabled"

--- a/client/goal.c
+++ b/client/goal.c
@@ -323,6 +323,13 @@ TDNFGoal(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if (nAlterType == ALTER_UPGRADEALL ||
+        nAlterType == ALTER_UPGRADE)
+    {
+        dwError = TDNFPkgsToExclude(pTdnf, &dwExcludeCount, &ppszExcludes);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     queue_init(&queueJobs);
     if (nAlterType == ALTER_UPGRADEALL)
     {
@@ -345,7 +352,8 @@ TDNFGoal(
         for (i = 0; i < pQueuePkgList->count; i++)
         {
             dwId = pQueuePkgList->elements[i];
-            TDNFAddGoal(pTdnf, nAlterType, &queueJobs, dwId);
+            TDNFAddGoal(pTdnf, nAlterType, &queueJobs, dwId,
+                        dwExcludeCount, ppszExcludes);
         }
     }
 
@@ -359,9 +367,6 @@ TDNFGoal(
     if (nAlterType == ALTER_UPGRADEALL ||
         nAlterType == ALTER_UPGRADE)
     {
-        dwError = TDNFPkgsToExclude(pTdnf, &dwExcludeCount, &ppszExcludes);
-        BAIL_ON_TDNF_ERROR(dwError);
-
         if (dwExcludeCount != 0 && ppszExcludes)
         {
             if (!pTdnf->pSack || !pTdnf->pSack->pPool)
@@ -462,15 +467,15 @@ TDNFAddGoal(
     PTDNF pTdnf,
     TDNF_ALTERTYPE nAlterType,
     Queue* pQueueJobs,
-    Id dwId
+    Id dwId,
+    uint32_t dwCount,
+    char** ppszExcludes
     )
 {
     uint32_t dwError = 0;
     char* pszPkg = NULL;
-    char** ppszExcludes = NULL;
     char** ppszPackagesTemp = NULL;
     char* pszName = NULL;
-    uint32_t dwCount = 0;
 
     if(!pQueueJobs || dwId == 0 || !pTdnf->pSack || !pTdnf->pSack->pPool)
     {
@@ -480,8 +485,6 @@ TDNFAddGoal(
 
     if (nAlterType == ALTER_UPGRADE)
     {
-        dwError = TDNFPkgsToExclude(pTdnf, &dwCount, &ppszExcludes);
-        BAIL_ON_TDNF_ERROR(dwError);
         if (dwCount != 0 && ppszExcludes)
         {
             dwError = SolvGetPkgNameFromId(
@@ -533,7 +536,6 @@ TDNFAddGoal(
     }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszPkg);
-    TDNF_SAFE_FREE_STRINGARRAY(ppszExcludes);
     TDNF_SAFE_FREE_MEMORY(pszName);
     return dwError;
 

--- a/client/init.c
+++ b/client/init.c
@@ -53,6 +53,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nVerbose       = pCmdArgsIn->nVerbose;
     pCmdArgs->nIPv4          = pCmdArgsIn->nIPv4;
     pCmdArgs->nIPv6          = pCmdArgsIn->nIPv6;
+    pCmdArgs->nDisableExcludes = pCmdArgsIn->nDisableExcludes;
 
     dwError = TDNFAllocateString(
                   pCmdArgsIn->pszInstallRoot,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -327,7 +327,9 @@ TDNFAddGoal(
     PTDNF pTdnf,
     TDNF_ALTERTYPE nAlterType,
     Queue* pQueueJobs,
-    Id dwId
+    Id dwId,
+    uint32_t dwCount,
+    char** ppszExcludes
     );
 
 uint32_t

--- a/common/configreader.c
+++ b/common/configreader.c
@@ -594,6 +594,47 @@ error:
 }
 
 uint32_t
+TDNFReadKeyValueStringArray(
+    PCONF_SECTION pSection,
+    const char* pszKeyName,
+    char*** pppszValueList
+    )
+{
+    uint32_t dwError = 0;
+    char** ppszValList = NULL;
+    PKEYVALUE pKeyValues = NULL;
+
+    if (!pSection || !pszKeyName || !pppszValueList)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    pKeyValues = pSection->pKeyValues;
+    for (; pKeyValues; pKeyValues = pKeyValues->pNext)
+    {
+        if (strcmp(pszKeyName, pKeyValues->pszKey) == 0)
+        {
+            dwError = TDNFSplitStringToArray(pKeyValues->pszValue,
+                                             " ", &ppszValList);
+            BAIL_ON_TDNF_ERROR(dwError);
+            *pppszValueList = ppszValList;
+            break;
+        }
+    }
+
+cleanup:
+    return dwError;
+
+error:
+    if(pppszValueList)
+    {
+        *pppszValueList = NULL;
+    }
+    goto cleanup;
+}
+
+uint32_t
 TDNFReadKeyValue(
     PCONF_SECTION pSection,
     const char* pszKeyName,
@@ -653,4 +694,3 @@ error:
     TDNF_SAFE_FREE_MEMORY(pszValue);
     goto cleanup;
 }
-

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -53,10 +53,11 @@ TDNFSafeAllocateString(
     char** ppszDst
     );
 
-size_t
+uint32_t
 TDNFStringSepCount(
     char *pszBuf,
-    char *pszSep
+    char *pszSep,
+    size_t *nSepCount
     );
 
 uint32_t

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -53,6 +53,19 @@ TDNFSafeAllocateString(
     char** ppszDst
     );
 
+size_t
+TDNFStringSepCount(
+    char *pszBuf,
+    char *pszSep
+    );
+
+uint32_t
+TDNFSplitStringToArray(
+    char *pszBuf,
+    char *pszSep,
+    char ***pppszTokens
+    );
+
 uint32_t
 TDNFAllocateStringPrintf(
     char** ppszDst,
@@ -134,6 +147,13 @@ TDNFReadKeyValueInt(
     const char* pszKeyName,
     int nDefault,
     int* pnValue
+    );
+
+uint32_t
+TDNFReadKeyValueStringArray(
+    PCONF_SECTION pSection,
+    const char* pszKeyName,
+    char*** pppszValueList
     );
 
 void

--- a/common/strings.c
+++ b/common/strings.c
@@ -88,23 +88,21 @@ error:
     goto cleanup;
 }
 
-size_t
+uint32_t
 TDNFStringSepCount(
     char *pszBuf,
-    char *pszSep
+    char *pszSep,
+    size_t *nSepCount
     )
 {
     size_t nCount = 0;
-    const char *pszTemp;
+    uint32_t dwError = 0;
+    const char *pszTemp = NULL;
 
-    if (IsNullOrEmptyString(pszBuf))
+    if (IsNullOrEmptyString(pszBuf) || IsNullOrEmptyString(pszSep))
     {
-        BAIL_ON_TDNF_ERROR(1);
-    }
-    if (IsNullOrEmptyString(pszSep))
-    {
-        nCount = 1;
-        BAIL_ON_TDNF_ERROR(1);
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     pszTemp = pszBuf;
@@ -125,8 +123,10 @@ TDNFStringSepCount(
         }
     }
 
+    *nSepCount = nCount;
+
 error:
-    return nCount;
+    return dwError;
 }
 
 uint32_t
@@ -149,12 +149,8 @@ TDNFSplitStringToArray(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    nCount = TDNFStringSepCount(pszBuf, pszSep);
-    if (nCount == 0)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
+    dwError = TDNFStringSepCount(pszBuf, pszSep, &nCount);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFAllocateMemory(nCount + 1, sizeof(char *), (void**)&ppszToks);
     BAIL_ON_TDNF_ERROR(dwError);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -235,6 +235,7 @@ typedef struct _TDNF_CMD_ARGS
     int nVerbose;          //print debug info
     int nIPv4;             //resolve to IPv4 addresses only
     int nIPv6;             //resolve to IPv6 addresses only
+    int nDisableExcludes;  //disable excludes from tdnf.conf
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location
     char* pszReleaseVer;   //Release version

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -259,6 +259,7 @@ typedef struct _TDNF_CONF
     char* pszBaseArch;
     char* pszVarReleaseVer;
     char* pszVarBaseArch;
+    char** ppszExcludes;
 }TDNF_CONF, *PTDNF_CONF;
 
 typedef struct _TDNF_REPO_DATA

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -57,6 +57,7 @@ TDNFCliShowHelp(
     printf("           [--reboot-required]\n");
     printf("           [--skipsignature]\n");
     printf("           [--skipdigest]\n");
+    printf("           [--disableexcludes]\n");
 
     printf("List of Main Commands\n");
     printf("\n");

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -77,6 +77,7 @@ static struct option pstOptions[] =
     {"noplugins",     no_argument, 0, 0},                  //--noplugins
     {"disableplugin", required_argument, 0, 0},            //--disableplugin
     {"enableplugin",  required_argument, 0, 0},            //--enableplugin
+    {"disableexcludes", no_argument, &_opt.nDisableExcludes, 1}, //--disableexcludes
     {0, 0, 0, 0}
 };
 
@@ -258,6 +259,7 @@ TDNFCopyOptions(
     pArgs->nVerbose       = pOptionArgs->nVerbose;
     pArgs->nIPv4          = pOptionArgs->nIPv4;
     pArgs->nIPv6          = pOptionArgs->nIPv6;
+    pArgs->nDisableExcludes = pOptionArgs->nDisableExcludes;
 
 cleanup:
     return dwError;


### PR DESCRIPTION
This patch adds the config option "excludepkgs" from tdnf.conf and some
utils to make this possible neatly.

This also adds a new TDNFReAllocateMemory() that mimics realloc() but
also guarantees that the newly reallocated memory is also zero-ed to
meet the general tdnf codebase expectation.

Signed-off-by: Siddharth Chandrasekaran <csiddharth@vmware.com>