### PR TITLE
Create lock file under /var/run

### DIFF
--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -21,7 +21,11 @@
 
 #pragma once
 
-#define TDNF_INSTANCE_LOCK_FILE     "/var/run/lock/.tdnf-instace-lockfile"
+/*
+ * creating this under /var/run because /var/run/lock doesn't exist
+ * in fedora docker images and as a result ci fails
+ */
+#define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instace-lockfile"
 
 #define BAIL_ON_CLI_ERROR(unError) \
     do {                                                           \


### PR DESCRIPTION
/var/run/lock doesn't exist in fedora docker image and ci fails as a
result. So let's create it under /var/run

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>