### PR TITLE
Fixed TDNFDownloadFile call in repogpgcheck plugin

### DIFF
--- a/plugins/repogpgcheck/includes.h
+++ b/plugins/repogpgcheck/includes.h
@@ -28,6 +28,7 @@
 #include "../../common/defines.h"
 #include "../../common/structs.h"
 #include "../../common/prototypes.h"
+#include "../../client/includes.h"
 #include "defines.h"
 #include "structs.h"
 #include "prototypes.h"

--- a/plugins/repogpgcheck/prototypes.h
+++ b/plugins/repogpgcheck/prototypes.h
@@ -79,13 +79,4 @@ TDNFRepoGPGCheckReadConfig(
     PTDNF_EVENT_CONTEXT pContext
     );
 
-uint32_t
-TDNFDownloadFile(
-    PTDNF pTdnf,
-    const char *pszRepo,
-    const char *pszFileUrl,
-    const char *pszFile,
-    const char *pszProgressData
-    );
-
 #endif /* __PLUGINS_REPOGPGCHECK_PROTOTYPES_H__ */

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -197,12 +197,13 @@ TDNFVerifySignature(
                   TDNF_REPO_METADATA_SIG_EXT);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFDownloadFile(
-                  pHandle->pTdnf,
-                  pcszRepoId,
-                  pszRepoMDSigUrl,
-                  pszRepoMDSigFile,
-                  pcszRepoId);
+    dwError = TDNFDownloadFile(pHandle->pTdnf,
+                               pcszRepoId,
+                               pszRepoMDSigUrl,
+                               pszRepoMDSigFile,
+                               pcszRepoId,
+                               0,
+                               NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFVerifyRepoMDSignature(pHandle, pcszRepoMDFile, pszRepoMDSigFile);

--- a/pytests/tests/test_repogpgcheck.py
+++ b/pytests/tests/test_repogpgcheck.py
@@ -67,11 +67,4 @@ def test_tdnfrepogpgcheck_plugin_validatesignature(utils):
     ret = utils.run([ 'tdnf', 'repolist', '--refresh'])
     #we should load the plugin
     assert(ret['stdout'][0].startswith('Loaded plugin: tdnfrepogpgcheck')) #nosec
-    dist = os.environ.get('DIST')
-    if dist == 'photon':
-        assert(ret['retval'] == 0)
-    elif dist == 'fedora':
-        # TODO:
-        # 'tdnf repolist --refresh' fails with "Unable to parse metalink, ERROR: code=201"
-        # needs to be investigated
-        assert(ret['retval'] == 86)
+    assert(ret['retval'] == 0)


### PR DESCRIPTION
repogpgcheck plugin calls TDNFDownloadFile but it's signtaure was wrong.
As a result this was ending up in unacceptable results.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>