### PR TITLE
Fix fetching remote keys (progress data)

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -781,7 +781,7 @@ TDNFDownloadFile(
     dwError = curl_easy_setopt(pCurl, CURLOPT_FOLLOWLOCATION, 1L);
     BAIL_ON_TDNF_CURL_ERROR(dwError);
 
-    if (!pTdnf->pArgs->nQuiet)
+    if (!pTdnf->pArgs->nQuiet && pszProgressData != NULL)
     {
         //print progress only if tty or verbose is specified.
         if (isatty(STDOUT_FILENO) || pTdnf->pArgs->nVerbose)

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -560,7 +560,7 @@ TDNFFetchRemoteGPGKey(
     }
 
     dwError = TDNFDownloadFile(pTdnf, pszRepoName, pszUrlGPGKey, pszFilePath,
-                               NULL, 0, NULL);
+                               basename(pszFilePath), 0, NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
     *ppszKeyLocation = pszNormalPath;

--- a/pytests/tests/test_cache.py
+++ b/pytests/tests/test_cache.py
@@ -93,3 +93,12 @@ def test_enable_repo_make_cache(utils):
     utils.run([ 'tdnf', '--disablerepo=*', '--enablerepo=photon-test', 'makecache' ])
     after = os.path.getmtime(lastrefresh)
     assert (before < after)
+
+# -v (verbose) prints progress data
+def test_enable_repo_make_cache_verbose(utils):
+    cache_dir = utils.tdnf_config.get('main', 'cachedir')
+    lastrefresh = os.path.join(cache_dir, 'photon-test/lastrefresh')
+    before = os.path.getmtime(lastrefresh)
+    utils.run([ 'tdnf', '-v', '--disablerepo=*', '--enablerepo=photon-test', 'makecache' ])
+    after = os.path.getmtime(lastrefresh)
+    assert (before < after)

--- a/pytests/tests/test_install.py
+++ b/pytests/tests/test_install.py
@@ -48,6 +48,14 @@ def test_install_package_without_version_suffix(utils):
     utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname ])
     assert(utils.check_package(pkgname) == True)
 
+# -v (verbose) prints progress data
+def test_install_package_verbose(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    utils.run([ 'tdnf', 'install', '-y','-v', '--nogpgcheck', pkgname ])
+    assert(utils.check_package(pkgname) == True)
+
 
 def test_dummy_requires(utils):
     pkg = utils.config["dummy_requires_pkgname"]

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -91,6 +91,15 @@ def test_install_remote_key(utils):
     assert(ret['retval']  == 0)
     assert(utils.check_package(pkgname))
 
+# -v (verbose) prints progress data
+def test_install_remote_key_verbose(utils):
+    set_gpgcheck(utils, True)
+    set_repo_key(utils, 'http://localhost:8080/photon-test/keys/pubkey.asc')
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run([ 'tdnf', 'install', '-v', '-y', pkgname])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname))
+
 # import remote key with url containing a directory traversal, expect fail
 def test_install_remote_key_no_traversal(utils):
     set_gpgcheck(utils, True)


### PR DESCRIPTION
Fetching remote keys has been broken in one of the recent changes:
```root [ /build/build ]# ./bin/tdnf install -y intel-icc-runtime-64bit

Installing:
tcsh                                        x86_64                6.22.02-1.ph4                 photon                  1.03M 1079995
intel-psxe-common-runtime                   noarch                2019.6-324                    intel-psxe-runtime-2019   49.71k 50898
intel-comp-common-runtime                   noarch                2019.6-324                    intel-psxe-runtime-2019     5.03k 5151
intel-icc-common-runtime                    noarch                2019.6-324                    intel-psxe-runtime-2019     5.68k 5815
intel-openmp-runtime-64bit                  x86_64                2019.6-324                    intel-psxe-runtime-2019   2.93M 3073013
intel-comp-runtime-64bit                    x86_64                2019.6-324                    intel-psxe-runtime-2019  35.51M 37237478
intel-icc-runtime-64bit                     x86_64                2019.6-324                    intel-psxe-runtime-2019  48.56M 50915588

Total installed size:  88.09M 92367938

Downloading:
tcsh                                    471722   100%
intel-psxe-common-runtime                20258   100%
importing key from https://yum.repos.intel.com/2019/setup/RPM-GPG-KEY-intel-psxe-runtime-2019
Error processing key: https://yum.repos.intel.com/2019/setup/RPM-GPG-KEY-intel-psxe-runtime-2019
Error processing package: intel-psxe-common-runtime-2019.6-324.noarch.rpm
Error(1622) : Invalid argument
```

Using `-q`, or piping the output to a file (or anything that is not a tty) works. Piping to a file and using `-v` would break it again. Root cause is the NULL pointer passed as `pszProgressData` to `TDNFDownloadFile()`, which then bails in `set_progress_cb()`. This wasn't caught in tests because the output in the tests is not a tty.

This PR adds the base filename of the key to be fetched, and also checks for a NULL pointer as `pszProgressData` before calling `set_progress_cb()`. Tests are added in a few places to use the `-v` flag which would catch this error even if no tty is used.