### PR TITLE
Fetch remote gpg keys from repo config

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -186,6 +186,7 @@ typedef enum
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_NO_GPGKEY_CONF_ENTRY,         "ERROR_TDNF_NO_GPGKEY_CONF_ENTRY",         "gpgkey entry is missing for this repo. please add gpgkey in repo file or use --nogpgcheck to ignore."}, \
+    {ERROR_TDNF_URL_INVALID,                          "ERROR_TDNF_URL_INVALID",          "URL is invalid."}, \
     {ERROR_TDNF_BASEURL_DOES_NOT_EXISTS,             "ERROR_TDNF_BASEURL_DOES_NOT_EXISTS",             "Base URL and Metalink URL not found in the repo file"},\
     {ERROR_TDNF_CHECKSUM_VALIDATION_FAILED,          "ERROR_TDNF_CHECKSUM_VALIDATION_FAILED",          "Checksum Validation failed for the repomd.xml downloaded using URL from metalink"},\
     {ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED, "ERROR_TDNF_METALINK_RESOURCE_VALIDATION_FAILED", "No Resource present in metalink file for file download"},\

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -495,8 +495,7 @@ uint32_t
 TDNFGetGPGCheck(
     PTDNF pTdnf,
     const char* pszRepo,
-    int* pnGPGCheck,
-    char** ppszUrlGPGKey
+    int* pnGPGCheck
     );
 
 uint32_t

--- a/client/repo.c
+++ b/client/repo.c
@@ -174,16 +174,14 @@ uint32_t
 TDNFGetGPGCheck(
     PTDNF pTdnf,
     const char* pszRepo,
-    int* pnGPGCheck,
-    char** ppszUrlGPGKey
+    int* pnGPGCheck
     )
 {
     uint32_t dwError = 0;
     PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
     int nGPGCheck = 0;
-    char* pszUrlGPGKey = NULL;
 
-    if(!pTdnf || !ppszUrlGPGKey || IsNullOrEmptyString(pszRepo) || !pnGPGCheck)
+    if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pnGPGCheck)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -199,28 +197,15 @@ TDNFGetGPGCheck(
         if(pRepo)
         {
             nGPGCheck = pRepo->nGPGCheck;
-            if(nGPGCheck)
-            {
-                dwError = TDNFAllocateString(
-                             pRepo->pszUrlGPGKey,
-                             &pszUrlGPGKey);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
         }
     }
 
     *pnGPGCheck = nGPGCheck;
-    *ppszUrlGPGKey = pszUrlGPGKey;
 
 cleanup:
     return dwError;
 
 error:
-    if(ppszUrlGPGKey)
-    {
-        *ppszUrlGPGKey = NULL;
-    }
-    TDNF_SAFE_FREE_MEMORY(pszUrlGPGKey);
     goto cleanup;
 }
 

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -492,7 +492,7 @@ TDNFFetchRemoteGPGKey(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFFileNameFromUri(pszUrlGPGKey, &pszKeyLocation);
+    dwError = TDNFPathFromUri(pszUrlGPGKey, &pszKeyLocation);
     if (dwError == ERROR_TDNF_URL_INVALID)
     {
         dwError = ERROR_TDNF_KEYURL_INVALID;
@@ -683,7 +683,7 @@ TDNFTransAddInstallPkg(
         }
         else
         {
-            dwError = TDNFFileNameFromUri(pszUrlGPGKey, &pszLocalGPGKey);
+            dwError = TDNFPathFromUri(pszUrlGPGKey, &pszLocalGPGKey);
             if (dwError == ERROR_TDNF_URL_INVALID)
             {
                 dwError = ERROR_TDNF_KEYURL_INVALID;

--- a/common/utils.c
+++ b/common/utils.c
@@ -481,19 +481,19 @@ error:
     goto cleanup;
 }
 
-uint32_t TDNFFileNameFromUri(
+uint32_t TDNFPathFromUri(
     const char* pszKeyUrl,
-    char** ppszFile)
+    char** ppszPath)
 {
     uint32_t dwError = 0;
     const char* pszPath = NULL;
-    char *pszFile = NULL;
+    char *pszPathTmp = NULL;
     size_t nOffset;
     const char *szProtocols[] = {"http://", "https://", "ftp://",
                                 "ftps://", "file://", NULL};
     int i = 0;
 
-    if(IsNullOrEmptyString(pszKeyUrl) || !ppszFile)
+    if(IsNullOrEmptyString(pszKeyUrl) || !ppszPath)
     {
       dwError = ERROR_TDNF_INVALID_PARAMETER;
       BAIL_ON_TDNF_ERROR(dwError);
@@ -534,18 +534,18 @@ uint32_t TDNFFileNameFromUri(
             BAIL_ON_TDNF_ERROR(dwError);
         }
     }
-    dwError = TDNFAllocateString(pszPath, &pszFile);
+    dwError = TDNFAllocateString(pszPath, &pszPathTmp);
     BAIL_ON_TDNF_ERROR(dwError);
-    *ppszFile = pszFile;
+    *ppszPath = pszPathTmp;
 
 cleanup:
     return dwError;
 
 error:
-    TDNF_SAFE_FREE_MEMORY(pszFile);
-    if(ppszFile)
+    TDNF_SAFE_FREE_MEMORY(pszPathTmp);
+    if(ppszPath)
     {
-        *ppszFile = NULL;
+        *ppszPath = NULL;
     }
     goto cleanup;
 }

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -242,9 +242,9 @@ uint32_t TDNFUriIsRemote(
     int *nRemote
 );
 
-uint32_t TDNFFileNameFromUri(
+uint32_t TDNFPathFromUri(
     const char* pszKeyUrl,
-    char** ppszFile);
+    char** ppszPath);
 
 //free global resources.
 void

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -237,6 +237,15 @@ TDNFFreeCmdOpt(
     PTDNF_CMD_OPT pCmdOpt
     );
 
+uint32_t TDNFUriIsRemote(
+    const char* pszKeyUrl,
+    int *nRemote
+);
+
+uint32_t TDNFFileNameFromUri(
+    const char* pszKeyUrl,
+    char** ppszFile);
+
 //free global resources.
 void
 TDNFUninit(

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -140,6 +140,7 @@ extern "C" {
 #define ERROR_TDNF_PLUGIN_NO_MORE_EVENTS     1521
 #define ERROR_TDNF_NO_PLUGIN_ERROR           1522
 #define ERROR_TDNF_NO_GPGKEY_CONF_ENTRY      1523
+#define ERROR_TDNF_URL_INVALID               1524
 
 //RPM Transaction
 #define ERROR_TDNF_TRANS_INCOMPLETE     1525


### PR DESCRIPTION
This PR adds downloading gpg keys from remote locations (http, ftp, ..). The key is first downloaded into the cache area, then used like a local key. The cached key will be deleted after it has ben added to the key ring.

When merging the PR, please squash all changes.
