### PR TITLE
normalize paths for gpg key URLs to prevent directory traversals

### DIFF
--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -558,9 +558,10 @@ TDNFFetchRemoteGPGKey(
                                NULL, 0, NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    *ppszKeyLocation = pszFilePath;
+    *ppszKeyLocation = pszNormalPath;
 
 cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszFilePath);
     TDNF_SAFE_FREE_MEMORY(pszRealTopKeyCacheDir);
     TDNF_SAFE_FREE_MEMORY(pszTopKeyCacheDir);
     TDNF_SAFE_FREE_MEMORY(pszFilePathCopy);
@@ -569,7 +570,7 @@ cleanup:
 
 error:
     fprintf(stderr, "Error processing key: %s\n", pszUrlGPGKey);
-    TDNF_SAFE_FREE_MEMORY(pszFilePath);
+    TDNF_SAFE_FREE_MEMORY(pszNormalPath);
     *ppszKeyLocation = NULL;
     goto cleanup;
 }

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -485,6 +485,7 @@ TDNFFetchRemoteGPGKey(
     char* pszNormalPath = NULL;
     char* pszFilePathCopy = NULL;
     char* pszTopKeyCacheDir = NULL;
+    char* pszRealTopKeyCacheDir = NULL;
     char* pszDownloadCacheDir = NULL;
     char* pszKeyLocation = NULL;
 
@@ -508,10 +509,14 @@ TDNFFetchRemoteGPGKey(
                   pszRepoName);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFNormalizePath(pszTopKeyCacheDir,
+                                &pszRealTopKeyCacheDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFAllocateStringPrintf(
                   &pszFilePath,
                   "%s/%s",
-                  pszTopKeyCacheDir,
+                  pszRealTopKeyCacheDir,
                   pszKeyLocation);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -520,7 +525,7 @@ TDNFFetchRemoteGPGKey(
                   &pszNormalPath);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if (strncmp(pszTopKeyCacheDir, pszNormalPath, strlen(pszTopKeyCacheDir)))
+    if (strncmp(pszRealTopKeyCacheDir, pszNormalPath, strlen(pszRealTopKeyCacheDir)))
     {
         dwError = ERROR_TDNF_KEYURL_INVALID;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -556,6 +561,7 @@ TDNFFetchRemoteGPGKey(
     *ppszKeyLocation = pszFilePath;
 
 cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszRealTopKeyCacheDir);
     TDNF_SAFE_FREE_MEMORY(pszTopKeyCacheDir);
     TDNF_SAFE_FREE_MEMORY(pszFilePathCopy);
     TDNF_SAFE_FREE_MEMORY(pszKeyLocation);

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -215,6 +215,11 @@ TDNFYesOrNo(
     int *pAnswer
     );
 
+uint32_t
+TDNFNormalizePath(
+    const char* pszPath,
+    char** ppszNormalPath);
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -91,3 +91,19 @@ def test_install_remote_key(utils):
     assert(ret['retval']  == 0)
     assert(utils.check_package(pkgname))
 
+# import remote key with url containing a directory traversal, expect fail
+def test_install_remote_key_no_traversal(utils):
+    set_gpgcheck(utils, True)
+    set_repo_key(utils, 'http://localhost:8080/../photon-test/keys/pubkey.asc')
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run([ 'tdnf', 'install', '-y', pkgname])
+    assert(ret['retval'] != 0)
+
+# import remote key with url containing a directory traversal, expect fail
+def test_install_remote_key_no_traversal2(utils):
+    set_gpgcheck(utils, True)
+    set_repo_key(utils, 'http://localhost:8080/photon-test/keys/../../../pubkey.asc')
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run([ 'tdnf', 'install', '-y', pkgname])
+    assert(ret['retval']  != 0)
+


### PR DESCRIPTION
This adds the function `TDNFNormalizePath()` to prevent directory traversals using the path to the key. The key is downloaded to cache using the same path as in the URL (analogous to the location of cached rpm packages). Potentially, this could result in a location outside of the cache in some arbitrary location in the filesystem, unless the path is checked. The check works by 'normalizing' the constructed cache path by parsing it and evaluating "up paths" like `../`. Double slashes and "same directory" nodes (`./`) are also eliminated. The result is checked to make sure it is within the cache directory.

The function `realpath()` from libc could not be used because the path may not exist yet.

Tests are also added.
