### PR TITLE
setopt: Support rpm transactions noscripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ Makefile.in
 *.status
 *.log
 *.pc
-*.spec
 *.patch
 *.diff
 

--- a/common/setopt.c
+++ b/common/setopt.c
@@ -52,6 +52,9 @@ AddSetOpt(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    dwError = AddSetOptWithValues(pCmdArgs, CMDOPT_KEYVALUE, pCmdOpt->pszOptName, pCmdOpt->pszOptValue);
+    BAIL_ON_TDNF_ERROR(dwError);
+
 cleanup:
     if(pCmdOpt)
     {

--- a/pytests/repo/tdnf-bad-pre.spec
+++ b/pytests/repo/tdnf-bad-pre.spec
@@ -1,0 +1,38 @@
+#
+# tdnf-bad-pre spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-bad-pre
+Version:    1.0.0
+Release:    1
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Test bad install scripts.
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/usr/bin
+cat << EOF >> %_topdir/%buildroot/usr/bin/bad-pre.sh
+#!/bin/sh
+# dummy script. Return false because we are bad.
+/bin/false
+EOF
+
+%pre
+# fail intentionally
+/bin/false
+
+%files
+/usr/bin/bad-pre.sh
+
+%changelog
+*   Fri Apr 2 2021 Oliver Kurth <okurth@vmware.com> 1.0.0-1
+    initial package to test '--setopt=tsflags=noscripts'

--- a/pytests/tests/test_noscripts.py
+++ b/pytests/tests/test_noscripts.py
@@ -1,0 +1,34 @@
+#
+# Copyright (C) 2019 - 2020 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import tempfile
+import pytest
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    pkgname = 'tdnf-bad-pre'
+    utils.run(['tdnf', 'erase', '-y', pkgname])
+
+# Verify that the package is really bad:
+def test_install_normal(utils):
+    pkgname = 'tdnf-bad-pre'
+    ret = utils.run([ 'tdnf', 'install' ,'-y', '--nogpgcheck', pkgname])
+    assert(ret['retval'] == 1525)
+
+def test_install_noscripts(utils):
+    pkgname = 'tdnf-bad-pre'
+    ret = utils.run([ 'tdnf', 'install' ,'-y', '--nogpgcheck',
+       '--setopt=tsflags=noscripts', pkgname])
+    assert(ret['retval'] == 0)
+


### PR DESCRIPTION
This is based on PR228 (Thank you!), but with various problems fixed. It also adds a test.

It's possible to extend this and allow more fine grained control for specific install and trigger scripts.

Testing done:
```
# ./bin/tdnf remove -y systemd-udev

Removing:
systemd-udev                                x86_64                247.3-1.ph4                   @System                 8.50M 8908222

Total installed size:   8.50M 8908222
Testing transaction
Running transaction
/var/tmp/rpm-tmp.5cDl5W: line 1: fg: no job control
package systemd-udev-247.3-1.ph4.x86_64: script error in %preun
Error(1525) : rpm transaction failed

# ./bin/tdnf remove --setopt=tsflags=noscripts -y systemd-udev

Removing:
systemd-udev                                x86_64                247.3-1.ph4                   @System                 8.50M 8908222

Total installed size:   8.50M 8908222
Testing transaction
Running transaction
Removing: systemd-udev-247.3-1.ph4.x86_64

Complete!
```
