### PR TITLE
Implement repository priority option

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -90,6 +90,7 @@ typedef enum
 #define TDNF_REPO_KEY_GPGKEY              "gpgkey"
 #define TDNF_REPO_KEY_USERNAME            "username"
 #define TDNF_REPO_KEY_PASSWORD            "password"
+#define TDNF_REPO_KEY_PRIORITY            "priority"
 #define TDNF_REPO_KEY_METADATA_EXPIRE     "metadata_expire"
 #define TDNF_REPO_KEY_TIMEOUT             "timeout"
 #define TDNF_REPO_KEY_RETRIES             "retries"

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -336,6 +336,13 @@ TDNFLoadReposFromFile(
 
         dwError = TDNFReadKeyValueInt(
                       pSections,
+                      TDNF_REPO_KEY_PRIORITY,
+                      50,
+                      &pRepo->nPriority);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValueInt(
+                      pSections,
                       TDNF_REPO_KEY_TIMEOUT,
                       0,
                       &pRepo->nTimeout);

--- a/client/structs.h
+++ b/client/structs.h
@@ -48,6 +48,7 @@ typedef struct _TDNF_REPO_DATA_INTERNAL_
     char** ppszUrlGPGKeys;
     char* pszUser;
     char* pszPass;
+    int nPriority;
     int nTimeout;
     int nMinrate;
     int nThrottle;


### PR DESCRIPTION
Implement the `priority` option for repositories. A lower value for `priority` indicates higher priority. The default is `50`.

Implemented by sorting the repositories by the `priority` value and initializing them in that order using `TDNFInitRepo()`.

Tested by copying `/etc/yum.repos.d/photon-updates.repo` a few times and setting different random priority values. Observed that packages will be installed from repo with lowest priority value.