### PR TITLE
implement the reposync feature

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1139,6 +1139,11 @@ TDNFRepoSync(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if (pReposyncArgs->nNewestOnly)
+    {
+        TDNFPkgInfoFilterNewest(pTdnf->pSack, pPkgInfos);
+    }
+
     /* iterate through all packages */
     for (pPkgInfo = pPkgInfos; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
     {

--- a/client/api.c
+++ b/client/api.c
@@ -1125,7 +1125,7 @@ TDNFRepoSync(
     }
     else
     {
-        dwError = TDNFAllocateString(pReposyncArgs->pszDownloadPath, &pszRootPath);
+        dwError = TDNFNormalizePath(pReposyncArgs->pszDownloadPath, &pszRootPath);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -1154,7 +1154,7 @@ TDNFRepoSync(
             dwError = TDNFUtilsMakeDir(pszDir);
             BAIL_ON_TDNF_ERROR(dwError);
 
-            dwError = TDNFDownloadPackageToDirectory(pTdnf,
+            dwError = TDNFDownloadPackageToTree(pTdnf,
                             pPkgInfo->pszLocation, pPkgInfo->pszName,
                             pPkgInfo->pszRepoName, pszDir,
                             &pszFilePath);

--- a/client/api.c
+++ b/client/api.c
@@ -1056,7 +1056,7 @@ TDNFRepoSync(
     uint32_t dwRepoCount = 0;
     TDNFRPMTS ts = {0};
 
-    if(!pTdnf || !pTdnf->pSack)
+    if(!pTdnf || !pTdnf->pSack || !pReposyncArgs)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -1194,9 +1194,9 @@ TDNFRepoSync(
         else
         {
             dwError = TDNFCreatePackageUrl(pTdnf,
-                                            pPkgInfo->pszRepoName,
-                                            pPkgInfo->pszLocation,
-                                            &pszUrl);
+                                           pPkgInfo->pszRepoName,
+                                           pPkgInfo->pszLocation,
+                                           &pszUrl);
             BAIL_ON_TDNF_ERROR(dwError);
 
             pr_info("%s\n", pszUrl);

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -18,6 +18,7 @@
  * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
  */
 
+#define _GNU_SOURCE 1
 #include "includes.h"
 
 uint32_t
@@ -253,22 +254,15 @@ TDNFPopulatePkgInfoForRepoSync(
         dwError = SolvGetPackageId(pPkgList, dwPkgIndex, &dwPkgId);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        dwError = SolvGetPkgNameFromId(pSack, dwPkgId, &pPkgInfo->pszName);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgArchFromId(pSack, dwPkgId, &pPkgInfo->pszArch);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgVersionFromId(
+        dwError = SolvGetNevraFromId(
                       pSack,
                       dwPkgId,
-                      &pPkgInfo->pszVersion);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgReleaseFromId(
-                      pSack,
-                      dwPkgId,
-                      &pPkgInfo->pszRelease);
+                      &pPkgInfo->dwEpoch,
+                      &pPkgInfo->pszName,
+                      &pPkgInfo->pszVersion,
+                      &pPkgInfo->pszRelease,
+                      &pPkgInfo->pszArch,
+                      &pPkgInfo->pszEVR);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = SolvGetPkgRepoNameFromId(
@@ -298,6 +292,93 @@ error:
     {
         TDNFFreePackageInfoArray(pPkgInfos, dwCount);
     }
+    goto cleanup;
+}
+
+static
+int _pkginfo_compare(
+        const void *ptr1,
+        const void *ptr2,
+        void *data
+    )
+{
+    const PTDNF_PKG_INFO* ppPkgInfo1 = (PTDNF_PKG_INFO*)ptr1;
+    const PTDNF_PKG_INFO* ppPkgInfo2 = (PTDNF_PKG_INFO*)ptr2;
+    Pool *pPool = (Pool *)data;
+    int ret;
+
+    /* sort by repo name first, then name, then version */
+    ret = strcmp((*ppPkgInfo1)->pszRepoName, (*ppPkgInfo2)->pszRepoName);
+    if (ret != 0)
+    {
+        return ret;
+    }
+    ret = strcmp((*ppPkgInfo1)->pszName, (*ppPkgInfo2)->pszName);
+    if (ret != 0)
+    {
+        return ret;
+    }
+
+    /* we want newest version first, so reverse it by using the negated value */
+    ret = - pool_evrcmp_str(pPool,
+                          (*ppPkgInfo1)->pszEVR, (*ppPkgInfo2)->pszEVR,
+                          EVRCMP_COMPARE);
+    return ret;
+}
+
+uint32_t
+TDNFPkgInfoFilterNewest(
+    PSolvSack pSack,
+    PTDNF_PKG_INFO pPkgInfos
+)
+{
+    uint32_t dwError = 0;
+    uint32_t dwCount, i;
+    PTDNF_PKG_INFO* ppPkgInfos = NULL;
+    PTDNF_PKG_INFO pPkgInfo = NULL;
+
+    dwCount = 0;
+    for (pPkgInfo = pPkgInfos; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
+    {
+        dwCount++;
+    }
+
+    dwError = TDNFAllocateMemory(
+                  dwCount,
+                  sizeof(PTDNF_PKG_INFO),
+                  (void**)&ppPkgInfos);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    i = 0;
+    for (pPkgInfo = pPkgInfos; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
+    {
+        ppPkgInfos[i++] = pPkgInfo;
+    }
+
+    qsort_r(ppPkgInfos, dwCount,
+            sizeof(PTDNF_PKG_INFO), _pkginfo_compare, (void *)pSack->pPool);
+
+    /* Loop though pointer array, use the linked list to skip over
+       older versions of the same packages. The linked list will only
+       touch the newest (first) version of a package.
+       The same package in different repos will be handled as two different
+       packages. */ 
+    pPkgInfo = ppPkgInfos[0];
+    for (i = 1; i < dwCount; i++)
+    {
+        if ((strcmp(ppPkgInfos[i]->pszRepoName, pPkgInfo->pszRepoName) != 0) ||
+            (strcmp(ppPkgInfos[i]->pszName, pPkgInfo->pszName) != 0))
+        {
+            pPkgInfo->pNext = ppPkgInfos[i];
+            pPkgInfo = ppPkgInfos[i];
+        }
+    }
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(ppPkgInfos);
+    return dwError;
+
+error:
     goto cleanup;
 }
 
@@ -864,7 +945,8 @@ TDNFPopulatePkgInfos(
                       &pPkgInfo->pszName,
                       &pPkgInfo->pszVersion,
                       &pPkgInfo->pszRelease,
-                      &pPkgInfo->pszArch);
+                      &pPkgInfo->pszArch,
+                      NULL);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = SolvGetPkgRepoNameFromId(

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -292,6 +292,13 @@ TDNFPopulatePkgInfos(
     );
 
 uint32_t
+TDNFPopulatePkgInfoForRepoSync(
+    PSolvSack pSack,
+    PSolvPackageList pPkgList,
+    PTDNF_PKG_INFO* ppPkgInfo
+    );
+
+uint32_t
 TDNFPopulatePkgInfoArray(
     PSolvSack pSack,
     PSolvPackageList pPkgList,
@@ -640,6 +647,21 @@ uint32_t
 TDNFReplaceFile(
     const char *pszSrcFile,
     const char *pszDstFile
+    );
+
+uint32_t
+TDNFDownloadMetadata(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
+    const char *pszRepoDir
+    );
+
+uint32_t
+TDNFDownloadRepoMDParts(
+    PTDNF pTdnf,
+    Repo *pSolvRepo,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
+    const char *pszDir
     );
 
 //repolist.c

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -92,6 +92,23 @@ TDNFImportGPGKeyFile(
     const char* pszFile
     );
 
+uint32_t
+TDNFGPGCheckPackage(
+    PTDNFRPMTS pTS,
+    PTDNF pTdnf,
+    const char* pszRepoName,
+    const char* pszFilePath,
+    Header *pRpmHeader
+    );
+
+uint32_t
+TDNFFetchRemoteGPGKey(
+    PTDNF pTdnf,
+    const char* pszRepoName,
+    const char* pszUrlGPGKey,
+    char** ppszKeyLocation
+    );
+
 //init.c
 uint32_t
 TDNFCloneCmdArgs(

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -292,6 +292,16 @@ TDNFDownloadPackageToCache(
     );
 
 uint32_t
+TDNFDownloadPackageToTree(
+    PTDNF pTdnf,
+    const char* pszPackageLocation,
+    const char* pszPkgName,
+    const char* pszRepoName,
+    char* pszNormalRpmCacheDir,
+    char** ppszFilePath
+    );
+
+uint32_t
 TDNFDownloadPackageToDirectory(
     PTDNF pTdnf,
     const char* pszPackageLocation,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -903,6 +903,12 @@ TDNFIsFileOrSymlink(
     );
 
 uint32_t
+TDNFGetFileSize(
+    const char* pszPath,
+    int *pnSize
+    );
+
+uint32_t
 TDNFIsDir(
     const char* pszPath,
     int* pnPathIsDir

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -249,6 +249,14 @@ TDNFDownloadFile(
     );
 
 uint32_t
+TDNFCreatePackageUrl(
+    PTDNF pTdnf,
+    const char* pszRepoName,
+    const char* pszPackageLocation,
+    char **ppszPackageUrl
+    );
+
+uint32_t
 TDNFDownloadPackage(
     PTDNF pTdnf,
     const char* pszPackageLocation,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -245,9 +245,7 @@ TDNFDownloadFile(
     const char *pszRepo,
     const char *pszFileUrl,
     const char *pszFile,
-    const char *pszProgressData,
-    int metalink,
-    TDNF_METALINK_FILE **ml_file
+    const char *pszProgressData
     );
 
 uint32_t

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -334,6 +334,12 @@ TDNFPopulatePkgInfoForRepoSync(
     );
 
 uint32_t
+TDNFPkgInfoFilterNewest(
+    PSolvSack pSack,
+    PTDNF_PKG_INFO pPkgInfos
+);
+
+uint32_t
 TDNFPopulatePkgInfoArray(
     PSolvSack pSack,
     PSolvPackageList pPkgList,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -661,7 +661,8 @@ uint32_t
 TDNFDownloadMetadata(
     PTDNF pTdnf,
     PTDNF_REPO_DATA_INTERNAL pRepo,
-    const char *pszRepoDir
+    const char *pszRepoDir,
+    int nPrintOnly
     );
 
 uint32_t
@@ -669,7 +670,8 @@ TDNFDownloadRepoMDParts(
     PTDNF pTdnf,
     Repo *pSolvRepo,
     PTDNF_REPO_DATA_INTERNAL pRepo,
-    const char *pszDir
+    const char *pszDir,
+    int nPrintOnly
     );
 
 //repolist.c

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -866,26 +866,22 @@ error:
 }
 
 uint32_t
-TDNFDownloadPackage(
+TDNFCreatePackageUrl(
     PTDNF pTdnf,
-    const char* pszPackageLocation,
-    const char* pszPkgName,
     const char* pszRepoName,
-    const char* pszRpmCacheDir
+    const char* pszPackageLocation,
+    char **ppszPackageUrl
     )
 {
     uint32_t dwError = 0;
     char* pszBaseUrl = NULL;
     char *pszPackageUrl = NULL;
-    char *pszPackageFile = NULL;
-    char *pszCopyOfPackageLocation = NULL;
-    int nSize;
 
     if(!pTdnf ||
        !pTdnf->pArgs ||
        IsNullOrEmptyString(pszPackageLocation) ||
-       IsNullOrEmptyString(pszPkgName) ||
-       IsNullOrEmptyString(pszRepoName))
+       IsNullOrEmptyString(pszRepoName) ||
+       !ppszPackageUrl)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -906,6 +902,44 @@ TDNFDownloadPackage(
         dwError = TDNFAllocateString(pszPackageLocation, &pszPackageUrl);
         BAIL_ON_TDNF_ERROR(dwError);
     }
+    *ppszPackageUrl = pszPackageUrl;
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszBaseUrl);
+    return dwError;
+
+error:
+    TDNF_SAFE_FREE_MEMORY(pszPackageUrl);
+    goto cleanup;
+}
+
+uint32_t
+TDNFDownloadPackage(
+    PTDNF pTdnf,
+    const char* pszPackageLocation,
+    const char* pszPkgName,
+    const char* pszRepoName,
+    const char* pszRpmCacheDir
+    )
+{
+    uint32_t dwError = 0;
+    char *pszPackageUrl = NULL;
+    char *pszPackageFile = NULL;
+    char *pszCopyOfPackageLocation = NULL;
+    int nSize;
+
+    if(!pTdnf ||
+       !pTdnf->pArgs ||
+       IsNullOrEmptyString(pszPackageLocation) ||
+       IsNullOrEmptyString(pszPkgName) ||
+       IsNullOrEmptyString(pszRepoName))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFCreatePackageUrl(pTdnf, pszRepoName, pszPackageLocation, &pszPackageUrl);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFAllocateString(pszPackageLocation,
                                  &pszCopyOfPackageLocation);
@@ -940,7 +974,6 @@ cleanup:
     TDNF_SAFE_FREE_MEMORY(pszPackageUrl);
     TDNF_SAFE_FREE_MEMORY(pszCopyOfPackageLocation);
     TDNF_SAFE_FREE_MEMORY(pszPackageFile);
-    TDNF_SAFE_FREE_MEMORY(pszBaseUrl);
     return dwError;
 
 error:

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -707,9 +707,7 @@ TDNFDownloadFile(
     const char *pszRepo,
     const char *pszFileUrl,
     const char *pszFile,
-    const char *pszProgressData,
-    int is_metalink,
-    TDNF_METALINK_FILE **ml_file
+    const char *pszProgressData
     )
 {
     uint32_t dwError = 0;
@@ -838,12 +836,6 @@ TDNFDownloadFile(
     {
         dwError = rename(pszFileTmp, pszFile);
         BAIL_ON_TDNF_ERROR(dwError);
-
-        if (is_metalink && ml_file)
-        {
-            dwError = TDNFParseAndGetURLFromMetalink(pTdnf, pszRepo, pszFile, ml_file);
-            BAIL_ON_TDNF_ERROR(dwError);
-        }
     }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszUserPass);
@@ -928,9 +920,7 @@ TDNFDownloadPackage(
                                pszRepoName,
                                pszPackageUrl,
                                pszPackageFile,
-                               pszPkgName,
-                               0,
-                               NULL);
+                               pszPkgName);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pr_info("\n");

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -879,6 +879,7 @@ TDNFDownloadPackage(
     char *pszPackageUrl = NULL;
     char *pszPackageFile = NULL;
     char *pszCopyOfPackageLocation = NULL;
+    int nSize;
 
     if(!pTdnf ||
        !pTdnf->pArgs ||
@@ -916,11 +917,21 @@ TDNFDownloadPackage(
                                        basename(pszCopyOfPackageLocation));
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFDownloadFile(pTdnf,
-                               pszRepoName,
-                               pszPackageUrl,
-                               pszPackageFile,
-                               pszPkgName);
+    /* don't download if file is already there. Older versions may have left
+       size 0 files, so check for those too */
+    dwError = TDNFGetFileSize(pszPackageFile, &nSize);
+    if ((dwError == ERROR_TDNF_FILE_NOT_FOUND) || (nSize == 0))
+    {
+        dwError = TDNFDownloadFile(pTdnf,
+                                   pszRepoName,
+                                   pszPackageUrl,
+                                   pszPackageFile,
+                                   pszPkgName);
+    }
+    else
+    {
+        pr_info("%s package already downloaded", pszPkgName);
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     pr_info("\n");

--- a/client/repo.c
+++ b/client/repo.c
@@ -1327,3 +1327,155 @@ cleanup:
 error:
     goto cleanup;
 }
+
+uint32_t
+TDNFDownloadMetadata(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
+    const char *pszRepoDir
+    )
+{
+    uint32_t dwError = 0;
+    char *pszRepoMDUrl = NULL;
+    char *pszRepoMDPath = NULL;
+    char *pszRepoDataDir = NULL;
+    Repo *pSolvRepo = NULL;
+    Pool *pPool = NULL;
+    FILE *fp = NULL;
+
+    dwError = TDNFUtilsMakeDir(pszRepoDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFAllocateStringPrintf(&pszRepoDataDir, "%s/repodata",
+                pszRepoDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFUtilsMakeDir(pszRepoDataDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFAllocateStringPrintf(&pszRepoMDPath, "%s/%s",
+                pszRepoDataDir, TDNF_REPO_METADATA_FILE_NAME);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFAllocateStringPrintf(&pszRepoMDUrl,
+                                       "%s/%s",
+                                       pRepo->pszBaseUrl,
+                                       TDNF_REPO_METADATA_FILE_PATH);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFDownloadFile(pTdnf, pRepo->pszId, pszRepoMDUrl, pszRepoMDPath, pRepo->pszId);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    pPool = pool_create();
+    pSolvRepo = repo_create(pPool, "md_parse_temp");
+
+    fp = fopen(pszRepoMDPath, "r");
+    if(!fp)
+    {
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+    }
+
+    dwError = repo_add_repomdxml(pSolvRepo, fp, 0);
+    if(dwError)
+    {
+        pr_crit("Error(%u) parsing repomd: %s\n",
+                dwError,
+                pool_errstr(pPool));
+    }
+
+    dwError = TDNFDownloadRepoMDParts(pTdnf, pSolvRepo, pRepo, pszRepoDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+cleanup:
+    if (fp)
+    {
+        fclose(fp);
+    }
+    if (pSolvRepo)
+    {
+        repo_free(pSolvRepo, 0);
+    }
+    if (pPool)
+    {
+        pool_free(pPool);
+    }
+    TDNF_SAFE_FREE_MEMORY(pszRepoMDPath);
+    TDNF_SAFE_FREE_MEMORY(pszRepoMDUrl);
+    TDNF_SAFE_FREE_MEMORY(pszRepoDataDir);
+    return dwError;
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFDownloadRepoMDParts(
+    PTDNF pTdnf,
+    Repo *pSolvRepo,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
+    const char *pszDir
+    )
+{
+    uint32_t dwError = 0;
+    Pool *pPool = NULL;
+    Dataiterator di = {0};
+    const char *pszPartFile = NULL;
+    char *pszPartUrl = NULL;
+    char *pszPartPath = NULL;
+
+    if(!pSolvRepo ||
+       !pSolvRepo->pool ||
+       !pRepo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    pPool = pSolvRepo->pool;
+
+    dwError = dataiterator_init(
+                  &di,
+                  pPool,
+                  pSolvRepo,
+                  SOLVID_META,
+                  REPOSITORY_REPOMD_TYPE,
+                  0,
+                  SEARCH_STRING);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dataiterator_prepend_keyname(&di, REPOSITORY_REPOMD);
+
+    while (dataiterator_step(&di))
+    {
+        dataiterator_setpos_parent(&di);
+        pszPartFile = pool_lookup_str(
+                          pPool,
+                          SOLVID_POS,
+                          REPOSITORY_REPOMD_LOCATION);
+
+        dwError = TDNFAllocateStringPrintf(&pszPartUrl,
+                                           "%s/%s",
+                                           pRepo->pszBaseUrl,
+                                           pszPartFile);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFAllocateStringPrintf(&pszPartPath,
+                                           "%s/%s",
+                                           pszDir,
+                                           pszPartFile);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFDownloadFile(pTdnf, pRepo->pszId, pszPartUrl, pszPartPath, pRepo->pszId);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        TDNF_SAFE_FREE_MEMORY(pszPartUrl);
+        TDNF_SAFE_FREE_MEMORY(pszPartPath);
+    }
+
+cleanup:
+    dataiterator_free(&di);
+    return dwError;
+error:
+    goto cleanup;
+}
+

--- a/client/repo.c
+++ b/client/repo.c
@@ -599,7 +599,7 @@ TDNFDownloadUsingMetalinkResources(
             BAIL_ON_TDNF_ERROR(dwError);
         }
         dwError = TDNFDownloadFile(pTdnf, pszRepo, urls->url, pszFile,
-                                   pszProgressData, 0, NULL);
+                                   pszProgressData);
         if (dwError)
         {
             urls = urls->next;
@@ -836,8 +836,11 @@ TDNFGetRepoMD(
                                                TDNF_REPO_BASEURL_FILE_NAME);
             BAIL_ON_TDNF_ERROR(dwError);
             dwError = TDNFDownloadFile(pTdnf, pRepoData->pszId, pszRepoMetalink,
-                                       pszTmpRepoMetalinkFile, pRepoData->pszId,
-                                       metalink, &ml_file);
+                                       pszTmpRepoMetalinkFile, pRepoData->pszId);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            dwError = TDNFParseAndGetURLFromMetalink(pTdnf,
+                        pRepoData->pszId, pszTmpRepoMetalinkFile, &ml_file);
             BAIL_ON_TDNF_ERROR(dwError);
 
             nReplaceRepoMD = 1;
@@ -901,9 +904,7 @@ TDNFGetRepoMD(
                               pRepoData->pszId,
                               pszRepoMDUrl,
                               pszTmpRepoMDFile,
-                              pRepoData->pszId,
-                              0,
-                              NULL);
+                              pRepoData->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
             nReplaceRepoMD = 1;
             if (pszCookie[0])
@@ -1051,9 +1052,7 @@ TDNFDownloadRepoMDPart(
                       pszRepo,
                       pszTempUrl,
                       pszDestPath,
-                      pszRepo,
-                      0,
-                      NULL);
+                      pszRepo);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -576,7 +576,7 @@ TDNFFetchRemoteGPGKey(
     }
 
     dwError = TDNFDownloadFile(pTdnf, pszRepoName, pszUrlGPGKey, pszFilePath,
-                               basename(pszFilePath), 0, NULL);
+                               basename(pszFilePath));
     BAIL_ON_TDNF_ERROR(dwError);
 
     *ppszKeyLocation = pszNormalPath;

--- a/client/structs.h
+++ b/client/structs.h
@@ -118,3 +118,4 @@ typedef struct _TDNF_EVENT_DATA_
     const char *pcszName;
     struct _TDNF_EVENT_DATA_ *pNext;
 }TDNF_EVENT_DATA, *PTDNF_EVENT_DATA;
+

--- a/client/utils.c
+++ b/client/utils.c
@@ -291,6 +291,46 @@ error:
 }
 
 uint32_t
+TDNFGetFileSize(
+    const char* pszPath,
+    int *pnSize
+    )
+{
+    uint32_t dwError = 0;
+    struct stat stStat = {0};
+
+    if(!pnSize || IsNullOrEmptyString(pszPath))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(stat(pszPath, &stStat))
+    {
+        {
+            dwError = errno;
+            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+        }
+    }
+    else
+    {
+        if (S_ISREG(stStat.st_mode))
+        {
+            *pnSize = stStat.st_size;
+        }
+    }
+cleanup:
+    return dwError;
+
+error:
+    if(pnSize)
+    {
+        *pnSize = 0;
+    }
+    goto cleanup;
+}
+
+uint32_t
 TDNFIsDir(
     const char* pszPath,
     int* pnPathIsDir

--- a/client/utils.c
+++ b/client/utils.c
@@ -307,10 +307,8 @@ TDNFGetFileSize(
 
     if(stat(pszPath, &stStat))
     {
-        {
-            dwError = errno;
-            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
-        }
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
     else
     {

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -232,6 +232,12 @@ TDNFRecursivelyRemoveDir(
     const char *pszPath
 );
 
+uint32_t
+TDNFStringMatchesOneOf(
+    const char *pszSearch,
+    char **ppszList,
+    int *pRet);
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/common/structs.h
+++ b/common/structs.h
@@ -32,3 +32,4 @@ typedef uint32_t
     const char *pszKey,
     const char *pszValue
     );
+

--- a/common/utils.c
+++ b/common/utils.c
@@ -731,3 +731,31 @@ cleanup:
 error:
     goto cleanup;
 }
+
+/* search pszSearch in the string ppszList, result will be in pRet */
+uint32_t
+TDNFStringMatchesOneOf(const char *pszSearch, char **ppszList, int *pRet)
+{
+    int i;
+    uint32_t dwError = 0;
+
+    if (IsNullOrEmptyString(pszSearch) || !ppszList || !pRet)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    *pRet = 0;
+    for(i = 0; ppszList[i]; i++)
+    {
+        if (strcmp(pszSearch, ppszList[i]) == 0)
+        {
+            *pRet = 1;
+            goto cleanup;
+        }
+    }
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}

--- a/common/utils.c
+++ b/common/utils.c
@@ -220,6 +220,7 @@ TDNFFreePackageInfoContents(
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszRepoName);
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszVersion);
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszArch);
+        TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszEVR);
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszSummary);
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszURL);
         TDNF_SAFE_FREE_MEMORY(pPkgInfo->pszLicense);

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -113,6 +113,13 @@ TDNFProvides(
     PTDNF_PKG_INFO* ppPkgInfo
     );
 
+//query repo
+uint32_t
+TDNFRepoSync(
+    PTDNF pTdnf,
+    PTDNF_REPOSYNC_ARGS pReposyncArgs
+    );
+
 //Show update info for specified scope
 uint32_t
 TDNFUpdateInfo(

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -122,6 +122,11 @@ TDNFCliRefresh(
     PTDNF_CLI_CONTEXT pContext
 );
 
+void
+TDNFCliFreeRepoSyncArgs(
+    PTDNF_REPOSYNC_ARGS pReposyncArgs
+    );
+
 //Commands
 uint32_t
 TDNFCliAutoEraseCommand(

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -72,6 +72,12 @@ TDNFCliParseRepoListArgs(
     );
 
 uint32_t
+TDNFCliParseRepoSyncArgs(
+    PTDNF_CMD_ARGS pCmdArgs,
+    PTDNF_REPOSYNC_ARGS* ppReposyncArgs
+    );
+
+uint32_t
 TDNFCliParseMode(
     const char* pszOutMode,
     TDNF_UPDATEINFO_OUTPUT* pnOutMode
@@ -185,6 +191,12 @@ TDNFCliMakeCacheCommand(
 
 uint32_t
 TDNFCliProvidesCommand(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_CMD_ARGS pCmdArgs
+    );
+
+uint32_t
+TDNFCliRepoSyncCommand(
     PTDNF_CLI_CONTEXT pContext,
     PTDNF_CMD_ARGS pCmdArgs
     );

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -108,6 +108,12 @@ typedef uint32_t
     );
 
 typedef uint32_t
+(*PFN_TDNF_REPOSYNC)(
+    PTDNF_CLI_CONTEXT,
+    PTDNF_REPOSYNC_ARGS
+    );
+
+typedef uint32_t
 (*PFN_TDNF_RESOLVE)(
     PTDNF_CLI_CONTEXT,
     TDNF_ALTERTYPE,
@@ -148,6 +154,7 @@ typedef struct _TDNF_CLI_CONTEXT_
     PFN_TDNF_LIST               pFnList;
     PFN_TDNF_PROVIDES           pFnProvides;
     PFN_TDNF_REPOLIST           pFnRepoList;
+    PFN_TDNF_REPOSYNC           pFnRepoSync;
     PFN_TDNF_RESOLVE            pFnResolve;
     PFN_TDNF_SEARCH             pFnSearch;
     PFN_TDNF_UPDATEINFO         pFnUpdateInfo;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -340,12 +340,11 @@ typedef struct _TDNF_REPOSYNC_ARGS
     int nGPGCheck;
     int nNewestOnly;
     int nPrintUrlsOnly;
+    int nNoRepoPath;
     char *pszDownloadPath;
     char *pszMetaDataPath;
     char **pszArchs;
 }TDNF_REPOSYNC_ARGS, *PTDNF_REPOSYNC_ARGS;
-
-
 
 #ifdef __cplusplus
 }

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -160,6 +160,7 @@ typedef struct _TDNF_PKG_INFO
     char* pszRepoName;
     char* pszVersion;
     char* pszArch;
+    char* pszEVR;
     char* pszSummary;
     char* pszURL;
     char* pszLicense;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -333,6 +333,8 @@ typedef struct _TDNF_UPDATEINFO_SUMMARY
     int nType;
 }TDNF_UPDATEINFO_SUMMARY, *PTDNF_UPDATEINFO_SUMMARY;
 
+#define TDNF_REPOSYNC_MAXARCHS 10
+
 typedef struct _TDNF_REPOSYNC_ARGS
 {
     int nDelete;
@@ -341,9 +343,10 @@ typedef struct _TDNF_REPOSYNC_ARGS
     int nNewestOnly;
     int nPrintUrlsOnly;
     int nNoRepoPath;
+    int nSourceOnly;
     char *pszDownloadPath;
     char *pszMetaDataPath;
-    char **pszArchs;
+    char **ppszArchs;
 }TDNF_REPOSYNC_ARGS, *PTDNF_REPOSYNC_ARGS;
 
 #ifdef __cplusplus

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -333,6 +333,20 @@ typedef struct _TDNF_UPDATEINFO_SUMMARY
     int nType;
 }TDNF_UPDATEINFO_SUMMARY, *PTDNF_UPDATEINFO_SUMMARY;
 
+typedef struct _TDNF_REPOSYNC_ARGS
+{
+    int nDelete;
+    int nDownloadMetadata;
+    int nGPGCheck;
+    int nNewestOnly;
+    int nPrintUrlsOnly;
+    char *pszDownloadPath;
+    char *pszMetaDataPath;
+    char **pszArchs;
+}TDNF_REPOSYNC_ARGS, *PTDNF_REPOSYNC_ARGS;
+
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -201,9 +201,7 @@ TDNFVerifySignature(
                                pcszRepoId,
                                pszRepoMDSigUrl,
                                pszRepoMDSigFile,
-                               pcszRepoId,
-                               0,
-                               NULL);
+                               pcszRepoId);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFVerifyRepoMDSignature(pHandle, pcszRepoMDFile, pszRepoMDSigFile);

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -241,16 +241,17 @@ class TestUtils(object):
                         '--error-exitcode=1']
         return self._run(memcheck_cmd + cmd, retvalonly=True)
 
-    def run(self, cmd):
+    def run(self, cmd, cwd=None):
         self._decorate_tdnf_cmd_for_test(cmd)
-        return self._run(cmd)
+        return self._run(cmd, cwd=cwd)
 
-    def _run(self, cmd, retvalonly=False):
+    def _run(self, cmd, retvalonly=False, cwd=None):
         use_shell = not isinstance(cmd, list)
         print(cmd)
         process = subprocess.Popen(cmd, shell=use_shell, #nosec
                                    stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
+                                   stderr=subprocess.PIPE,
+                                   cwd=cwd)
         #process.wait()
         out, err = process.communicate()
         if retvalonly:

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -25,6 +25,7 @@ PUBLISH_PATH=${TEST_REPO_DIR}/photon-test
 mkdir -p ${BUILD_PATH}/BUILD \
 	 ${BUILD_PATH}/SRPMS \
 	 ${BUILD_PATH}/RPMS/x86_64 \
+	 ${BUILD_PATH}/RPMS/noarch \
 	 ${PUBLISH_PATH} \
 	 ${TEST_REPO_DIR}/yum.repos.d
 

--- a/pytests/tests/test_downloadonly.py
+++ b/pytests/tests/test_downloadonly.py
@@ -39,7 +39,7 @@ def test_install_download_only(utils):
 # be in specified directory
 def test_install_download_only_to_directory(utils):
     pkgname = utils.config["sglversion_pkgname"]
-    os.makedirs(DOWNLOADDIR)
+    os.makedirs(DOWNLOADDIR, exist_ok=True)
     ret = utils.run([ 'tdnf', 'install', '-y', '--downloadonly', '--downloaddir', DOWNLOADDIR, pkgname])
     print (ret)
     assert(ret['retval']  == 0)

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -1,0 +1,407 @@
+#
+# Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import shutil
+import errno
+import pytest
+
+DOWNLOADDIR='/root/reposync/download'
+METADATADIR='/root/reposync/metadata'
+WORKDIR='/root/reposync/workdir'
+REPOFILENAME='reposync.repo'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    if os.path.isdir(DOWNLOADDIR):
+        shutil.rmtree(DOWNLOADDIR)
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+    if os.path.isdir(METADATADIR):
+        shutil.rmtree(METADATADIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+# helper to create directory tree without complains when it exists:
+def makedirs(d):
+    try:
+        os.makedirs(d)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+# helper to check a synced repo -
+# uses the local repository and compares the list of RPMs
+def check_synced_repo(utils, reponame, synced_dir):
+
+    local_dir = os.path.join(utils.config['repo_path'], reponame, 'RPMS', 'x86_64')
+
+    local_rpms = \
+        list(filter(lambda f: os.path.isfile(os.path.join(local_dir, f)) and f.endswith('.rpm'), \
+            os.listdir(local_dir)))
+
+    # make sure we aren't confused which directory to check
+    assert(len(local_rpms) > 0)
+
+    for rpm in local_rpms:
+        assert(os.path.isfile(os.path.join(synced_dir, 'RPMS', 'x86_64', rpm)))
+
+def create_repoconf(filename, baseurl, name):
+    templ = """
+[{name}]
+name=Test Repo
+baseurl={baseurl}
+enabled=1
+gpgcheck=0
+metadata_expire=86400
+ui_repoid_vars=basearch
+"""
+    with open(filename, "w") as f:
+        f.write(templ.format(name=name, baseurl=baseurl))
+
+# reposync with no options - sync to local directory
+def test_reposync(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    shutil.rmtree(synced_dir)
+
+# reposync with download directory
+def test_reposync_download_path(utils):
+    reponame = 'photon-test'
+    downloaddir = DOWNLOADDIR
+    makedirs(downloaddir)
+    assert(os.path.isdir(downloaddir))
+
+    ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-path={}'.format(downloaddir),
+                     'reposync'])
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(os.path.join(downloaddir, reponame)))
+
+    check_synced_repo(utils, reponame, os.path.join(downloaddir, reponame))
+
+# reposync with download directory with an ending slash
+# (There was a bug about this)
+def test_reposync_download_path_slash(utils):
+    reponame = 'photon-test'
+    downloaddir = DOWNLOADDIR + '/'
+    makedirs(downloaddir)
+    assert(os.path.isdir(downloaddir))
+
+    ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-path={}'.format(downloaddir),
+                     'reposync'])
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(os.path.join(downloaddir, reponame)))
+
+    check_synced_repo(utils, reponame, os.path.join(downloaddir, reponame))
+
+# reposync excluding the repo name from path
+def test_reposync_download_path_norepopath(utils):
+    reponame = 'photon-test'
+    downloaddir = DOWNLOADDIR
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-path={}'.format(downloaddir),
+                     '--norepopath',
+                     'reposync'])
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(downloaddir))
+
+    check_synced_repo(utils, reponame, downloaddir)
+
+# reposync excluding the repo name and delete option is incompatible
+def test_reposync_download_path_norepopath_delete(utils):
+    reponame = 'photon-test'
+    downloaddir = DOWNLOADDIR
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-path={}'.format(downloaddir),
+                     '--norepopath',
+                     '--delete',
+                     'reposync'])
+    assert(ret['retval'] == 1622)
+
+# reposync excluding the repo name and multiple repos is incompatible
+def xxxtest_reposync_download_path_norepopath_multiple_repos(utils):
+    reponame = 'photon-test'
+    downloaddir = DOWNLOADDIR
+    ret = utils.run(['tdnf',
+                     '--download-path={}'.format(downloaddir),
+                     '--norepopath',
+                     'reposync'])
+    assert(ret['retval'] == 1622)
+
+# reposync with metadata
+def test_reposync_metadata(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-metadata',
+                     'reposync'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
+    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    shutil.rmtree(synced_dir)
+
+# reposync with metadata
+def test_reposync_metadata_path(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+    mdatadir = METADATADIR
+    makedirs(mdatadir)
+
+    ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-metadata',
+                     '--metadata-path={}'.format(mdatadir),
+                     'reposync'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+    assert(os.path.isfile(os.path.join(mdatadir, reponame, 'repodata', 'repomd.xml')))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    shutil.rmtree(synced_dir)
+
+# test --delete option
+def test_reposync_delete(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    synced_dir = os.path.join(workdir, reponame)
+    makedirs(synced_dir)
+
+    faked_rpm = os.path.join((synced_dir), 'faked-0.1.2.rpm')
+    with open(faked_rpm, 'w') as f:
+        f.write('fake package')
+
+    assert(os.path.isfile(faked_rpm))
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--delete',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    # file should be gone
+    assert(not os.path.isfile(faked_rpm))
+
+    shutil.rmtree(synced_dir)
+
+# test no --delete option (we should not delete files if not asked to)
+def test_reposync_no_delete(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    synced_dir = os.path.join(workdir, reponame)
+    makedirs(synced_dir)
+
+    faked_rpm = os.path.join((synced_dir), 'faked-0.1.2.rpm')
+    with open(faked_rpm, 'w') as f:
+        f.write('fake package')
+
+    assert(os.path.isfile(faked_rpm))
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    # file should still be there
+    assert(os.path.isfile(faked_rpm))
+
+    shutil.rmtree(synced_dir)
+
+# reposync with gpgcheck
+def test_reposync_gpgcheck(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--gpgcheck',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    shutil.rmtree(synced_dir)
+
+# reposync with --urls option (print only)
+def test_reposync_urls(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--urls',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(not os.path.isdir(synced_dir))
+
+# reposync a repo and install from it
+def test_reposync_create_repo(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--download-metadata',
+                     'reposync'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
+    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    baseurl = "file://{}".format(synced_dir)
+
+    create_repoconf(filename, baseurl, "synced-repo")
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo=synced-repo',
+                     'makecache'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--disablerepo=*', '--enablerepo=synced-repo',
+                     'install', pkgname ],
+                    cwd=workdir)
+    assert(utils.check_package(pkgname) == True)
+
+# reposync with arch option should not sync other archs
+def test_reposync_arch_x86_64(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    synced_dir = os.path.join(workdir, reponame)
+    if os.path.isdir(synced_dir):
+        shutil.rmtree(synced_dir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--arch', 'x86_64',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    assert(not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch')))
+    shutil.rmtree(synced_dir)
+
+
+# reposync with arch option should work for multiple archs
+def test_reposync_arch_x86_64_others(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    synced_dir = os.path.join(workdir, reponame)
+    if os.path.isdir(synced_dir):
+        shutil.rmtree(synced_dir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--arch', 'classic',
+                     '--arch', 'baroque',
+                     '--arch', 'modern',
+                     '--arch', 'x86_64',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(os.path.isdir(synced_dir))
+
+    check_synced_repo(utils, reponame, synced_dir)
+
+    assert(not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch')))
+    shutil.rmtree(synced_dir)
+
+# reposync with --newest-only option - sync to local directory
+def test_reposync_newest(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    makedirs(workdir)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     '--newest-only',
+                     'reposync'],
+                     cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+
+    mulversion_pkgname_found = False
+    for f in os.listdir(os.path.join(synced_dir, 'RPMS', 'x86_64')):
+        if f.startswith(utils.config['mulversion_pkgname']):
+            assert(not utils.config['mulversion_lower'] in f)
+            mulversion_pkgname_found = True
+
+    assert(mulversion_pkgname_found)
+
+    shutil.rmtree(synced_dir)

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -262,7 +262,8 @@ SolvGetNevraFromId(
     char **ppszName,
     char **ppszVersion,
     char **ppszRelease,
-    char **ppszArch
+    char **ppszArch,
+    char **ppszEVR
     );
 
 // tdnfpool.c

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1804,7 +1804,8 @@ SolvGetNevraFromId(
     char **ppszName,
     char **ppszVersion,
     char **ppszRelease,
-    char **ppszArch
+    char **ppszArch,
+    char **ppszEVR
     )
 {
     uint32_t dwError = 0;
@@ -1816,6 +1817,7 @@ SolvGetNevraFromId(
     char *pszVersion = NULL;
     char *pszRelease = NULL;
     char *pszArch = NULL;
+    char *pszEVR = NULL;
 
     if(!pSack ||
        !ppszName ||
@@ -1862,6 +1864,9 @@ SolvGetNevraFromId(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    dwError = TDNFAllocateString(pszTmp, &pszEVR);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = SolvSplitEvr(pSack,
                            pszTmp,
                            &pszEpoch,
@@ -1879,6 +1884,10 @@ SolvGetNevraFromId(
     *ppszVersion = pszVersion;
     *ppszRelease = pszRelease;
     *ppszArch = pszArch;
+    if (ppszEVR)
+    {
+        *ppszEVR = pszEVR;
+    }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszEpoch);
     return dwError;
@@ -1904,9 +1913,14 @@ error:
     {
         *ppszArch = NULL;
     }
+    if(ppszEVR)
+    {
+        *ppszEVR = NULL;
+    }
     TDNF_SAFE_FREE_MEMORY(pszName);
     TDNF_SAFE_FREE_MEMORY(pszVersion);
     TDNF_SAFE_FREE_MEMORY(pszRelease);
     TDNF_SAFE_FREE_MEMORY(pszArch);
+    TDNF_SAFE_FREE_MEMORY(pszEVR);
     goto cleanup;
 }

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -674,36 +674,36 @@ SolvApplyListQuery(
             Pool *pool = pQuery->pSack->pPool;
             if (how == SOLVER_SOLVABLE_ALL)
             {
-               FOR_POOL_SOLVABLES(p)
-               {
-                  if(is_pseudo_package(pool, &pool->solvables[p]))
-                     continue;
-                  queue_push(&queueTmp, p);
-               }
+                FOR_POOL_SOLVABLES(p)
+                {
+                    if(is_pseudo_package(pool, &pool->solvables[p]))
+                        continue;
+                    queue_push(&queueTmp, p);
+                }
             }
             else if (how == SOLVER_SOLVABLE_REPO)
             {
-               Repo *repo = pool_id2repo(pool, what);
-               if (repo)
-               {
-                   Solvable *s = NULL;
+                Repo *repo = pool_id2repo(pool, what);
+                if (repo)
+                {
+                    Solvable *s = NULL;
 
-	           FOR_REPO_SOLVABLES(repo, p, s)
-                   {
-                      if (is_pseudo_package(pool, &pool->solvables[p]))
-                          continue;
-	              queue_push(&queueTmp, p);
-                   }
-	       }
+                    FOR_REPO_SOLVABLES(repo, p, s)
+                    {
+                        if (is_pseudo_package(pool, &pool->solvables[p]))
+                            continue;
+                        queue_push(&queueTmp, p);
+                    }
+                }
             }
             else
             {
-               FOR_JOB_SELECT(p, pp, how, what)
-               {
-                  if (is_pseudo_package(pool, &pool->solvables[p]))
-                      continue;
-	          queue_push(&queueTmp, p);
-               }
+                FOR_JOB_SELECT(p, pp, how, what)
+                {
+                    if (is_pseudo_package(pool, &pool->solvables[p]))
+                        continue;
+                    queue_push(&queueTmp, p);
+                }
             }
             queue_insertn(&pQuery->queueResult,
                           pQuery->queueResult.count,

--- a/tools/cli/lib/CMakeLists.txt
+++ b/tools/cli/lib/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(${LIB_TDNF_CLI} SHARED
     parsecleanargs.c
     parselistargs.c
     parserepolistargs.c
+    parsereposyncargs.c
     parseupdateinfo.c
     updateinfocmd.c
 )

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -476,7 +476,9 @@ TDNFCliRepoSyncCommand(
 
     dwError = pContext->pFnRepoSync(pContext, pReposyncArgs);
     BAIL_ON_CLI_ERROR(dwError);
+
 cleanup:
+    TDNFCliFreeRepoSyncArgs(pReposyncArgs);
     return dwError;
 
 error:

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -457,6 +457,33 @@ error:
 }
 
 uint32_t
+TDNFCliRepoSyncCommand(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_CMD_ARGS pCmdArgs
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_REPOSYNC_ARGS pReposyncArgs;
+
+    if(!pContext || !pContext->hTdnf || !pCmdArgs || !pContext->pFnRepoSync)
+    {
+        dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+
+    dwError = TDNFCliParseRepoSyncArgs(pCmdArgs, &pReposyncArgs);
+    BAIL_ON_CLI_ERROR(dwError);
+
+    dwError = pContext->pFnRepoSync(pContext, pReposyncArgs);
+    BAIL_ON_CLI_ERROR(dwError);
+cleanup:
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+uint32_t
 TDNFCliCheckUpdateCommand(
     PTDNF_CLI_CONTEXT pContext,
     PTDNF_CMD_ARGS pCmdArgs

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -60,6 +60,19 @@ TDNFCliShowHelp(
     pr_crit("           [--disableexcludes]\n");
     pr_crit("           [--downloadonly]\n");
     pr_crit("           [--downloaddir=<directory>]\n");
+    pr_crit("\n");
+    pr_crit("reposync options:\n");
+    pr_crit("           [--arch=<arch> [--arch=<arch> [..]]\n");
+    pr_crit("           [--delete]\n");
+    pr_crit("           [--download-path=<directory>]\n");
+    pr_crit("           [--download-metadata]\n");
+    pr_crit("           [--gpgcheck]\n");
+    pr_crit("           [--metadata-path=<directory>]\n");
+    pr_crit("           [--newest-only]\n");
+    pr_crit("           [--norepopath]\n");
+    pr_crit("           [--source]\n");
+    pr_crit("           [--urls]\n");
+    pr_crit("\n");
 
     pr_crit("List of Main Commands\n");
     pr_crit("\n");
@@ -79,6 +92,7 @@ TDNFCliShowHelp(
     pr_crit("remove                    Remove a package or packages from your system\n");
     pr_crit("reinstall                 reinstall a package\n");
     pr_crit("repolist                  Display the configured software repositories\n");
+    pr_crit("reposync                  Download all packages from one or more repositories to a directory\n");
     pr_crit("search                    Search package details for the given string\n");
     pr_crit("update                    Upgrade a package or packages on your system (same as 'upgrade')\n");
     pr_crit("updateinfo                Display advisories about packages\n");

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -36,7 +36,7 @@ static SetOptArgs OptValTable[] = {
     {CMDOPT_DISABLEPLUGIN, "disableplugin", NULL},
     {CMDOPT_KEYVALUE, "skipconflicts;skipobsoletes;skipsignature;skipdigest;"
                       "noplugins;reboot-required;security;"
-                      "delete;download-metadata;gpgcheck;newest-only;norepopath;urls",
+                      "delete;download-metadata;gpgcheck;newest-only;norepopath;source;urls",
                       "1"}
 };
 
@@ -92,6 +92,7 @@ static struct option pstOptions[] =
     {"newest-only",   no_argument, 0, 0},
     {"norepopath",    no_argument, 0, 0},
     {"download-path", required_argument, 0, 0},
+    {"source",        no_argument, 0, 0},
     {"urls",          no_argument, 0, 0},
     {0, 0, 0, 0}
 };
@@ -329,7 +330,8 @@ ParseOption(
         dwError = TDNFAllocateString(optarg, &pCmdArgs->pszReleaseVer);
     }
     else if ((!strcasecmp(pszName, "metadata-path")) ||
-             (!strcasecmp(pszName, "download-path")))
+             (!strcasecmp(pszName, "download-path")) ||
+             (!strcasecmp(pszName, "arch")))
     {
         dwError = AddSetOptWithValues(pCmdArgs,
                             CMDOPT_KEYVALUE,

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -36,7 +36,7 @@ static SetOptArgs OptValTable[] = {
     {CMDOPT_DISABLEPLUGIN, "disableplugin", NULL},
     {CMDOPT_KEYVALUE, "skipconflicts;skipobsoletes;skipsignature;skipdigest;"
                       "noplugins;reboot-required;security;"
-                      "delete;download-metadata;gpgcheck;newest-only;urls",
+                      "delete;download-metadata;gpgcheck;newest-only;norepopath;urls",
                       "1"}
 };
 
@@ -84,14 +84,15 @@ static struct option pstOptions[] =
     {"downloadonly",  no_argument, &_opt.nDownloadOnly, 1}, //--downloadonly
     {"downloaddir",   required_argument, 0, 0},            //--downloaddir
     // reposync options
-    {"arch",          required_argument, 0, 'a'},
+    {"arch",          required_argument, 0, 0},
     {"delete",        no_argument, 0, 0},
     {"download-metadata", no_argument, 0, 0},
-    {"gpgcheck", no_argument, 0, 'g'},
+    {"gpgcheck", no_argument, 0, 0},
     {"metadata-path", required_argument, 0, 0},
-    {"newest-only",   no_argument, 0, 'n'},
+    {"newest-only",   no_argument, 0, 0},
+    {"norepopath",    no_argument, 0, 0},
     {"download-path", required_argument, 0, 0},
-    {"urls",          no_argument, 0, 'u'},
+    {"urls",          no_argument, 0, 0},
     {0, 0, 0, 0}
 };
 

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -34,7 +34,10 @@ static SetOptArgs OptValTable[] = {
     {CMDOPT_DISABLEREPO, "disablerepo", NULL},
     {CMDOPT_ENABLEPLUGIN, "enableplugin", NULL},
     {CMDOPT_DISABLEPLUGIN, "disableplugin", NULL},
-    {CMDOPT_KEYVALUE, "skipconflicts;skipobsoletes;skipsignature;skipdigest;noplugins;reboot-required;security", "1"}
+    {CMDOPT_KEYVALUE, "skipconflicts;skipobsoletes;skipsignature;skipdigest;"
+                      "noplugins;reboot-required;security;"
+                      "delete;download-metadata;gpgcheck;newest-only;urls",
+                      "1"}
 };
 
 static TDNF_CMD_ARGS _opt = {0};
@@ -80,6 +83,15 @@ static struct option pstOptions[] =
     {"disableexcludes", no_argument, &_opt.nDisableExcludes, 1}, //--disableexcludes
     {"downloadonly",  no_argument, &_opt.nDownloadOnly, 1}, //--downloadonly
     {"downloaddir",   required_argument, 0, 0},            //--downloaddir
+    // reposync options
+    {"arch",          required_argument, 0, 'a'},
+    {"delete",        no_argument, 0, 0},
+    {"download-metadata", no_argument, 0, 0},
+    {"gpgcheck", no_argument, 0, 'g'},
+    {"metadata-path", required_argument, 0, 0},
+    {"newest-only",   no_argument, 0, 'n'},
+    {"download-path", required_argument, 0, 0},
+    {"urls",          no_argument, 0, 'u'},
     {0, 0, 0, 0}
 };
 
@@ -314,6 +326,15 @@ ParseOption(
     else if (!strcasecmp(pszName, "releasever"))
     {
         dwError = TDNFAllocateString(optarg, &pCmdArgs->pszReleaseVer);
+    }
+    else if ((!strcasecmp(pszName, "metadata-path")) ||
+             (!strcasecmp(pszName, "download-path")))
+    {
+        dwError = AddSetOptWithValues(pCmdArgs,
+                            CMDOPT_KEYVALUE,
+                            pszName,
+                            optarg);
+        BAIL_ON_CLI_ERROR(dwError);
     }
     else if (!strcasecmp(pszName, "setopt"))
     {

--- a/tools/cli/lib/parsereposyncargs.c
+++ b/tools/cli/lib/parsereposyncargs.c
@@ -28,6 +28,12 @@ TDNFCliParseRepoSyncArgs(
     PTDNF_REPOSYNC_ARGS pReposyncArgs = NULL;
     PTDNF_CMD_OPT pSetOpt = NULL;
 
+    if (!pArgs || !ppReposyncArgs)
+    {
+        dwError = ERROR_TDNF_CLI_INVALID_ARGUMENT;
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+
     dwError = TDNFAllocateMemory(
         1,
         sizeof(TDNF_REPOSYNC_ARGS),

--- a/tools/cli/lib/parsereposyncargs.c
+++ b/tools/cli/lib/parsereposyncargs.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+/*
+ * Module   : parsereposyncargs.c
+ *
+ * Abstract :
+ *
+ *            tdnf
+ *
+ *            command line tools
+ */
+
+#include "includes.h"
+
+uint32_t
+TDNFCliParseRepoSyncArgs(
+    PTDNF_CMD_ARGS pArgs,
+    PTDNF_REPOSYNC_ARGS* ppReposyncArgs
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_REPOSYNC_ARGS pReposyncArgs = NULL;
+    PTDNF_CMD_OPT pSetOpt = NULL;
+
+    dwError = TDNFAllocateMemory(
+        1,
+        sizeof(TDNF_REPOSYNC_ARGS),
+        (void**) &pReposyncArgs);
+    BAIL_ON_CLI_ERROR(dwError);
+
+    for (pSetOpt = pArgs->pSetOpt;
+         pSetOpt;
+         pSetOpt = pSetOpt->pNext)
+    {
+        if(pSetOpt->nType == CMDOPT_KEYVALUE)
+        {
+            if (strcasecmp(pSetOpt->pszOptName, "delete") == 0)
+            {
+                pReposyncArgs->nDelete = 1;
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "download-metadata") == 0)
+            {
+                pReposyncArgs->nDownloadMetadata = 1;
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "gpgcheck") == 0)
+            {
+                pReposyncArgs->nGPGCheck = 1;
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "newest-only") == 0)
+            {
+                pReposyncArgs->nNewestOnly = 1;
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "urls") == 0)
+            {
+                pReposyncArgs->nPrintUrlsOnly = 1;
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "download-path") == 0)
+            {
+                dwError = TDNFAllocateString(
+                    pSetOpt->pszOptValue,
+                    &pReposyncArgs->pszDownloadPath);
+                BAIL_ON_CLI_ERROR(dwError);
+            }
+            else if (strcasecmp(pSetOpt->pszOptName, "metadata-path") == 0)
+            {
+                dwError = TDNFAllocateString(
+                    pSetOpt->pszOptValue,
+                    &pReposyncArgs->pszMetaDataPath);
+                BAIL_ON_CLI_ERROR(dwError);
+            }
+        }
+    }
+    *ppReposyncArgs = pReposyncArgs;
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}
+

--- a/tools/cli/lib/parsereposyncargs.c
+++ b/tools/cli/lib/parsereposyncargs.c
@@ -56,6 +56,10 @@ TDNFCliParseRepoSyncArgs(
             {
                 pReposyncArgs->nNewestOnly = 1;
             }
+            else if (strcasecmp(pSetOpt->pszOptName, "norepopath") == 0)
+            {
+                pReposyncArgs->nNoRepoPath = 1;
+            }
             else if (strcasecmp(pSetOpt->pszOptName, "urls") == 0)
             {
                 pReposyncArgs->nPrintUrlsOnly = 1;

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -56,7 +56,6 @@ int main(int argc, char* argv[])
         {"remove",             TDNFCliEraseCommand},
         {"repolist",           TDNFCliRepoListCommand},
         {"reposync",           TDNFCliRepoSyncCommand},
-        {"provides",           TDNFCliProvidesCommand},
         {"search",             TDNFCliSearchCommand},
         {"update",             TDNFCliUpgradeCommand},
         {"update-to",          TDNFCliUpgradeCommand},

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -55,6 +55,8 @@ int main(int argc, char* argv[])
         {"reinstall",          TDNFCliReinstallCommand},
         {"remove",             TDNFCliEraseCommand},
         {"repolist",           TDNFCliRepoListCommand},
+        {"reposync",           TDNFCliRepoSyncCommand},
+        {"provides",           TDNFCliProvidesCommand},
         {"search",             TDNFCliSearchCommand},
         {"update",             TDNFCliUpgradeCommand},
         {"update-to",          TDNFCliUpgradeCommand},
@@ -102,6 +104,7 @@ int main(int argc, char* argv[])
     _context.pFnList = TDNFCliInvokeList;
     _context.pFnProvides = TDNFCliInvokeProvides;
     _context.pFnRepoList = TDNFCliInvokeRepoList;
+    _context.pFnRepoSync = TDNFCliInvokeRepoSync;
 
     /*
      * Alter and resolve will address commands like
@@ -442,6 +445,15 @@ TDNFCliInvokeRepoList(
     )
 {
     return TDNFRepoList(pContext->hTdnf, nFilter, ppRepos);
+}
+
+uint32_t
+TDNFCliInvokeRepoSync(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_REPOSYNC_ARGS pRepoSyncArgs
+    )
+{
+    return TDNFRepoSync(pContext->hTdnf, pRepoSyncArgs);
 }
 
 uint32_t

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -92,6 +92,12 @@ TDNFCliInvokeRepoList(
     );
 
 uint32_t
+TDNFCliInvokeRepoSync(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_REPOSYNC_ARGS pReposyncArgs
+    );
+
+uint32_t
 TDNFCliInvokeResolve(
     PTDNF_CLI_CONTEXT pContext,
     TDNF_ALTERTYPE nAlterType,
@@ -299,6 +305,13 @@ uint32_t
 TDNFCliParseRepoListArgs(
     PTDNF_CMD_ARGS pCmdArgs,
     TDNF_REPOLISTFILTER* pnFilter
+    );
+
+//parsereposyncargs.c
+uint32_t
+TDNFCliParseRepoSyncArgs(
+    PTDNF_CMD_ARGS pCmdArgs,
+    PTDNF_REPOSYNC_ARGS* ppReposyncArgs
     );
 
 //parseupdateinfo.c


### PR DESCRIPTION
This adds the "reposync" feature. This synchronizes a remote repository with a local one. By default, all packages will be downloaded to a local directory, unless they already exist. Optionally, metadata will be downloaded as well.

These options are implemented:
* `--delete`: remove old package that are not part of the repository any more
* `--download-metadata`: download metadata as well. The directory can be used as a repository after download.
* `--gpgcheck`: check the gpg signature. If invalid, the package will be deleted.
* `--norepopath`: no subdirectory with the repo name will be created. This option is only valid if there is more than one repository configured. It is also incompatible with the `--delete` option to prevent accidentally deleting unrelated packages.
* `--urls`: instead of downloading, the URLs of all files will be printed to `stdout`.
* `--download-path`: by default, files will be downloaded relative to the current directory. With this option another directory can be specified.
* `--metadata-path`: download metadata to another directory
* `--arch`: download specific architectures (can be given repeatedly)
* `--source`: download only source packages, same as `--arch src`. Incompatible with the `--arch` option. 
*  `--newest-only`: download latest versions only

The dnf reposync plugin has three more options that are not yet implemented in this PR: `--newest`, `--arch` and `--source`. These will be implemented in another PR.

Simple example usage, syncing a single repo:

`tdnf --disablerepo=* --enablerepo=photon-release reposync`

Explanation of changes (to help reviewers):

The main driver of the feature is the `TDNFRepoSync()` function in `client/api.c`. The function first generates a list of packages, this is very similar to `TDNFInfo()` and `TDNFList()`. 




