### PR TITLE
Fix the --cacheonly option

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -191,6 +191,7 @@ typedef enum
     {ERROR_TDNF_PERM, "ERROR_TDNF_PERM", "Operation not permitted. You have to be root."},\
     {ERROR_TDNF_OPT_NOT_FOUND, "ERROR_TDNF_OPT_NOT_FOUND", "A required option was not found"},\
     {ERROR_TDNF_OPERATION_ABORTED, "ERROR_TDNF_OPERATION_ABORTED", "Operation aborted."},\
+    {ERROR_TDNF_CACHE_DISABLED, "ERROR_TDNF_CACHE_DISABLED", "cache only is set, but no repo data found"},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to disable all plugins or --disableplugin=<plugin> to disable a specific one. You can permanently disable an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_NO_GPGKEY_CONF_ENTRY,         "ERROR_TDNF_NO_GPGKEY_CONF_ENTRY",         "gpgkey entry is missing for this repo. please add gpgkey in repo file or use --nogpgcheck to ignore."}, \

--- a/client/init.c
+++ b/client/init.c
@@ -46,6 +46,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nNoOutput      = pCmdArgsIn->nNoOutput;
     pCmdArgs->nQuiet         = pCmdArgsIn->nQuiet;
     pCmdArgs->nRefresh       = pCmdArgsIn->nRefresh;
+    pCmdArgs->nCacheOnly     = pCmdArgsIn->nCacheOnly;
     pCmdArgs->nRpmVerbosity  = pCmdArgsIn->nRpmVerbosity;
     pCmdArgs->nShowDuplicates= pCmdArgsIn->nShowDuplicates;
     pCmdArgs->nShowHelp      = pCmdArgsIn->nShowHelp;

--- a/client/repo.c
+++ b/client/repo.c
@@ -798,7 +798,7 @@ TDNFGetRepoMD(
     }
 
     /* download repomd.xml to tmp */
-    if (nNeedDownload)
+    if(nNeedDownload && !pTdnf->pArgs->nCacheOnly)
     {
         pr_info("Refreshing metadata for: '%s'\n", pRepoData->pszName);
         /* always download to tmp */
@@ -965,6 +965,10 @@ TDNFGetRepoMD(
         BAIL_ON_TDNF_ERROR(dwError);
     }
     dwError = TDNFParseRepoMD(pRepoMDRel);
+    if (dwError == ERROR_TDNF_FILE_NOT_FOUND && pTdnf->pArgs->nCacheOnly)
+    {
+        dwError = ERROR_TDNF_CACHE_DISABLED;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFEnsureRepoMDParts(

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -68,6 +68,9 @@ extern "C" {
 // for invalid input on interactive questions
 #define ERROR_TDNF_INVALID_INPUT            1033
 
+// cache only set, but no cache available
+#define ERROR_TDNF_CACHE_DISABLED           1034
+
 //curl errors
 #define ERROR_TDNF_CURL_INIT                  1200
 #define ERROR_TDNF_CURL_BASE                  1201

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -46,7 +46,7 @@ static struct option pstOptions[] =
     {"assumeno",      no_argument, &_opt.nAssumeNo, 1},    //--assumeno
     {"assumeyes",     no_argument, 0, 'y'},                //--assumeyes
     {"best",          no_argument, &_opt.nBest, 1},        //--best
-    {"cacheonly",     no_argument, 0, 'C'},                //-C, --cacheonly
+    {"cacheonly",     no_argument, &_opt.nCacheOnly, 'C'}, //-C, --cacheonly
     {"config",        required_argument, 0, 'c'},          //-c, --config
     {"debuglevel",    required_argument, 0, 'd'},          //-d, --debuglevel
     {"debugsolver",   no_argument, &_opt.nDebugSolver, 1}, //--debugsolver


### PR DESCRIPTION
The `-C`/`--cacheonly` option wasn't working. Fixing this. See https://github.com/vmware/tdnf/issues/204 .

Test:
```
root [ /build/build ]# ./bin/tdnf clean all
Cleaning repos: photon-extras photon-updates photon
Cleaning up everything
root [ /build/build ]# ./bin/tdnf install -C less
Error(1034) : cache only is set, but no repo data found
Error: Failed to synchronize cache for repo 'VMware Photon Linux 3.0 (x86_64)' from 'https://packages.vmware.com/photon/3.0/photon_release_3.0_x86_64'
Disabling Repo: 'VMware Photon Linux 3.0 (x86_64)'
Error(1034) : cache only is set, but no repo data found
Error: Failed to synchronize cache for repo 'VMware Photon Linux 3.0 (x86_64) Updates' from 'https://packages.vmware.com/photon/3.0/photon_updates_3.0_x86_64'
Disabling Repo: 'VMware Photon Linux 3.0 (x86_64) Updates'
Error(1034) : cache only is set, but no repo data found
Error: Failed to synchronize cache for repo 'VMware Photon Extras 3.0 (x86_64)' from 'https://packages.vmware.com/photon/3.0/photon_extras_3.0_x86_64'
Disabling Repo: 'VMware Photon Extras 3.0 (x86_64)'
Error(1011) : No matching packages
root [ /build/build ]# ./bin/tdnf makecache
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 3.0 (x86_64) Updates'
Refreshing metadata for: 'VMware Photon Extras 3.0 (x86_64)'
Metadata cache created.                    123   100%
root [ /build/build ]# ./bin/tdnf install -C less

Installing:
less                                            x86_64                  530-2.ph3                       photon-updates           236.70k 242379

Total installed size: 236.70k 242379
Is this ok [y/N]:
```
