### PR TITLE
move special metalink handling out of TDNFDownloadFile() to caller

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -245,9 +245,7 @@ TDNFDownloadFile(
     const char *pszRepo,
     const char *pszFileUrl,
     const char *pszFile,
-    const char *pszProgressData,
-    int metalink,
-    TDNF_METALINK_FILE **ml_file
+    const char *pszProgressData
     );
 
 uint32_t

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -707,9 +707,7 @@ TDNFDownloadFile(
     const char *pszRepo,
     const char *pszFileUrl,
     const char *pszFile,
-    const char *pszProgressData,
-    int is_metalink,
-    TDNF_METALINK_FILE **ml_file
+    const char *pszProgressData
     )
 {
     uint32_t dwError = 0;
@@ -838,12 +836,6 @@ TDNFDownloadFile(
     {
         dwError = rename(pszFileTmp, pszFile);
         BAIL_ON_TDNF_ERROR(dwError);
-
-        if (is_metalink && ml_file)
-        {
-            dwError = TDNFParseAndGetURLFromMetalink(pTdnf, pszRepo, pszFile, ml_file);
-            BAIL_ON_TDNF_ERROR(dwError);
-        }
     }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszUserPass);
@@ -928,9 +920,7 @@ TDNFDownloadPackage(
                                pszRepoName,
                                pszPackageUrl,
                                pszPackageFile,
-                               pszPkgName,
-                               0,
-                               NULL);
+                               pszPkgName);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pr_info("\n");

--- a/client/repo.c
+++ b/client/repo.c
@@ -599,7 +599,7 @@ TDNFDownloadUsingMetalinkResources(
             BAIL_ON_TDNF_ERROR(dwError);
         }
         dwError = TDNFDownloadFile(pTdnf, pszRepo, urls->url, pszFile,
-                                   pszProgressData, 0, NULL);
+                                   pszProgressData);
         if (dwError)
         {
             urls = urls->next;
@@ -836,8 +836,11 @@ TDNFGetRepoMD(
                                                TDNF_REPO_BASEURL_FILE_NAME);
             BAIL_ON_TDNF_ERROR(dwError);
             dwError = TDNFDownloadFile(pTdnf, pRepoData->pszId, pszRepoMetalink,
-                                       pszTmpRepoMetalinkFile, pRepoData->pszId,
-                                       metalink, &ml_file);
+                                       pszTmpRepoMetalinkFile, pRepoData->pszId);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            dwError = TDNFParseAndGetURLFromMetalink(pTdnf,
+                        pRepoData->pszId, pszTmpRepoMetalinkFile, &ml_file);
             BAIL_ON_TDNF_ERROR(dwError);
 
             nReplaceRepoMD = 1;
@@ -901,9 +904,7 @@ TDNFGetRepoMD(
                               pRepoData->pszId,
                               pszRepoMDUrl,
                               pszTmpRepoMDFile,
-                              pRepoData->pszId,
-                              0,
-                              NULL);
+                              pRepoData->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
             nReplaceRepoMD = 1;
             if (pszCookie[0])
@@ -1051,9 +1052,7 @@ TDNFDownloadRepoMDPart(
                       pszRepo,
                       pszTempUrl,
                       pszDestPath,
-                      pszRepo,
-                      0,
-                      NULL);
+                      pszRepo);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -576,7 +576,7 @@ TDNFFetchRemoteGPGKey(
     }
 
     dwError = TDNFDownloadFile(pTdnf, pszRepoName, pszUrlGPGKey, pszFilePath,
-                               basename(pszFilePath), 0, NULL);
+                               basename(pszFilePath));
     BAIL_ON_TDNF_ERROR(dwError);
 
     *ppszKeyLocation = pszNormalPath;

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -201,9 +201,7 @@ TDNFVerifySignature(
                                pcszRepoId,
                                pszRepoMDSigUrl,
                                pszRepoMDSigFile,
-                               pcszRepoId,
-                               0,
-                               NULL);
+                               pcszRepoId);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFVerifyRepoMDSignature(pHandle, pcszRepoMDFile, pszRepoMDSigFile);


### PR DESCRIPTION
Cleanup: there are 7 callers to `TDNFDownloadFile()`, only one of them cares about metalinks. The special code handling this is at the very end of the function, using the supplied arguments and can therefore be placed into the single caller. This way the other 6 callers do not need to supply the NULL args.