### PR TITLE
add script run coverity checks inside a container

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,31 @@ run:
 
 You should see a list of installed packages and their related info
 
+## Testing
+
+To build and run the test scripts within a container, do:
+
+```text
+export DIST=photon
+docker run --security-opt seccomp:unconfined --rm -it -e DIST -v$(pwd):/build -w/build ${DIST}/tdnf-build ./ci/docker-entrypoint.sh
+```
+Same for
+```text
+export DIST=fedora
+```
+
+## Coverity
+
+Assuming you have coverity installed on `/pathto/coverity`, you can run:
+
+```text
+docker run --rm -it -v $(pwd):/build -v /pathto/coverity/:/coverity/ -w /build photon/tdnf-build ./ci/coverity.sh
+```
+
+This will put the output to `./build-coverity`. You can then commit the results to the coverity database from that directory, or view the results in `./build-coverity/html`. For example, you can start an nginx container:
+
+```text
+docker run -it --rm -p 8080:80 --name web -v $(pwd)/build-coverity/html:/usr/share/nginx/html nginx
+```
+and then view results in your browser at `http://<host>:8080/`.
+

--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+COVERITY_BIN=/coverity/bin/
+export PATH=${COVERITY_BIN}:${PATH}
+
+COVERITY_DIR=build-coverity
+rm -rf ${COVERITY_DIR}
+mkdir -p ${COVERITY_DIR}
+cd ${COVERITY_DIR}
+
+cmake ..
+
+COV_CONFIG=coverity-config.xml
+COV_DIR=coverity-intermediate
+CC=cc
+
+cov-configure --config ${COV_CONFIG} --compiler ${CC} --comptype gcc --template
+cov-build --dir ${COV_DIR} --config ${COV_CONFIG} make
+cov-analyze --dir ${COV_DIR} --config ${COV_CONFIG} --all
+
+mkdir html
+cov-format-errors --dir ${COV_DIR} --html-output html
+


### PR DESCRIPTION
This adds a script to run coverity for tdnf inside a container. Usage:

On a host that has access to the coverity binaries in `/pathto/toolchain/cov-analysis/bin/ ` do:

`docker run --rm -it -v $(pwd):/build -v /pathto/toolchain:/pathto/toolchain -e COVERITY_BIN=/pathto/toolchain/cov-analysis/bin/ -w /build photon/tdnf-build ./ci/coverity.sh`

Results can seen in build-coverity/html. To see them, you can start an nginx container:

`docker run -it --rm -p 8080:80 --name coverity-web -v $(pwd)/build-coverity/html:/usr/share/nginx/html nginx`

Then point your browser at `<host>:8080`.