### PR TITLE
Fix provides for existing files

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -710,12 +710,6 @@ TDNFOpenHandle(
     BAIL_ON_TDNF_ERROR(dwError);
 
     pTdnf->pSack = pSack;
-    pSack = NULL;
-    dwError = TDNFAddCmdLinePackages(
-                  pTdnf
-                  );
-    BAIL_ON_TDNF_ERROR(dwError);
-
     *ppTdnf = pTdnf;
 
 cleanup:

--- a/pytests/tests/test_whatprovides.py
+++ b/pytests/tests/test_whatprovides.py
@@ -25,6 +25,13 @@ def test_whatprovides_invalid_arg(utils):
     ret = utils.run([ 'tdnf', 'whatprovides', 'invalid_arg' ])
     assert(ret['stderr'][0] == 'No data available')
 
-def test_whatprovides_valid_file(utils):
+def test_whatprovides_valid_file_notinstalled(utils):
     ret = utils.run([ 'tdnf', 'whatprovides', '/lib/systemd/system/tdnf-test-one.service' ])
+    assert('tdnf-test-one' in "\n".join(ret['stdout']))
+    assert(ret['retval'] == 0)
+
+def test_whatprovides_valid_file_installed(utils):
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', 'tdnf-test-one' ])
+    ret = utils.run([ 'tdnf', 'whatprovides', '/lib/systemd/system/tdnf-test-one.service' ])
+    assert('tdnf-test-one' in "\n".join(ret['stdout']))
     assert(ret['retval'] == 0)

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -180,6 +180,11 @@ TDNFCliAlterCommand(
 
     nSilent = pCmdArgs->nNoOutput;
 
+    dwError = TDNFAddCmdLinePackages(
+                  pContext->hTdnf
+                  );
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFCliParsePackageArgs(
                   pCmdArgs,
                   &ppszPackageArgs,


### PR DESCRIPTION
See https://github.com/vmware/tdnf/issues/220 . Fix this by moving the call to `TDNFAddCmdLinePackages()` to the `TDNFCliAlterCommand()` function. This way command line args are only interpreted as package files for altering commands.

Also add a test that would have caught this issue.