### PR TITLE
set repo expiry to two days as intended and add macros for other repo…

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -110,7 +110,8 @@ typedef enum
 #define TDNF_REPO_METADATA_FILE_NAME      "repomd.xml"
 #define TDNF_REPO_METALINK_FILE_NAME      "metalink"
 #define TDNF_REPO_BASEURL_FILE_NAME       "baseurl"
-//Repo defaults
+
+// repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
 #define TDNF_DEFAULT_CACHE_LOCATION       "/var/cache/tdnf"
 #define TDNF_DEFAULT_DISTROVERPKG         "system-release"
@@ -118,9 +119,21 @@ typedef enum
 #define TDNF_RPM_CACHE_DIR_NAME           "rpms"
 #define TDNF_REPODATA_DIR_NAME            "repodata"
 #define TDNF_SOLVCACHE_DIR_NAME           "solvcache"
-#define TDNF_REPO_DEFAULT_METADATA_EXPIRE "8294400"//48 hours in seconds
 #define TDNF_REPO_METADATA_EXPIRE_NEVER   "never"
-//var names
+
+// repo default settings
+#define TDNF_REPO_DEFAULT_ENABLED         0
+#define TDNF_REPO_DEFAULT_SKIP            0
+#define TDNF_REPO_DEFAULT_GPGCHECK        1
+#define TDNF_REPO_DEFAULT_MINRATE         0
+#define TDNF_REPO_DEFAULT_THROTTLE        0
+#define TDNF_REPO_DEFAULT_TIMEOUT         0
+#define TDNF_REPO_DEFAULT_SSLVERIFY       1
+#define TDNF_REPO_DEFAULT_RETRIES         10
+#define TDNF_REPO_DEFAULT_PRIORITY        50
+#define TDNF_REPO_DEFAULT_METADATA_EXPIRE "172800" // 48 hours in seconds
+
+// var names
 #define TDNF_VAR_RELEASEVER               "$releasever"
 #define TDNF_VAR_BASEARCH                 "$basearch"
 /* dummy setopt values */

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -275,7 +275,7 @@ TDNFLoadReposFromFile(
         dwError = TDNFReadKeyValueBoolean(
                       pSections,
                       TDNF_REPO_KEY_ENABLED,
-                      0,
+                      TDNF_REPO_DEFAULT_ENABLED,
                       &pRepo->nEnabled);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -303,14 +303,14 @@ TDNFLoadReposFromFile(
         dwError = TDNFReadKeyValueBoolean(
                       pSections,
                       TDNF_REPO_KEY_SKIP,
-                      1,
+                      TDNF_REPO_DEFAULT_SKIP,
                       &pRepo->nSkipIfUnavailable);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueBoolean(
                       pSections,
                       TDNF_REPO_KEY_GPGCHECK,
-                      1,
+                      TDNF_REPO_DEFAULT_GPGCHECK,
                       &pRepo->nGPGCheck);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -337,42 +337,42 @@ TDNFLoadReposFromFile(
         dwError = TDNFReadKeyValueInt(
                       pSections,
                       TDNF_REPO_KEY_PRIORITY,
-                      50,
+                      TDNF_REPO_DEFAULT_PRIORITY,
                       &pRepo->nPriority);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueInt(
                       pSections,
                       TDNF_REPO_KEY_TIMEOUT,
-                      0,
+                      TDNF_REPO_DEFAULT_TIMEOUT,
                       &pRepo->nTimeout);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueInt(
                       pSections,
                       TDNF_REPO_KEY_RETRIES,
-                      10,
+                      TDNF_REPO_DEFAULT_RETRIES,
                       &pRepo->nRetries);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueInt(
                       pSections,
                       TDNF_REPO_KEY_MINRATE,
-                      0,
+                      TDNF_REPO_DEFAULT_MINRATE,
                       &pRepo->nMinrate);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueInt(
                       pSections,
                       TDNF_REPO_KEY_THROTTLE,
-                      0,
+                      TDNF_REPO_DEFAULT_THROTTLE,
                       &pRepo->nThrottle);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadKeyValueBoolean(
                       pSections,
                       TDNF_REPO_KEY_SSL_VERIFY,
-                      1,
+                      TDNF_REPO_DEFAULT_SSLVERIFY,
                       &pRepo->nSSLVerify);
         BAIL_ON_TDNF_ERROR(dwError);
 


### PR DESCRIPTION
The default repo expiry duration was set to 8294400 seconds, which is 96 days and not 48 hours as was intended as indicated in the comment. This is also the default in Fedora's dnf. Setting this to 172800 seconds (equal to 48 hours).

Also adding macros for other default repo configuration values. There is no intention to change the defaults other than the expiry duration.