### PR TITLE
Fix pytest in fedora

### DIFF
--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:32
 
 MAINTAINER csiddharth@vmware.com
 

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -131,7 +131,7 @@ TDNFCreateCmdLineRepo(
     )
 {
     uint32_t dwError;
-    PTDNF_REPO_DATA_INTERNAL pRepo;
+    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
 
     if(!ppRepo)
     {


### PR DESCRIPTION
Fedora latest has python 3.9.0 and latest pytest which
does not have '_pytest.deprecated'. Moving to fedora 32 till we fix this issue.