### PR TITLE
Delay refreshing repo metadata to after argument validation

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -706,10 +706,7 @@ TDNFOpenHandle(
     dwError = TDNFRepoListFinalize(pTdnf);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFRefreshSack(
-                  pTdnf,
-                  pSack,
-                  pTdnf->pArgs->nRefresh);
+    dwError = TDNFInitCmdLineRepo(pTdnf, pSack);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pTdnf->pSack = pSack;

--- a/client/init.c
+++ b/client/init.c
@@ -205,9 +205,6 @@ TDNFRefreshSack(
         pTdnf->pArgs->nRefresh = 1;
     }
 
-    dwError = TDNFInitCmdLineRepo(pTdnf, pSack);
-    BAIL_ON_TDNF_ERROR(dwError);
-
     /* First repo is the "@cmdline" repo, which always exists.
      * skip over it - options do not apply, and it is initialized. */
     if(pTdnf->pRepos->pNext)
@@ -283,3 +280,11 @@ cleanup:
 error:
     goto cleanup;
 }
+
+uint32_t
+TDNFRefresh(
+    PTDNF pTdnf)
+{
+    return TDNFRefreshSack(pTdnf, pTdnf->pSack, pTdnf->pArgs->nRefresh);
+}
+

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -33,6 +33,11 @@ TDNFOpenHandle(
     );
 
 uint32_t
+TDNFRefresh(
+    PTDNF pTdnf
+    );
+
+uint32_t
 TDNFAddCmdLinePackages(
     PTDNF pTdnf
 );

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -111,6 +111,11 @@ TDNFCliFreeSolvedPackageInfo(
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
     );
 
+uint32_t
+TDNFCliRefresh(
+    PTDNF_CLI_CONTEXT pContext
+);
+
 //Commands
 uint32_t
 TDNFCliAutoEraseCommand(

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -158,6 +158,9 @@ TDNFCliListCommand(
     dwError = TDNFCliParseListArgs(pCmdArgs, &pListArgs);
     BAIL_ON_CLI_ERROR(dwError);
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     dwError = pContext->pFnList(pContext, pListArgs, &pPkgInfo, &dwCount);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -242,6 +245,9 @@ TDNFCliInfoCommand(
     }
 
     dwError = TDNFCliParseInfoArgs(pCmdArgs, &pInfoArgs);
+    BAIL_ON_CLI_ERROR(dwError);
+
+    dwError = TDNFCliRefresh(pContext);
     BAIL_ON_CLI_ERROR(dwError);
 
     dwError = pContext->pFnInfo(pContext, pInfoArgs, &pPkgInfo, &dwCount);
@@ -356,6 +362,9 @@ TDNFCliSearchCommand(
         BAIL_ON_CLI_ERROR(dwError);
     }
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     dwError = pContext->pFnSearch(pContext, pCmdArgs, &pPkgInfo, &dwCount);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -427,6 +436,9 @@ TDNFCliProvidesCommand(
         BAIL_ON_CLI_ERROR(dwError);
     }
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     dwError = pContext->pFnProvides(pContext,
                                     pCmdArgs->ppszCmds[1],
                                     &pPkgInfos);
@@ -482,6 +494,9 @@ TDNFCliCheckUpdateCommand(
                   &nPackageCount);
     BAIL_ON_CLI_ERROR(dwError);
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     dwError = pContext->pFnCheckUpdate(pContext,
                                        ppszPackageArgs,
                                        &pPkgInfo,
@@ -522,8 +537,9 @@ TDNFCliMakeCacheCommand(
         dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
         BAIL_ON_CLI_ERROR(dwError);
     }
-    //Empty as refresh flag is set for makecache command
-    //and will execute refresh on all enabled repos
+
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
 
     pr_crit("Metadata cache created.\n");
 
@@ -547,6 +563,9 @@ TDNFCliCheckCommand(
         dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
         BAIL_ON_CLI_ERROR(dwError);
     }
+
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
 
     dwError = pContext->pFnCheck(pContext);
     BAIL_ON_CLI_ERROR(dwError);

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -186,6 +186,9 @@ TDNFCliAlterCommand(
                   &nPackageCount);
     BAIL_ON_CLI_ERROR(dwError);
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     dwError = pContext->pFnResolve(
                   pContext,
                   nAlterType,

--- a/tools/cli/lib/updateinfocmd.c
+++ b/tools/cli/lib/updateinfocmd.c
@@ -59,6 +59,9 @@ TDNFCliUpdateInfoCommand(
     dwError = TDNFCliParseUpdateInfoArgs(pCmdArgs, &pInfoArgs);
     BAIL_ON_CLI_ERROR(dwError);
 
+    dwError = TDNFCliRefresh(pContext);
+    BAIL_ON_CLI_ERROR(dwError);
+
     if(pInfoArgs->nMode == OUTPUT_SUMMARY)
     {
         dwError = TDNFCliUpdateInfoSummary(pContext, pCmdArgs, pInfoArgs);

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -490,3 +490,11 @@ TDNFCliInvokeUpdateInfoSummary(
                pInfoArgs->ppszPackageNameSpecs,
                ppSummary);
 }
+
+uint32_t
+TDNFCliRefresh(
+    PTDNF_CLI_CONTEXT pContext)
+{
+    return TDNFRefresh(pContext->hTdnf);
+}
+


### PR DESCRIPTION
This addresses issue #https://github.com/vmware/tdnf/issues/90.

Also includes rearranging code in TDNFRefreshSack().
