### PR TITLE
add photon 3.0 to ci tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,21 @@ jobs:
               working-directory: ${{ github.workspace }}
               run: |
                 docker run --security-opt seccomp:unconfined --rm -e DIST -v$(pwd):/build -w/build ${DIST}/tdnf-build ./ci/docker-entrypoint.sh
+    photon-3:
+        env:
+            DIST: photon
+            DIST_VERSION: '3.0'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: build container
+              working-directory: ${{ github.workspace }}
+              run: |
+                docker build -t ${DIST}/tdnf-build:${DIST_VERSION} -f ci/Dockerfile.${DIST}-${DIST_VERSION} .
+            - name: run container with tests
+              working-directory: ${{ github.workspace }}
+              run: |
+                docker run --security-opt seccomp:unconfined --rm -e DIST -v$(pwd):/build -w/build ${DIST}/tdnf-build:${DIST_VERSION} ./ci/docker-entrypoint.sh
     fedora:
         env:
             DIST: fedora

--- a/ci/Dockerfile.photon-3.0
+++ b/ci/Dockerfile.photon-3.0
@@ -1,0 +1,17 @@
+FROM photon:3.0
+
+MAINTAINER okurth@vmware.com
+
+RUN tdnf update  -q -y
+RUN tdnf remove  -q -y toybox
+RUN tdnf install -q -y --enablerepo=photon-debuginfo \
+                       build-essential cmake curl-devel rpm-build libsolv-devel \
+                       popt-devel sed createrepo_c glib libxml2 findutils \
+                       python3 python3-pip python3-setuptools python3-devel \
+                       valgrind gpgme-devel glibc-debuginfo libmetalink-devel \
+                       openssl-devel which
+
+# python build/test dependencies
+RUN pip3 install -q requests urllib3 pyOpenSSL pytest
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
Might be a good idea to test in Photon 3 since latest tdnf is in Photon 3, and Photon 4 uses another libsolv version now.