### PR TITLE
fix segfault when no key is set in repo config

### DIFF
--- a/client/repo.c
+++ b/client/repo.c
@@ -380,7 +380,8 @@ TDNFGetGPGSignatureCheck(
             nGPGSigCheck = 1;
             if (pppszUrlGPGKeys != NULL)
             {
-                if (IsNullOrEmptyString(pRepo->ppszUrlGPGKeys[0]))
+                if (pRepo->ppszUrlGPGKeys == NULL ||
+                    IsNullOrEmptyString(pRepo->ppszUrlGPGKeys[0]))
                 {
                     dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
                     BAIL_ON_TDNF_ERROR(dwError);

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -116,3 +116,12 @@ def test_install_remote_key_no_traversal2(utils):
     ret = utils.run([ 'tdnf', 'install', '-y', pkgname])
     assert(ret['retval']  != 0)
 
+# test with gpgcheck enabled but no key entry, expect fail
+def test_install_nokey(utils):
+    set_gpgcheck(utils, True)
+    set_repo_key(utils, None)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run([ 'tdnf', 'install', '-y', pkgname])
+    assert(ret['retval']  == 1523)
+    assert(not utils.check_package(pkgname))
+


### PR DESCRIPTION
When gpgcheck is enabled but no key in the repo is configured tdnf crashes with a segfault. Fixing this, and adding a test to catch this error.

Example:
```
[docker-ce-stable]
name=Docker CE Stable - $basearch
baseurl=https://download.docker.com/linux/centos/8/$basearch/stable
enabled=1
gpgcheck=1
#gpgkey=https://download.docker.com/linux/centos/gpg
```