### PR TITLE
'rpmbuild --sign' option is deprecated, use 'rpmsign' instead

### DIFF
--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -53,9 +53,8 @@ EOF
 
 echo building packages
 rpmbuild  --define "_topdir ${BUILD_PATH}" \
-	  --define "__gpg_sign_cmd %%{__gpg} gpg --batch" \
-	  -r ${BUILD_PATH} -ba ${REPO_SRC_DIR}/*.spec --sign
-
+	  -r ${BUILD_PATH} -ba ${REPO_SRC_DIR}/*.spec
+rpmsign --addsign ${BUILD_PATH}/RPMS/*/*.rpm
 cp -r ${BUILD_PATH}/RPMS ${PUBLISH_PATH}
 
 # save key to later be imported:


### PR DESCRIPTION
With Photon 4.0 GA, the `rpmbuild` command no longer supports the `--sign` option. This broke the Travis CI tests. With this change RPMs are signed with the `rpmsign` command.