### PR TITLE
read multiple keys from one file

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -54,15 +54,23 @@ TDNFApplyScopeFilter(
 
 //gpgcheck.c
 uint32_t
-ReadGPGKey(
-   const char* pszFile,
-   char** ppszKeyData
+ReadGPGKeyFile(
+    const char* pszFile,
+    char** ppszKeyData,
+    int* pnSize
    );
 
 uint32_t
-AddKeyToKeyRing(
+AddKeyFileToKeyring(
     const char* pszFile,
     rpmKeyring pKeyring
+    );
+
+uint32_t
+AddKeyPktToKeyring(
+    rpmKeyring pKeyring,
+    uint8_t* pPkt,
+    size_t nPktLen
     );
 
 uint32_t
@@ -79,7 +87,7 @@ TDNFGPGCheck(
     );
 
 uint32_t
-TDNFImportGPGKey(
+TDNFImportGPGKeyFile(
     rpmts pTS,
     const char* pszFile
     );

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -56,7 +56,7 @@ TDNFRepoSetBaseUrl(
     }
 
     TDNF_SAFE_FREE_MEMORY(pszRepo->pszBaseUrl);
-    dwError = TDNFFileReadAllText(pszBaseUrlFile, &pszBaseUrl);
+    dwError = TDNFFileReadAllText(pszBaseUrlFile, &pszBaseUrl, NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pszRepo->pszBaseUrl = pszBaseUrl;

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -689,7 +689,7 @@ TDNFTransAddInstallPkg(
                 BAIL_ON_TDNF_ERROR(dwError);
             }
 
-            dwError = TDNFImportGPGKey(pTS->pTS, pszLocalGPGKey);
+            dwError = TDNFImportGPGKeyFile(pTS->pTS, pszLocalGPGKey);
             BAIL_ON_TDNF_ERROR(dwError);
 
             pKeyring = rpmtsGetKeyring(pTS->pTS, 0);
@@ -698,7 +698,7 @@ TDNFTransAddInstallPkg(
             {
                 nMatched++;
             }
-	    else if (dwError == ERROR_TDNF_RPM_GPG_NO_MATCH)
+            else if (dwError == ERROR_TDNF_RPM_GPG_NO_MATCH)
             {
                 dwError = 0;
             }

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -184,7 +184,8 @@ TDNFCreateAndWriteToFile(
 uint32_t
 TDNFFileReadAllText(
     const char *pszFileName,
-    char **ppszText
+    char **ppszText,
+    int *pnLength
     );
 
 const char *

--- a/common/utils.c
+++ b/common/utils.c
@@ -11,7 +11,8 @@
 uint32_t
 TDNFFileReadAllText(
     const char *pszFileName,
-    char **ppszText
+    char **ppszText,
+    int *pnLength
     )
 {
     uint32_t dwError = 0;
@@ -52,6 +53,9 @@ TDNFFileReadAllText(
     }
 
     *ppszText = pszText;
+    if (pnLength != NULL) {
+        *pnLength = nLength;
+    }
 cleanup:
     if(fp)
     {


### PR DESCRIPTION
A single key file can have multiple keys, but tdnf read only one. This change makes it read all public keys from the file. This also fixes a potential bug where tdnf wouldn't accept a key file when the first packet in it was not a public key but other pgp data.
