### PR TITLE
use %{_unitdir} for SYSTEM_DIR in rpm build script

### DIFF
--- a/tdnf.spec.in
+++ b/tdnf.spec.in
@@ -102,6 +102,7 @@ cmake \
 -DCMAKE_BUILD_TYPE=Debug \
 -DCMAKE_INSTALL_PREFIX=%{_prefix} \
 -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+-DSYSTEMD_DIR=%{_unitdir} \
 ..
 make %{?_smp_mflags} && make python
 


### PR DESCRIPTION
Newer systemd uses `/usr/lib`. tdnf needs to install to the proper directory. This fixes it automatically in the rpm build script.