### PR TITLE
move TDNFCliRefresh() to lib

### DIFF
--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -577,3 +577,11 @@ cleanup:
 error:
     goto cleanup;
 }
+
+uint32_t
+TDNFCliRefresh(
+    PTDNF_CLI_CONTEXT pContext)
+{
+    return TDNFRefresh(pContext->hTdnf);
+}
+

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -491,10 +491,3 @@ TDNFCliInvokeUpdateInfoSummary(
                ppSummary);
 }
 
-uint32_t
-TDNFCliRefresh(
-    PTDNF_CLI_CONTEXT pContext)
-{
-    return TDNFRefresh(pContext->hTdnf);
-}
-


### PR DESCRIPTION
This is to fix the `pmd` build. It was broken with https://github.com/vmware/tdnf/pull/206 . The function `TDNFCliRefresh()` is called from the library code and thus needs to be part of the library, not just the cli tool.
```
libtool: link: x86_64-unknown-linux-gnu-gcc -Wall -Werror -Wno-unused-variable -fno-strict-aliasing -O2 -g -o .libs/pmd-cli pmd_cli-help.o pmd_cli-parseargs.o pmd_cli-options.o pmd_cli-main.o pmd_cli-utils.o  -L/usr/lib ../../client/.libs/libpmdclient.so -ldcerpc -lpthread ../../tools/cli/fwmgmt/.libs/libfwmgmtcli.a ../../tools/cli/pkgmgmt/.libs/libpkgmgmtcli.a -L/usr/lib64 -ltdnfcli -ltdnf -lsolvext -lsolv -lrpm -lrpmio -lcurl ../../tools/cli/netmgmt/.libs/libnetmgmtcli.a -lnetwork_config_manager -lglib-2.0 ../../tools/cli/rolemgmt/.libs/librolemgmtcli.a ../../tools/cli/usermgmt/.libs/libusermgmtcli.a
/bin/ld: /usr/lib/libtdnfcli.so: undefined reference to `TDNFCliRefresh'
```
