### PR TITLE
Fix 'clean all' when already clean

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,9 @@ add_c_compiler_flag(-O3 RELEASE)
 add_c_compiler_flag(-s RELEASE)
 add_c_compiler_flag(-g DEBUG)
 
+add_c_compiler_flag(-D_XOPEN_SOURCE=500)
+add_c_compiler_flag(-D_DEFAULT_SOURCE)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 ### External dependency: rpm-devel

--- a/client/api.c
+++ b/client/api.c
@@ -441,6 +441,9 @@ TDNFClean(
                 BAIL_ON_TDNF_ERROR(dwError);
             }
 
+            dwError = TDNFRemoveKeysCache(pTdnf, *ppszReposUsed);
+            BAIL_ON_TDNF_ERROR(dwError);
+
             ++ppszReposUsed;
         }
     }

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -189,6 +189,12 @@ TDNFRemoveSolvCache(
     );
 
 uint32_t
+TDNFRemoveKeysCache(
+    PTDNF pTdnf,
+    const char* pszRepoId
+    );
+
+uint32_t
 TDNFRepoApplyDownloadSettings(
     PTDNF_REPO_DATA_INTERNAL pRepo,
     CURL *pCurl

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -227,6 +227,11 @@ TDNFNormalizePath(
     const char* pszPath,
     char** ppszNormalPath);
 
+uint32_t
+TDNFRecursivelyRemoveDir(
+    const char *pszPath
+);
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/pytests/tests/test_clean.py
+++ b/pytests/tests/test_clean.py
@@ -44,3 +44,14 @@ def test_clean_expire_cache(utils):
 def test_clean_plugins(utils):
     ret = utils.run([ 'tdnf', 'clean', 'plugins' ])
     assert (ret['retval'] == 1016)
+
+def test_clean_all(utils):
+    utils.run(['tdnf', 'makecache'])
+    ret = utils.run([ 'tdnf', 'clean', 'all' ])
+    assert (ret['retval'] == 0)
+
+def test_clean_all_clean_already(utils):
+    utils.run([ 'tdnf', 'clean', 'all' ])
+    ret = utils.run([ 'tdnf', 'clean', 'all' ])
+    assert (ret['retval'] == 0)
+

--- a/pytests/tests/test_clean.py
+++ b/pytests/tests/test_clean.py
@@ -51,7 +51,17 @@ def test_clean_all(utils):
     assert (ret['retval'] == 0)
 
 def test_clean_all_clean_already(utils):
+    utils.run(['tdnf', 'makecache'])
     utils.run([ 'tdnf', 'clean', 'all' ])
+    ret = utils.run([ 'tdnf', 'clean', 'all' ])
+    assert (ret['retval'] == 0)
+
+def test_clean_install_and_clean(utils):
+    utils.run(['tdnf', 'makecache'])
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname ])
+
     ret = utils.run([ 'tdnf', 'clean', 'all' ])
     assert (ret['retval'] == 0)
 

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1744,7 +1744,7 @@ SolvDataIterator(
     Id keyname = SOLVABLE_NAME;
     int flags = 0;
     char **ppszPackagesTemp = NULL;
-    uint32_t dwError;
+    uint32_t dwError = 0;
 
     if (!pPool || !ppszExcludes || !pMap)
     {


### PR DESCRIPTION
When doing `tdnf clean all` after another `tdnf clean all`, `tdnf` would throw an error because it did not find the cache directories (thanks to @tapakund for pointing that out). This issue only became apparent with https://github.com/vmware/tdnf/pull/206 . This PR fixes that issue.

During testing I found also found that `pszVarBaseArch` wouldn't be set if the config file did not include any substitution variables.

Also adds two tests for `tdnf clean all`.
