### PR TITLE
do not use FTW_MOUNT flag for ntfw()

### DIFF
--- a/common/utils.c
+++ b/common/utils.c
@@ -721,7 +721,7 @@ TDNFRecursivelyRemoveDir(const char *pszPath)
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if (nftw(pszPath, _rm_file, 10, FTW_DEPTH|FTW_MOUNT|FTW_PHYS) < 0)
+    if (nftw(pszPath, _rm_file, 10, FTW_DEPTH|FTW_PHYS) < 0)
     {
         dwError = errno;
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);


### PR DESCRIPTION
The `ntfw()` function would ignore non-directory objects for older kernel versions. This caused files in the cache to not be deleted. This issue only happens when using the `FTW_MOUNT` flag, see https://bugzilla.kernel.org/show_bug.cgi?id=114951 . This change removes the flag. This is a good idea anyway since in the (unlikely) case that a subtree under the cache directory is from another filesystem, the files wouldn't be cleared out.

Issue manifested itself when calling `tdnf makecache` twice or `make clean all` called after `makecache` in a container running on a host with an older kernel, for example on Photon 2.0:

```
root [ / ]# tdnf makecache
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64)'
unable to remove /var/cache/tdnf/photon-release/tmp: Directory not empty
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64) Updates'
unable to remove /var/cache/tdnf/photon-updates/tmp: Directory not empty
Refreshing metadata for: 'VMware Photon Extras 4.0 (x86_64)'
unable to remove /var/cache/tdnf/photon-extras/tmp: Directory not empty
Metadata cache created.```
