### PR TITLE
Add SSL options support

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -91,6 +91,10 @@ typedef enum
 #define TDNF_REPO_KEY_USERNAME            "username"
 #define TDNF_REPO_KEY_PASSWORD            "password"
 #define TDNF_REPO_KEY_METADATA_EXPIRE     "metadata_expire"
+#define TDNF_REPO_KEY_SSL_VERIFY          "sslverify"
+#define TDNF_REPO_KEY_SSL_CA_CERT         "sslcacert"
+#define TDNF_REPO_KEY_SSL_CLI_CERT        "sslclientcert"
+#define TDNF_REPO_KEY_SSL_CLI_KEY         "sslclientkey"
 
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"
@@ -159,6 +163,7 @@ typedef enum
     {ERROR_TDNF_SOLV_CACHE_NOT_CREATED, "ERROR_TDNF_SOLV_CACHE_NOT_CREATED", "Solv - Solv cache not found"}, \
     {ERROR_TDNF_ADD_SOLV,            "ERROR_TDNF_ADD_SOLV",            "Solv - Failed to add solv"}, \
     {ERROR_TDNF_REPO_BASE,           "ERROR_TDNF_REPO_BASE",           "Repo error base"}, \
+    {ERROR_TDNF_SET_SSL_SETTINGS,    "ERROR_TDNF_SET_SSL_SETTINGS",    "There was an error while setting SSL settings for the repo."}, \
     {ERROR_TDNF_REPO_PERFORM,        "ERROR_TDNF_REPO_PERFORM",        "Error during repo handle execution"}, \
     {ERROR_TDNF_REPO_GETINFO,        "ERROR_TDNF_REPO_GETINFO",        "Repo during repo result getinfo"}, \
     {ERROR_TDNF_TRANS_INCOMPLETE,    "ERROR_TDNF_TRANS_INCOMPLETE",    "Incomplete rpm transaction"}, \

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -186,6 +186,13 @@ TDNFRepoApplyProxySettings(
     CURL *pCurl
     );
 
+uint32_t
+TDNFRepoApplySSLSettings(
+    PTDNF pTdnf,
+    const char* pszRepo,
+    CURL *pCurl
+    );
+
 //remoterepo.c
 uint32_t
 TDNFCheckRepoMDFileHashFromMetalink(

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -767,6 +767,9 @@ TDNFDownloadFile(
     dwError = TDNFRepoApplyProxySettings(pTdnf->pConf, pCurl);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFRepoApplySSLSettings(pTdnf, pszRepo, pCurl);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = curl_easy_setopt(pCurl, CURLOPT_URL, pszFileUrl);
     BAIL_ON_TDNF_CURL_ERROR(dwError);
 

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -291,6 +291,34 @@ TDNFLoadReposFromFile(
                       &pRepo->pszPass);
         BAIL_ON_TDNF_ERROR(dwError);
 
+        dwError = TDNFReadKeyValueBoolean(
+                      pSections,
+                      TDNF_REPO_KEY_SSL_VERIFY,
+                      1,
+                      &pRepo->nSSLVerify);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValue(
+                      pSections,
+                      TDNF_REPO_KEY_SSL_CA_CERT,
+                      NULL,
+                      &pRepo->pszSSLCaCert);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValue(
+                      pSections,
+                      TDNF_REPO_KEY_SSL_CLI_CERT,
+                      NULL,
+                      &pRepo->pszSSLClientCert);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValue(
+                      pSections,
+                      TDNF_REPO_KEY_SSL_CLI_KEY,
+                      NULL,
+                      &pRepo->pszSSLClientKey);
+        BAIL_ON_TDNF_ERROR(dwError);
+
         dwError = TDNFReadKeyValue(
                       pSections,
                       TDNF_REPO_KEY_METADATA_EXPIRE,

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -680,3 +680,101 @@ cleanup:
 error:
     goto cleanup;
 }
+
+uint32_t
+TDNFRepoApplySSLSettings(
+    PTDNF pTdnf,
+    const char* pszRepo,
+    CURL *pCurl
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+
+    if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pCurl)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    if(!pTdnf->pRepos)
+    {
+        dwError = ERROR_TDNF_NO_REPOS;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    pRepos = pTdnf->pRepos;
+
+    while(pRepos)
+    {
+        if(!strcmp(pszRepo, pRepos->pszId))
+        {
+            break;
+        }
+        pRepos = pRepos->pNext;
+    }
+
+    if(!pRepos)
+    {
+        dwError = ERROR_TDNF_REPO_NOT_FOUND;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(curl_easy_setopt(
+            pCurl,
+            CURLOPT_SSL_VERIFYPEER,
+            ((pRepos->nSSLVerify) ? 1 : 0)) != CURLE_OK)
+    {
+        dwError = ERROR_TDNF_SET_SSL_SETTINGS;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(curl_easy_setopt(
+            pCurl,
+            CURLOPT_SSL_VERIFYHOST,
+            ((pRepos->nSSLVerify) ? 2 : 0)) != CURLE_OK)
+    {
+        dwError = ERROR_TDNF_SET_SSL_SETTINGS;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+
+    if(!IsNullOrEmptyString(pRepos->pszSSLCaCert))
+    {
+        if(curl_easy_setopt(
+                pCurl,
+                CURLOPT_CAINFO,
+                pRepos->pszSSLCaCert) != CURLE_OK)
+        {
+            dwError = ERROR_TDNF_SET_SSL_SETTINGS;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+    if(!IsNullOrEmptyString(pRepos->pszSSLClientCert))
+    {
+        if(curl_easy_setopt(
+                pCurl,
+                CURLOPT_SSLCERT,
+                pRepos->pszSSLClientCert) != CURLE_OK)
+        {
+            dwError = ERROR_TDNF_SET_SSL_SETTINGS;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+    if(!IsNullOrEmptyString(pRepos->pszSSLClientKey))
+    {
+        if(curl_easy_setopt(
+                pCurl,
+                CURLOPT_SSLKEY,
+                pRepos->pszSSLClientKey) != CURLE_OK)
+        {
+            dwError = ERROR_TDNF_SET_SSL_SETTINGS;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}

--- a/client/structs.h
+++ b/client/structs.h
@@ -36,12 +36,16 @@ typedef struct _TDNF_REPO_DATA_INTERNAL_
     int nEnabled;
     int nSkipIfUnavailable;
     int nGPGCheck;
+    int nSSLVerify;
     long lMetadataExpire;
     char* pszId;
     char* pszName;
     char* pszBaseUrl;
     char* pszMetaLink;
     char* pszUrlGPGKey;
+    char* pszSSLCaCert;
+    char* pszSSLClientCert;
+    char* pszSSLClientKey;
     char* pszUser;
     char* pszPass;
 

--- a/client/structs.h
+++ b/client/structs.h
@@ -42,7 +42,6 @@ typedef struct _TDNF_REPO_DATA_INTERNAL_
     char* pszName;
     char* pszBaseUrl;
     char* pszMetaLink;
-    char* pszUrlGPGKey;
     char* pszSSLCaCert;
     char* pszSSLClientCert;
     char* pszSSLClientKey;

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -109,6 +109,7 @@ extern "C" {
 #define ERROR_TDNF_ADD_SOLV            (ERROR_TDNF_SOLV_BASE + 15)
 //Repo errors 1400 to 1469
 #define ERROR_TDNF_REPO_BASE                 1400
+#define ERROR_TDNF_SET_SSL_SETTINGS          1401
 
 //RPM Errors 1470 to 1599
 #define ERROR_TDNF_RPM_BASE                  1470

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -274,7 +274,6 @@ typedef struct _TDNF_REPO_DATA
     char* pszName;
     char* pszBaseUrl;
     char* pszMetaLink;
-    char* pszUrlGPGKey;
     char* pszSSLCaCert;
     char* pszSSLClientCert;
     char* pszSSLClientKey;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -268,12 +268,16 @@ typedef struct _TDNF_REPO_DATA
     int nEnabled;
     int nSkipIfUnavailable;
     int nGPGCheck;
+    int nSSLVerify;
     long lMetadataExpire;
     char* pszId;
     char* pszName;
     char* pszBaseUrl;
     char* pszMetaLink;
     char* pszUrlGPGKey;
+    char* pszSSLCaCert;
+    char* pszSSLClientCert;
+    char* pszSSLClientKey;
 
     struct _TDNF_REPO_DATA* pNext;
 }TDNF_REPO_DATA, *PTDNF_REPO_DATA;


### PR DESCRIPTION
- Parse SSL related fields from .repo file: `sslverify, sslcacert, sslclientcert, sslclientkey`
- Pass these options to curl.
- Define a new error value for errors occurring in this phase.