### PR TITLE
use high level openssl api for calculating hash

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -188,4 +188,5 @@ typedef enum
     {ERROR_TDNF_BASEURL_DOES_NOT_EXISTS,             "ERROR_TDNF_BASEURL_DOES_NOT_EXISTS",             "Base URL and Metalink URL not found in the repo file"},\
     {ERROR_TDNF_CHECKSUM_VALIDATION_FAILED,          "ERROR_TDNF_CHECKSUM_VALIDATION_FAILED",          "Checksum Validation failed for the file downloaded using URL from metalink"},\
     {ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED, "ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED", "No Resource present in metalink file for file download"},\
+    {ERROR_TDNF_FIPS_MODE_FORBIDDEN,                 "ERROR_TDNF_FIPS_MODE_FORBIDDEN",                 "API call to digest API forbidden in FIPS mode!"},\
 };

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -23,13 +23,12 @@
 
 #include <openssl/sha.h>
 #include <openssl/md5.h>
-
-#define MAX_DIGEST_LENGTH 64
+#include <openssl/evp.h>
 typedef struct metalinkfile{
     char *filename;
     int   type;
     /* raw digest value, not ascii hex digest */
-    unsigned char digest[MAX_DIGEST_LENGTH];
+    unsigned char digest[EVP_MAX_MD_SIZE];
 } metalinkfile;
 
 //clean.c

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -169,6 +169,12 @@ TDNFGetDigestForFile(
     {
         fprintf(stderr, "Digest Init Failed\n");
         dwError = ERROR_TDNF_CHECKSUM_VALIDATION_FAILED;
+        /*MD5 is not approved in FIPS mode. So, overrriding
+          the dwError to show the right error to the user */
+        if (FIPS_mode() && !strcasecmp(hash->hash_type, "md5"))
+        {
+            dwError = ERROR_TDNF_FIPS_MODE_FORBIDDEN;
+        }
         BAIL_ON_TDNF_ERROR(dwError);
     }
 

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -161,6 +161,9 @@ extern "C" {
 #define ERROR_TDNF_CHECKSUM_VALIDATION_FAILED          2501
 #define ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED 2502
 
+//FIPS error
+#define ERROR_TDNF_FIPS_MODE_FORBIDDEN       2600
+
 #define CMD_INSTALL "install"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Use EVP api for hash calculation as low level openssl api's are not accessible in FIPS mode.

Signed-off-by: Tapas Kundu <tkundu@vmware.com>