### PR TITLE
use curl_easy_strerror() to print errors

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -894,6 +894,11 @@ TDNFGetSystemError(
     );
 
 uint32_t
+TDNFGetCurlError(
+    uint32_t dwError
+    );
+
+uint32_t
 TDNFIsFileOrSymlink(
     const char* pszPath,
     int* pnPathIsFile

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -803,7 +803,7 @@ TDNFDownloadFile(
 
         if (i > 0)
         {
-            pr_crit("\nretrying %d/%d\n", i, pRepo->nRetries);
+            pr_info("retrying %d/%d\n", i, pRepo->nRetries);
         }
         dwError = curl_easy_perform(pCurl);
         if (dwError == CURLE_OK)
@@ -870,14 +870,6 @@ error:
         unlink(pszFileTmp);
     }
 
-    if(pCurl && TDNFIsCurlError(dwError))
-    {
-        uint32_t nCurlError = dwError - ERROR_TDNF_CURL_BASE;
-        pr_err(
-                "curl#%u: %s\n",
-                nCurlError,
-                curl_easy_strerror(nCurlError));
-    }
     goto cleanup;
 }
 

--- a/client/utils.c
+++ b/client/utils.c
@@ -29,6 +29,7 @@ TDNFGetErrorString(
     uint32_t dwError = 0;
     char* pszError = NULL;
     char* pszSystemError = NULL;
+    const char* pszCurlError = NULL;
     int i = 0;
     int nCount = 0;
     uint32_t dwActualError = 0;
@@ -56,6 +57,18 @@ TDNFGetErrorString(
         if(pszSystemError)
         {
             dwError = TDNFAllocateString(pszSystemError, &pszError);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
+    //Get curl error
+    if(!pszError && TDNFIsCurlError(dwErrorCode))
+    {
+        dwActualError = TDNFGetCurlError(dwErrorCode);
+        pszCurlError = curl_easy_strerror(dwActualError);
+        if(pszCurlError)
+        {
+            dwError = TDNFAllocateString(pszCurlError, &pszError);
             BAIL_ON_TDNF_ERROR(dwError);
         }
     }
@@ -108,6 +121,19 @@ TDNFGetSystemError(
         dwSystemError = dwError - ERROR_TDNF_SYSTEM_BASE;
     }
     return dwSystemError;
+}
+
+uint32_t
+TDNFGetCurlError(
+    uint32_t dwError
+    )
+{
+    uint32_t dwCurlError = 0;
+    if(TDNFIsCurlError(dwError))
+    {
+        dwCurlError = dwError - ERROR_TDNF_CURL_BASE;
+    }
+    return dwCurlError;
 }
 
 int


### PR DESCRIPTION
Print out curl errors. Example with intentionally mistyped URL:

```# ./bin/tdnf makecache
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64) Updates'
Refreshing metadata for: 'VMware Photon Extras 4.0 (x86_64)'
Refreshing metadata for: 'Kubernetes'     2962   100%
...
retrying 10/10
curl#6: Couldn't resolve host name
Error(1207) : Couldn't resolve host name
Error: Failed to synchronize cache for repo 'Kubernetes' from 'https://packages.kloud.google.com/yum/repos/kubernetes-el7-x86_64'
Disabling Repo: 'Kubernetes'
Metadata cache created.
```
Before it would print `Error(1207) : Unknown error`.
