### PR TITLE
install local or remote packages from command line

### DIFF
--- a/client/init.c
+++ b/client/init.c
@@ -205,10 +205,14 @@ TDNFRefreshSack(
         pTdnf->pArgs->nRefresh = 1;
     }
 
-    //If there is an empty repo directory, do nothing
-    if(pTdnf->pRepos)
+    dwError = TDNFInitCmdLineRepo(pTdnf, pSack);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    /* First repo is the "@cmdline" repo, which always exists.
+     * skip over it - options do not apply, and it is initialized. */
+    if(pTdnf->pRepos->pNext)
     {
-        PTDNF_REPO_DATA_INTERNAL pTempRepo = pTdnf->pRepos;
+        PTDNF_REPO_DATA_INTERNAL pTempRepo = pTdnf->pRepos->pNext;
         while(pTempRepo)
         {
             nMetadataExpired = 0;

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -826,6 +826,12 @@ TDNFGetSystemError(
     );
 
 uint32_t
+TDNFIsFileOrSymlink(
+    const char* pszPath,
+    int* pnPathIsFile
+    );
+
+uint32_t
 TDNFIsDir(
     const char* pszPath,
     int* pnPathIsDir

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -221,6 +221,15 @@ TDNFDownloadPackage(
     const char* pszRpmCacheDir
     );
 
+uint32_t
+TDNFDownloadPackageToCache(
+    PTDNF pTdnf,
+    const char* pszPackageLocation,
+    const char* pszPkgName,
+    const char* pszRepoName,
+    char** ppszFilePath
+    );
+
 //packageutils.c
 uint32_t
 TDNFMatchForReinstall(
@@ -492,6 +501,12 @@ TDNFInitRepo(
     );
 
 uint32_t
+TDNFInitCmdLineRepo(
+    PTDNF pTdnf,
+    PSolvSack pSack
+    );
+
+uint32_t
 TDNFGetGPGCheck(
     PTDNF pTdnf,
     const char* pszRepo,
@@ -587,6 +602,11 @@ TDNFLoadReposFromFile(
     PTDNF pTdnf,
     char* pszRepoFile,
     PTDNF_REPO_DATA_INTERNAL* ppRepos
+    );
+
+uint32_t
+TDNFCreateCmdLineRepo(
+    PTDNF_REPO_DATA_INTERNAL* ppRepo
     );
 
 uint32_t

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -46,6 +46,9 @@ TDNFLoadRepoData(
     }
     pConf = pTdnf->pConf;
 
+    dwError = TDNFCreateCmdLineRepo(&pReposAll);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     pDir = opendir(pConf->pszRepoDir);
     if(pDir == NULL)
     {
@@ -118,6 +121,47 @@ error:
     if(pReposAll)
     {
         TDNFFreeReposInternal(pReposAll);
+    }
+    goto cleanup;
+}
+
+uint32_t
+TDNFCreateCmdLineRepo(
+    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    )
+{
+    uint32_t dwError;
+    PTDNF_REPO_DATA_INTERNAL pRepo;
+
+    if(!ppRepo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFAllocateMemory(
+                  1,
+                  sizeof(TDNF_REPO_DATA_INTERNAL),
+                  (void**)&pRepo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFSafeAllocateString("@cmdline", &pRepo->pszName);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFSafeAllocateString("@cmdline", &pRepo->pszId);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    *ppRepo = pRepo;
+cleanup:
+    return dwError;
+error:
+    if(ppRepo)
+    {
+        *ppRepo = NULL;
+    }
+    if(pRepo)
+    {
+        TDNFFreeReposInternal(pRepo);
     }
     goto cleanup;
 }

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -106,8 +106,10 @@ TDNFRepoGetBaseUrl(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFAllocateString(pRepos->pszBaseUrl, &pszBaseUrl);
-    BAIL_ON_TDNF_ERROR(dwError);
+    if (pRepos->pszBaseUrl) {
+        dwError = TDNFAllocateString(pRepos->pszBaseUrl, &pszBaseUrl);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
     *ppszBaseUrl = pszBaseUrl;
 

--- a/client/structs.h
+++ b/client/structs.h
@@ -54,6 +54,8 @@ typedef struct _TDNF_
     PTDNF_CMD_ARGS pArgs;
     PTDNF_CONF pConf;
     PTDNF_REPO_DATA_INTERNAL pRepos;
+    Repo *pSolvCmdLineRepo;
+    Queue queueCmdLinePkgs;
     PTDNF_PLUGIN pPlugins;
 }TDNF;
 

--- a/client/utils.c
+++ b/client/utils.c
@@ -220,6 +220,51 @@ error:
 }
 
 uint32_t
+TDNFIsFileOrSymlink(
+    const char* pszPath,
+    int* pnPathIsFile
+    )
+{
+    uint32_t dwError = 0;
+    int nPathIsFile = 0;
+    struct stat stStat = {0};
+
+    if(!pnPathIsFile || IsNullOrEmptyString(pszPath))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(stat(pszPath, &stStat))
+    {
+        if (errno == ENOENT)
+	{
+            nPathIsFile = 0;
+        }
+        else
+        {
+            dwError = errno;
+            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+        }
+    }
+    else
+    {
+        nPathIsFile = S_ISREG(stStat.st_mode) | S_ISLNK(stStat.st_mode);
+    }
+
+    *pnPathIsFile = nPathIsFile;
+cleanup:
+    return dwError;
+
+error:
+    if(pnPathIsFile)
+    {
+        *pnPathIsFile = 0;
+    }
+    goto cleanup;
+}
+
+uint32_t
 TDNFIsDir(
     const char* pszPath,
     int* pnPathIsDir

--- a/common/strings.c
+++ b/common/strings.c
@@ -244,7 +244,7 @@ TDNFAllocateStringArray(
     )
 {
     uint32_t dwError = 0;
-    char** ppszDst;
+    char** ppszDst = NULL;
     int i, n = 0;
 
     if(!ppszSrc || !pppszDst)

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -32,6 +32,11 @@ TDNFOpenHandle(
     PTDNF* pTdnf
     );
 
+uint32_t
+TDNFAddCmdLinePackages(
+    PTDNF pTdnf
+);
+
 //check for updates
 uint32_t
 TDNFCheckUpdates(

--- a/pytests/config.json.in
+++ b/pytests/config.json.in
@@ -6,6 +6,7 @@
     "build_dir": "@CMAKE_BINARY_DIR@",
     "plugin_path": "@CMAKE_BINARY_DIR@/plugins/lib",
     "sglversion_pkgname": "tdnf-test-one",
+    "sglversion2_pkgname": "tdnf-test-two",
     "mulversion_pkgname": "tdnf-test-multiversion",
     "mulversion_lower": "1.0.1-1",
     "dummy_requires_pkgname": "tdnf-test-dummy-requires",

--- a/pytests/tests/test_rpm_cmdline.py
+++ b/pytests/tests/test_rpm_cmdline.py
@@ -1,0 +1,128 @@
+#
+# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+
+import os
+import glob
+import pytest
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test_function(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['tdnf', 'erase', '-y', pkgname])
+    os.mkdir(os.path.join(utils.config['repo_path'], 'dummydir'))
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['tdnf', 'erase', '-y', pkgname])
+    os.rmdir(os.path.join(utils.config['repo_path'], 'dummydir'))
+
+def get_pkg_file_path(utils, pkgname):
+    dir = os.path.join(utils.config['repo_path'], 'photon-test', 'RPMS', 'x86_64')
+    matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
+    return matches[0]
+
+def get_pkg_file_path_with_doubledots(utils, pkgname):
+    dir = os.path.join(utils.config['repo_path'], 'dummydir', '..', 'photon-test', 'RPMS', 'x86_64')
+    matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
+    return matches[0]
+
+def get_pkg_remote_url(utils, pkgname):
+    path = get_pkg_file_path(utils, pkgname)
+    url = "http://localhost:8080/{}".format(path[len(utils.config['repo_path'])+1:])
+    return url
+
+def get_pkg_remote_url_with_doubledots(utils, pkgname):
+    path = get_pkg_file_path(utils, pkgname)
+    url = "http://localhost:8080/dummydir/../{}".format(path[len(utils.config['repo_path'])+1:])
+    return url
+
+# test something like "tdnf install /path/to/pkg.rpm"
+def test_install_as_file(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_pkg_file_path(utils, pkgname)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', path])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install ../path/to/pkg.rpm" (relative path)
+def test_install_as_file_relpath(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_pkg_file_path(utils, pkgname)
+    filename = os.path.basename(path) 
+    os.mkdir('rpmtmp')
+    shutil.copy(path, 'rpmtmp')
+    relpath = os.path.join('..', 'rpmtmp', filename)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', relpath])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+    shutil.rmtree('rpmtmp')
+
+# test something like "tdnf install /somepath/../path/to/pkg.rpm"
+def test_install_as_file_with_doubledots(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_pkg_file_path_with_doubledots(utils, pkgname)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', path])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install pkg.rpm"
+def test_install_as_file_relpath(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = os.path.relpath(get_pkg_file_path(utils, pkgname))
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', path])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install file:///path/to/pkg.rpm"
+def test_install_as_file_uri(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_pkg_file_path(utils, pkgname)
+    uri = 'file://{}'.format(path)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', uri])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install http://server.com/path/to/pkg.rpm"
+def test_install_remote(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    uri = get_pkg_remote_url(utils, pkgname)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', uri])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install http://server.com/otherpath/../path/to/pkg.rpm"
+def test_install_remote_with_doubledots(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    uri = get_pkg_remote_url_with_doubledots(utils, pkgname)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', uri])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+
+# test something like "tdnf install http://server.com/path/to/pkg.rpm",
+# but file doesn't exist, expect failure
+def test_install_remote_notfound(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    uri = 'http://localhost:8080/doesnotexist.rpm'
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', uri])
+    assert(ret['retval']  == 1622)
+
+# test something like "tdnf install /path/to/pkg.rpm otherpkg"
+def test_install_as_mixed(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    pkgname2 = utils.config["sglversion2_pkgname"]
+    path = get_pkg_file_path(utils, pkgname)
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', path, pkgname2])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)
+    assert(utils.check_package(pkgname2) == True)
+
+
+
+
+


### PR DESCRIPTION
This adds the functionality to install packages using a file or url on the command line, for example:
`tdnf install /path/to/package.rpm`
or
`tdnf install http://foo.bar.com/packages/package.rpm`

```
Example:
./bin/tdnf install https://packages.vmware.com/photon/3.0/photon_updates_3.0_x86_64/x86_64/less-530-2.ph3.x86_64.rpm
less-530-2.ph3.x86_64.rpm               130134   100%

Installing:
less                                      x86_64               530-2.ph3                   @cmdline             236.70k 242379

Total installed size: 236.70k 242379
Is this ok [y/N]: 
```
Internally this works by creating a temporary repository (called `@cmdline`) which contains all packages from the command line that are files or URL, then resolve for them, and install.

This PR also adds test cases to test the new functionality.

This addresses issue #151 .