### PR TITLE
prevent re-adding keys even if signature check has passed with keys f…

### DIFF
--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -576,8 +576,7 @@ TDNFTransAddInstallPkg(
     {
         BAIL_ON_TDNF_RPM_ERROR(dwError);
     }
-
-    if(nGPGSigCheck)
+    else if(nGPGSigCheck)
     {
         dwError = TDNFGetGPGSignatureCheck(pTdnf, pszRepoName, &nGPGSigCheck, &pszUrlGPGKey);
         BAIL_ON_TDNF_ERROR(dwError);


### PR DESCRIPTION
Turns out that the `else` in `client/rpmtrans.c` is needed after all. I had it removed as suggested in a review comment but missed that it's needed for the case that the first `rpmReadPackageFile()` succeeds (with a key that's already in the keyring). tdnf would ask for every single package for confirmation. This PR fixes that.
