### PR TITLE
Fix gpgkey configured in repo config 

### DIFF
--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -264,7 +264,6 @@ AddKeyToKeyRing(
         }
         BAIL_ON_TDNF_ERROR(dwError);
     }
-
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszKeyData);
     return dwError;
@@ -376,3 +375,36 @@ error:
     }
     goto cleanup;
 }
+
+uint32_t
+TDNFImportGPGKey(
+    rpmts pTS,
+    const char* pszFile
+    )
+{
+    uint32_t dwError = 0;
+    pgpArmor nArmor = PGPARMOR_NONE;
+    uint8_t* pPkt = NULL;
+    size_t nPktLen = 0;
+    char* pszKeyData = NULL;
+
+    dwError = ReadGPGKey(pszFile, &pszKeyData);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    nArmor = pgpParsePkts(pszKeyData, &pPkt, &nPktLen);
+    if(nArmor != PGPARMOR_PUBKEY)
+    {
+        dwError = ERROR_TDNF_INVALID_PUBKEY_FILE;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = rpmtsImportPubkey(pTS, pPkt, nPktLen);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszKeyData);
+    return dwError;
+error:
+    goto cleanup;
+}
+

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -388,6 +388,12 @@ TDNFImportGPGKey(
     size_t nPktLen = 0;
     char* pszKeyData = NULL;
 
+    if(pTS == NULL || IsNullOrEmptyString(pszFile))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     dwError = ReadGPGKey(pszFile, &pszKeyData);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -72,6 +72,12 @@ TDNFGPGCheck(
     const char* pszPackage
     );
 
+uint32_t
+TDNFImportGPGKey(
+    rpmts pTS,
+    const char* pszFile
+    );
+
 //init.c
 uint32_t
 TDNFCloneCmdArgs(
@@ -895,6 +901,13 @@ TDNFGetCmdOpt(
     PTDNF pTdnf,
     TDNF_CMDOPT_TYPE cmdType,
     PTDNF_CMD_OPT *ppOpt
+    );
+
+uint32_t
+TDNFYesOrNo(
+    PTDNF_CMD_ARGS pArgs,
+    const char *pszQuestion,
+    int *pAnswer
     );
 
 //validate.c

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -903,13 +903,6 @@ TDNFGetCmdOpt(
     PTDNF_CMD_OPT *ppOpt
     );
 
-uint32_t
-TDNFYesOrNo(
-    PTDNF_CMD_ARGS pArgs,
-    const char *pszQuestion,
-    int *pAnswer
-    );
-
 //validate.c
 uint32_t
 TDNFValidateCmdArgs(

--- a/client/repo.c
+++ b/client/repo.c
@@ -318,7 +318,7 @@ TDNFGetGPGSignatureCheck(
     uint32_t dwSkipSignature = 0;
     char* pszUrlGPGKey = NULL;
 
-    if(!pTdnf || !ppszUrlGPGKey || IsNullOrEmptyString(pszRepo) || !pnGPGSigCheck)
+    if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pnGPGSigCheck)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -340,21 +340,25 @@ TDNFGetGPGSignatureCheck(
             nGPGSigCheck = pRepo->nGPGCheck;
             if(nGPGSigCheck)
             {
-                if (IsNullOrEmptyString(pRepo->pszUrlGPGKey))
-                {
-                    dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
+                if (ppszUrlGPGKey != NULL) {
+                    if (IsNullOrEmptyString(pRepo->pszUrlGPGKey))
+                    {
+                        dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
+                        BAIL_ON_TDNF_ERROR(dwError);
+                    }
+                    dwError = TDNFAllocateString(
+                                 pRepo->pszUrlGPGKey,
+                                 &pszUrlGPGKey);
                     BAIL_ON_TDNF_ERROR(dwError);
                 }
-                dwError = TDNFAllocateString(
-                             pRepo->pszUrlGPGKey,
-                             &pszUrlGPGKey);
-                BAIL_ON_TDNF_ERROR(dwError);
             }
         }
     }
 
     *pnGPGSigCheck = nGPGSigCheck;
-    *ppszUrlGPGKey = pszUrlGPGKey;
+    if (ppszUrlGPGKey) {
+        *ppszUrlGPGKey = pszUrlGPGKey;
+    }
 
 cleanup:
     return dwError;

--- a/client/repo.c
+++ b/client/repo.c
@@ -335,28 +335,27 @@ TDNFGetGPGSignatureCheck(
             dwError = 0;
         }
         BAIL_ON_TDNF_ERROR(dwError);
-        if(pRepo)
+        if(pRepo && pRepo->nGPGCheck)
         {
-            nGPGSigCheck = pRepo->nGPGCheck;
-            if(nGPGSigCheck)
+            nGPGSigCheck = 1;
+            if (ppszUrlGPGKey != NULL)
             {
-                if (ppszUrlGPGKey != NULL) {
-                    if (IsNullOrEmptyString(pRepo->pszUrlGPGKey))
-                    {
-                        dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
-                        BAIL_ON_TDNF_ERROR(dwError);
-                    }
-                    dwError = TDNFAllocateString(
-                                 pRepo->pszUrlGPGKey,
-                                 &pszUrlGPGKey);
+                if (IsNullOrEmptyString(pRepo->pszUrlGPGKey))
+                {
+                    dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
                     BAIL_ON_TDNF_ERROR(dwError);
                 }
+                dwError = TDNFAllocateString(
+                             pRepo->pszUrlGPGKey,
+                             &pszUrlGPGKey);
+                BAIL_ON_TDNF_ERROR(dwError);
             }
         }
     }
 
     *pnGPGSigCheck = nGPGSigCheck;
-    if (ppszUrlGPGKey) {
+    if (ppszUrlGPGKey)
+    {
         *ppszUrlGPGKey = pszUrlGPGKey;
     }
 

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -451,6 +451,9 @@ TDNFTransAddInstallPkg(
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
 
+    dwError = TDNFGetGPGSignatureCheck(pTdnf, pszRepoName, &nGPGSigCheck, NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     fp = Fopen (pszFilePath, "r.ufdio");
     if(!fp)
     {

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -473,7 +473,8 @@ TDNFTransAddInstallPkg(
     {
         BAIL_ON_TDNF_RPM_ERROR(dwError);
     }
-    else if(nGPGSigCheck)
+
+    if(nGPGSigCheck)
     {
         dwError = TDNFGetGPGSignatureCheck(pTdnf, pszRepoName, &nGPGSigCheck, &pszUrlGPGKey);
         BAIL_ON_TDNF_ERROR(dwError);
@@ -486,35 +487,33 @@ TDNFTransAddInstallPkg(
         {
             dwError = ERROR_TDNF_OPERATION_ABORTED;
             BAIL_ON_TDNF_ERROR(dwError);
-	}
-	else
-	{
-            pKeyring = rpmtsGetKeyring(pTS->pTS, 0);
+        }
 
-            dwError = TDNFImportGPGKey(pTS->pTS, pszUrlGPGKey);
-            BAIL_ON_TDNF_ERROR(dwError);
+        pKeyring = rpmtsGetKeyring(pTS->pTS, 0);
 
-            dwError = TDNFGPGCheck(pKeyring, pszUrlGPGKey, pszFilePath);
-            BAIL_ON_TDNF_ERROR(dwError);
+        dwError = TDNFImportGPGKey(pTS->pTS, pszUrlGPGKey);
+        BAIL_ON_TDNF_ERROR(dwError);
 
-            fp = Fopen (pszFilePath, "r.ufdio");
-            if(!fp)
-            {
-                dwError = errno;
-                BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
-            }
+        dwError = TDNFGPGCheck(pKeyring, pszUrlGPGKey, pszFilePath);
+        BAIL_ON_TDNF_ERROR(dwError);
 
-            dwError = rpmReadPackageFile(
-                          pTS->pTS,
-                          fp,
-                          pszFilePath,
-                          &rpmHeader);
+        fp = Fopen (pszFilePath, "r.ufdio");
+        if(!fp)
+        {
+            dwError = errno;
+            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+        }
 
-            BAIL_ON_TDNF_RPM_ERROR(dwError);
+        dwError = rpmReadPackageFile(
+                      pTS->pTS,
+                      fp,
+                      pszFilePath,
+                      &rpmHeader);
 
-            Fclose(fp);
-            fp = NULL;
-	}
+        BAIL_ON_TDNF_RPM_ERROR(dwError);
+
+        Fclose(fp);
+        fp = NULL;
     }
 
     dwError = TDNFGetGPGCheck(pTdnf, pszRepoName, &nGPGCheck, &pszUrlGPGKey);

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -466,6 +466,9 @@ TDNFTransAddInstallPkg(
     {
         dwError = TDNFGPGCheck(pTS->pKeyring, pszUrlGPGKey, pszFilePath);
         BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = rpmtsSetKeyring (pTS->pTS, pTS->pKeyring);
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     fp = Fopen (pszFilePath, "r.ufdio");

--- a/client/structs.h
+++ b/client/structs.h
@@ -73,7 +73,6 @@ typedef struct _TDNF_RPM_TS_
 {
     int                     nQuiet;
     rpmts                   pTS;
-    rpmKeyring              pKeyring;
     rpmtransFlags           nTransFlags;
     rpmprobFilterFlags      nProbFilterFlags;
     FD_t                    pFD;

--- a/client/utils.c
+++ b/client/utils.c
@@ -649,3 +649,36 @@ TDNFGetCmdOpt(
 error:
     return dwError;
 }
+
+uint32_t
+TDNFYesOrNo(
+    PTDNF_CMD_ARGS pArgs,
+    const char *pszQuestion,
+    int *pAnswer
+    )
+{
+    uint32_t dwError = 0;
+    int nAnswer = 0;
+    int32_t opt = 0;
+
+    if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
+    {
+        printf("%s ", pszQuestion);
+        while ((getchar()) != '\n');
+        opt = getchar();
+        if (tolower(opt) != 'y' && tolower(opt) != 'n')
+        {
+            printf("Invalid input\n");
+            dwError = ERROR_TDNF_INVALID_INPUT;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+    if(pArgs->nAssumeYes || (tolower(opt) == 'y'))
+    {
+        nAnswer = 1;
+    }
+    *pAnswer = nAnswer;
+error:
+    return dwError;
+}

--- a/client/utils.c
+++ b/client/utils.c
@@ -650,35 +650,3 @@ error:
     return dwError;
 }
 
-uint32_t
-TDNFYesOrNo(
-    PTDNF_CMD_ARGS pArgs,
-    const char *pszQuestion,
-    int *pAnswer
-    )
-{
-    uint32_t dwError = 0;
-    int nAnswer = 0;
-    int32_t opt = 0;
-
-    if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
-    {
-        printf("%s ", pszQuestion);
-        while ((getchar()) != '\n');
-        opt = getchar();
-        if (tolower(opt) != 'y' && tolower(opt) != 'n')
-        {
-            printf("Invalid input\n");
-            dwError = ERROR_TDNF_INVALID_INPUT;
-            BAIL_ON_TDNF_ERROR(dwError);
-        }
-    }
-
-    if(pArgs->nAssumeYes || (tolower(opt) == 'y'))
-    {
-        nAnswer = 1;
-    }
-    *pAnswer = nAnswer;
-error:
-    return dwError;
-}

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -175,6 +175,13 @@ TDNFUtilsMakeDirs(
     const char* pszPath
     );
 
+uint32_t
+TDNFYesOrNo(
+    PTDNF_CMD_ARGS pArgs,
+    const char *pszQuestion,
+    int *pAnswer
+    );
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/common/utils.c
+++ b/common/utils.c
@@ -377,3 +377,37 @@ TDNFFreeCleanInfo(
         TDNFFreeMemory(pCleanInfo);
     }
 }
+
+uint32_t
+TDNFYesOrNo(
+    PTDNF_CMD_ARGS pArgs,
+    const char *pszQuestion,
+    int *pAnswer
+    )
+{
+    uint32_t dwError = 0;
+    int32_t opt = 0;
+
+    *pAnswer = 0;
+
+    if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
+    {
+        printf("%s ", pszQuestion);
+        while ((opt = getchar()) == '\n' || opt == '\r'));
+        opt = tolower(opt);
+        if (opt != 'y' && opt != 'n')
+        {
+            printf("Invalid input\n");
+            dwError = ERROR_TDNF_INVALID_INPUT;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+    if(pArgs->nAssumeYes || opt == 'y')
+    {
+        *pAnswer = 1;
+    }
+error:
+    return dwError;
+}
+

--- a/common/utils.c
+++ b/common/utils.c
@@ -397,7 +397,7 @@ TDNFYesOrNo(
 
     if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
     {
-        printf("%s ", pszQuestion);
+        printf("%s", pszQuestion);
         while ((opt = getchar()) == '\n' || opt == '\r');
         opt = tolower(opt);
         if (opt != 'y' && opt != 'n')

--- a/common/utils.c
+++ b/common/utils.c
@@ -388,12 +388,17 @@ TDNFYesOrNo(
     uint32_t dwError = 0;
     int32_t opt = 0;
 
+    if(!pArgs || !pszQuestion || !pAnswer)
+    {
+      dwError = ERROR_TDNF_INVALID_PARAMETER;
+      BAIL_ON_TDNF_ERROR(dwError);
+    }
     *pAnswer = 0;
 
     if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
     {
         printf("%s ", pszQuestion);
-        while ((opt = getchar()) == '\n' || opt == '\r'));
+        while ((opt = getchar()) == '\n' || opt == '\r');
         opt = tolower(opt);
         if (opt != 'y' && opt != 'n')
         {

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -65,6 +65,8 @@ extern "C" {
 #define ERROR_TDNF_ERASE_NEEDS_INSTALL      1031
 #define ERROR_TDNF_OPERATION_ABORTED        1032
 
+#define ERROR_TDNF_INVALID_INPUT            1033
+
 //curl errors
 #define ERROR_TDNF_CURL_INIT                1200
 #define ERROR_TDNF_CURL_BASE                1201

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -65,6 +65,7 @@ extern "C" {
 #define ERROR_TDNF_ERASE_NEEDS_INSTALL      1031
 #define ERROR_TDNF_OPERATION_ABORTED        1032
 
+// for invalid input on interactive questions
 #define ERROR_TDNF_INVALID_INPUT            1033
 
 //curl errors

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -217,20 +217,12 @@ TDNFCliAlterCommand(
 
     if(pSolvedPkgInfo->nNeedAction)
     {
-        int32_t opt = 0;
+        int nAnswer = 0;
 
-        if(!pCmdArgs->nAssumeYes && !pCmdArgs->nAssumeNo)
-        {
-            printf("Is this ok [y/N]: ");
+        dwError = TDNFYesOrNo(pCmdArgs, "Is this ok [y/N]", &nAnswer);
+        BAIL_ON_CLI_ERROR(dwError);
 
-            opt = getchar();
-            if (tolower(opt) != 'y' && tolower(opt) != 'n')
-            {
-                printf("Invalid input\n");
-            }
-        }
-
-        if(pCmdArgs->nAssumeYes || (tolower(opt) == 'y'))
+        if(nAnswer)
         {
             if(!nSilent && pSolvedPkgInfo->nNeedDownload)
             {

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -219,7 +219,7 @@ TDNFCliAlterCommand(
     {
         int nAnswer = 0;
 
-        dwError = TDNFYesOrNo(pCmdArgs, "Is this ok [y/N]", &nAnswer);
+        dwError = TDNFYesOrNo(pCmdArgs, "Is this ok [y/N]: ", &nAnswer);
         BAIL_ON_CLI_ERROR(dwError);
 
         if(nAnswer)


### PR DESCRIPTION
When a key is configured for the repo with the "gpgkey" option, the key is ignored. Only keys import with rpm are used.

To reproduce - the step `rpm -e gpg-pubkey-66fd4949-4803fe57` is crucial:
```
root [ /etc/yum.repos.d ]# cat photon.repo 
[photon]
name=VMware Photon Linux $releasever ($basearch)
baseurl=https://dl.bintray.com/vmware/photon_release_$releasever_$basearch
gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
gpgcheck=1
enabled=1
skip_if_unavailable=True
root [ /etc/yum.repos.d ]# ls -l /etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
-rw-r--r-- 1 root root 755 2020-02-15 03:16 /etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
root [ /etc/yum.repos.d ]# rpm -q gpg-pubkey
gpg-pubkey-66fd4949-4803fe57
root [ /etc/yum.repos.d ]# rpm -e gpg-pubkey-66fd4949-4803fe57
root [ /etc/yum.repos.d ]# tdnf install less
Installing:
less                                      x86_64               530-1.ph3                   photon               229.65k 235163
Total installed size: 229.65k 235163
Is this ok [y/N]:y
Downloading:
less                                    121878    100%
Error(1474) : public key is unavailable. install public key using rpm --import or use --nogpgcheck to ignore.
root [ /etc/yum.repos.d ]# 
```

This change first tests the rpm keyring, and if that fails with a signature error adds the configured to a new keyring. The keyring will be discarded so it's not going to be used for other packages from another repo that may have other keys configured.
