### PR TITLE
Fix unnecessary meta data refresh when installing

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -166,8 +166,6 @@ TDNFAlterCommand(
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
-    dwError = TDNFRefresh(pTdnf);
-    BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFRpmExecTransaction(pTdnf, pSolvedInfo, nAlterType);
     BAIL_ON_TDNF_ERROR(dwError);


### PR DESCRIPTION
When installing a package using the `--refresh` option, `TDNFRefresh` was called twice. Thanks to @keerthanakalyan to point it out.
```
root [ / ]# tdnf install rpm-devel --refresh
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64) Updates'
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Extras 4.0 (x86_64)'
Refreshing metadata for: 'docker'         2962   100%
docker                                    3081   100%
Installing:
zstd-devel                                                             x86_64                              1.4.5-2.ph4                                     photon                                       152.83k 156503
rpm-devel                                                              x86_64                              4.16.1.2-4.ph4                                  photon-updates                               288.72k 295652
Total installed size: 441.56k 452155
Upgrading:
rpm-libs                                                               x86_64                              4.16.1.2-4.ph4                                  photon-updates                               774.13k 792705
rpm                                                                    x86_64                              4.16.1.2-4.ph4                                  photon-updates                               417.72k 427745
Total installed size:   1.16M 1220450
Is this ok [y/N]: y
Downloading:
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64) Updates'
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64)'
Refreshing metadata for: 'VMware Photon Extras 4.0 (x86_64)'
Refreshing metadata for: 'docker'         2962   100%
zstd-devel                               40562   100%
rpm-devel                                82055   100%
rpm-libs                                321499   100%
rpm                                      85843   100%
Testing transaction
...
```

The second call is invoked rom`TDNFAlterCommand()`, but this is not needed (and won't help) because we already called it in `TDNFResolv()`.

