### PR TITLE
fix handling error returned by rpmtsRun(), and remove unused error codes

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -170,8 +170,7 @@ typedef enum
     {ERROR_TDNF_SET_SSL_SETTINGS,    "ERROR_TDNF_SET_SSL_SETTINGS",    "There was an error while setting SSL settings for the repo."}, \
     {ERROR_TDNF_REPO_PERFORM,        "ERROR_TDNF_REPO_PERFORM",        "Error during repo handle execution"}, \
     {ERROR_TDNF_REPO_GETINFO,        "ERROR_TDNF_REPO_GETINFO",        "Repo during repo result getinfo"}, \
-    {ERROR_TDNF_TRANS_INCOMPLETE,    "ERROR_TDNF_TRANS_INCOMPLETE",    "Incomplete rpm transaction"}, \
-    {ERROR_TDNF_TRANS_PKG_NOT_FOUND, "ERROR_TDNF_TRANS_PKG_NOT_FOUND", "Failed to find rpm package"}, \
+    {ERROR_TDNF_TRANSACTION_FAILED,  "ERROR_TDNF_TRANSACTION_FAILED",  "rpm transaction failed"}, \
     {ERROR_TDNF_NO_SEARCH_RESULTS,   "ERROR_TDNF_NO_SEARCH_RESULTS",   "No matches found"}, \
     {ERROR_TDNF_RPMRC_NOTFOUND,      "ERROR_TDNF_RPMRC_NOTFOUND",      "rpm generic error - not found (possible corrupt rpm file)"}, \
     {ERROR_TDNF_RPMRC_FAIL,          "ERROR_TDNF_RPMRC_FAIL",          "rpm generic failure"}, \

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -353,6 +353,7 @@ TDNFRunTransaction(
     int rpmVfyLevelMask = 0;
     uint32_t dwSkipSignature = 0;
     uint32_t dwSkipDigest = 0;
+    int rc;
 
     if(!pTS || !pTdnf || !pTdnf->pArgs)
     {
@@ -403,8 +404,12 @@ TDNFRunTransaction(
          rpmtsSetVfyLevel(pTS->pTS, ~rpmVfyLevelMask);
     }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_TEST);
-    dwError = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
-    BAIL_ON_TDNF_RPM_ERROR(dwError);
+    rc = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
+    if (rc != 0)
+    {
+        dwError = ERROR_TDNF_TRANSACTION_FAILED;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
     //TODO do callbacks for output
     if(!nSilent)
@@ -412,8 +417,12 @@ TDNFRunTransaction(
         printf("Running transaction\n");
     }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_NONE);
-    dwError = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
-    BAIL_ON_TDNF_RPM_ERROR(dwError);
+    rc = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
+    if (rc != 0)
+    {
+        dwError = ERROR_TDNF_TRANSACTION_FAILED;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
 cleanup:
     return dwError;

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -144,8 +144,7 @@ extern "C" {
 #define ERROR_TDNF_URL_INVALID               1524
 
 //RPM Transaction
-#define ERROR_TDNF_TRANS_INCOMPLETE     1525
-#define ERROR_TDNF_TRANS_PKG_NOT_FOUND  1526
+#define ERROR_TDNF_TRANSACTION_FAILED        1525
 
 /* event context */
 #define ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND      1551


### PR DESCRIPTION
Fix the error handling returned from `rpmtsRun()`. Return newly added `ERROR_TDNF_TRANSACTION_FAILED`. Reused the `1525` from never used error code `ERROR_TDNF_TRANS_INCOMPLETE`, which is removed together with  unused `ERROR_TDNF_TRANS_PKG_NOT_FOUND`.

Test:
```
root [ /build/build ]# ./bin/tdnf install ../open-vm-tools-11.2.0-0.16938113.x86_64.rpm less lsof

Installing:
lsof                                            x86_64                  4.91-1.ph3                      photon                   196.10k 200810
less                                            x86_64                  530-2.ph3                       photon-updates           236.70k 242379

Total installed size: 432.80k 443189

Reinstalling:
open-vm-tools                                   x86_64                  11.2.0-0.16938113               @cmdline                  2.50M 2621154

Total installed size:   2.50M 2621154
Is this ok [y/N]: y

Downloading:
lsof                                    123327   100%
less                                    130134   100%
Testing transaction
Found 1 problems
package open-vm-tools-11.2.0-0.16938113.x86_64 is already installed
Error(1525) : rpm transaction failed
```

