### PR TITLE
add --repoid/--repo and --repofrompath options

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -812,7 +812,7 @@ TDNFAddCmdLinePackages(
                                pTdnf,
                                pszPkgName,
                                basename(pszCopyOfPkgName),
-                               "@cmdline",
+                               CMDLINE_REPO_NAME,
                                &pszRPMPath
                            );
                  BAIL_ON_TDNF_ERROR(dwError);
@@ -1063,7 +1063,7 @@ TDNFRepoSync(
     /* count enabled repos */
     for (pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
     {
-        if ((strcmp(pRepo->pszName, "@cmdline") == 0) ||
+        if ((strcmp(pRepo->pszName, CMDLINE_REPO_NAME) == 0) ||
             (!pRepo->nEnabled))
         {
             continue;
@@ -1250,7 +1250,7 @@ TDNFRepoSync(
            marker file */
         for (pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
         {
-            if ((strcmp(pRepo->pszName, "@cmdline") == 0) ||
+            if ((strcmp(pRepo->pszName, CMDLINE_REPO_NAME) == 0) ||
                 (!pRepo->nEnabled))
             {
                 continue;
@@ -1280,7 +1280,7 @@ TDNFRepoSync(
     {
         for (pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
         {
-            if ((strcmp(pRepo->pszName, "@cmdline") == 0) ||
+            if ((strcmp(pRepo->pszName, CMDLINE_REPO_NAME) == 0) ||
                 (!pRepo->nEnabled))
             {
                 continue;

--- a/client/defines.h
+++ b/client/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -48,6 +48,8 @@ typedef enum
             goto error;                                            \
         }                                                          \
     } while(0)
+
+#define STR_IS_TRUE(s) ((s) && (!strcmp((s), "1") || !strcasecmp((s), "true")))
 
 //Misc
 #define TDNF_RPM_EXT                      ".rpm"
@@ -136,7 +138,8 @@ typedef enum
 #define TDNF_REPO_DEFAULT_SSLVERIFY       1
 #define TDNF_REPO_DEFAULT_RETRIES         10
 #define TDNF_REPO_DEFAULT_PRIORITY        50
-#define TDNF_REPO_DEFAULT_METADATA_EXPIRE "172800" // 48 hours in seconds
+#define TDNF_REPO_DEFAULT_METADATA_EXPIRE 172800 // 48 hours in seconds
+#define TDNF_REPO_DEFAULT_METADATA_EXPIRE_STR STRINGIFYX(TDNF_REPO_DEFAULT_METADATA_EXPIRE)
 
 // var names
 #define TDNF_VAR_RELEASEVER               "$releasever"

--- a/client/init.c
+++ b/client/init.c
@@ -254,7 +254,7 @@ TDNFRefreshSack(
     {
         /* skip the @cmdline repo - options do not apply, and it is
            initialized. */
-        if ((strcmp(pRepo->pszName, "@cmdline") == 0) ||
+        if ((strcmp(pRepo->pszName, CMDLINE_REPO_NAME) == 0) ||
             (!pRepo->nEnabled))
         {
             continue;
@@ -271,7 +271,7 @@ TDNFRefreshSack(
 
         for(pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
         {
-            if ((strcmp(pRepo->pszName, "@cmdline") == 0) ||
+            if ((strcmp(pRepo->pszName, CMDLINE_REPO_NAME) == 0) ||
                 (!pRepo->nEnabled))
             {
                 continue;

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -754,6 +754,19 @@ TDNFCreateCmdLineRepo(
     );
 
 uint32_t
+TDNFCreateRepoFromPath(
+    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    const char *pzsId,
+    const char *pszPath
+    );
+
+uint32_t
+TDNFCreateRepo(
+    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    const char *pszId
+    );
+
+uint32_t
 TDNFLoadRepoData(
     PTDNF pTdnf,
     TDNF_REPOLISTFILTER nFilter,

--- a/client/repo.c
+++ b/client/repo.c
@@ -195,7 +195,7 @@ TDNFInitCmdLineRepo(
                   (void**)&pSolvRepoInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    pRepo = repo_create(pPool, "@cmdline");
+    pRepo = repo_create(pPool, CMDLINE_REPO_NAME);
     if (!pRepo)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;

--- a/common/defines.h
+++ b/common/defines.h
@@ -20,6 +20,9 @@
 
 #pragma once
 
+#define STRINGIFYX(N) STRINGIFY(N)
+#define STRINGIFY(N) #N
+
 #define MAX_CONFIG_LINE_LENGTH      1024
 
 #define TDNF_SAFE_FREE_PKGINFO(pPkgInfo) \

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -274,6 +274,13 @@ class TestUtils(object):
         ret['retval'] = retval
         return ret
 
+    # helper to create directory tree without complains when it exists:
+    def makedirs(self, d):
+        try:
+            os.makedirs(d)
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
 
 @pytest.fixture(scope='session')
 def utils():

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -282,6 +282,19 @@ class TestUtils(object):
             if e.errno != errno.EEXIST:
                 raise
 
+    def create_repoconf(self, filename, baseurl, name):
+        templ = """
+[{name}]
+name=Test Repo
+baseurl={baseurl}
+enabled=1
+gpgcheck=0
+metadata_expire=86400
+ui_repoid_vars=basearch
+"""
+        with open(filename, "w") as f:
+            f.write(templ.format(name=name, baseurl=baseurl))
+
 @pytest.fixture(scope='session')
 def utils():
     test_utils = TestUtils()

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -97,26 +97,13 @@ def test_makecache(utils):
 
     shutil.rmtree(INSTALLROOT)
 
-def create_repoconf(filename, baseurl, name):
-    templ = """
-[{name}]
-name=Test Repo
-baseurl={baseurl}
-enabled=1
-gpgcheck=0
-metadata_expire=86400
-ui_repoid_vars=basearch
-"""
-    with open(filename, "w") as f:
-        f.write(templ.format(name=name, baseurl=baseurl))
-
 # --setopt=reposdir overrides any dir in install root
 def test_setopt_reposdir_with_installroot(utils):
     install_root(utils)
     utils.makedirs(REPODIR)
-    create_repoconf(os.path.join(REPODIR, REPOFILENAME),
-                    "http://foo.bar.com/packages",
-                    REPONAME)
+    utils.create_repoconf(os.path.join(REPODIR, REPOFILENAME),
+                          "http://foo.bar.com/packages",
+                          REPONAME)
     ret = utils.run(['tdnf',
                      '--installroot', INSTALLROOT,
                      '--releasever=4.0',

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -28,17 +28,9 @@ def teardown_test(utils):
         shutil.rmtree(INSTALLROOT)
     pass
 
-# helper to create directory tree without complains when it exists:
-def makedirs(d):
-    try:
-        os.makedirs(d)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-
 def install_root(utils, no_reposd=False):
-    makedirs(INSTALLROOT)
-    makedirs(os.path.join(INSTALLROOT, 'etc/tdnf'))
+    utils.makedirs(INSTALLROOT)
+    utils.makedirs(os.path.join(INSTALLROOT, 'etc/tdnf'))
     conffile = os.path.join(utils.config['repo_path'], 'tdnf.conf')
 
     # remove special settings for repodir and cachedir
@@ -50,10 +42,10 @@ def install_root(utils, no_reposd=False):
                     fout.write(line)
 
     if not no_reposd:
-        makedirs(os.path.join(INSTALLROOT, 'etc/yum.repos.d'))
+        utils.makedirs(os.path.join(INSTALLROOT, 'etc/yum.repos.d'))
         repofile = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
         shutil.copyfile(repofile, os.path.join(INSTALLROOT, 'etc/yum.repos.d', REPOFILENAME))
-    makedirs(os.path.join(INSTALLROOT, 'var/cache/tdnf'))
+    utils.makedirs(os.path.join(INSTALLROOT, 'var/cache/tdnf'))
     utils.run(['rpm', '--root', INSTALLROOT, '--initdb'])
 
 # local version of check_package with install root
@@ -121,7 +113,7 @@ ui_repoid_vars=basearch
 # --setopt=reposdir overrides any dir in install root
 def test_setopt_reposdir_with_installroot(utils):
     install_root(utils)
-    makedirs(REPODIR)
+    utils.makedirs(REPODIR)
     create_repoconf(os.path.join(REPODIR, REPOFILENAME),
                     "http://foo.bar.com/packages",
                     REPONAME)

--- a/pytests/tests/test_repofrompath.py
+++ b/pytests/tests/test_repofrompath.py
@@ -1,0 +1,69 @@
+#
+# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import shutil
+import pytest
+import errno
+
+REPODIR='/root/repofrompath/yum.repos.d'
+REPOFILENAME='repofrompath.repo'
+REPONAME="repofrompath-test"
+WORKDIR='/root/repofrompath/workdir'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    if os.path.isdir(REPODIR):
+        shutil.rmtree(REPODIR)
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+# reposync a repo and install from it
+def test_repofrompath_created_repo(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    utils.makedirs(workdir)
+
+    ret = utils.run(['tdnf', '--repo={}'.format(reponame),
+                     '--download-metadata',
+                     'reposync'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
+    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+
+    baseurl = "file://{}".format(synced_dir)
+
+    ret = utils.run(['tdnf',
+                     '--repofrompath=synced-repo,{}'.format(synced_dir),
+                     '--repo=synced-repo',
+                     'makecache'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--repofrompath=synced-repo,{}'.format(synced_dir),
+                     '--repo=synced-repo',
+                     'install', pkgname ],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(utils.check_package(pkgname) == True)
+

--- a/pytests/tests/test_repoid.py
+++ b/pytests/tests/test_repoid.py
@@ -1,0 +1,82 @@
+#
+# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import shutil
+import pytest
+import errno
+
+REPODIR='/root/repoid/yum.repos.d'
+REPOFILENAME='repoid.repo'
+REPONAME="repoid-test"
+WORKDIR='/root/repoid/workdir'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    if os.path.isdir(REPODIR):
+        shutil.rmtree(REPODIR)
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+def test_repoid(utils):
+    utils.makedirs(REPODIR)
+    utils.create_repoconf(os.path.join(REPODIR, REPOFILENAME),
+                          "http://foo.bar.com/packages",
+                          REPONAME)
+    ret = utils.run(['tdnf',
+        '--setopt=reposdir={}'.format(REPODIR),
+        '--repoid={}'.format(REPONAME),
+        'repolist'])
+    assert(ret['retval'] == 0)
+    assert(REPONAME in "\n".join(ret['stdout']))
+
+# reposync a repo and install from it
+def test_repoid_created_repo(utils):
+    reponame = 'photon-test'
+    workdir = WORKDIR
+    utils.makedirs(workdir)
+
+    ret = utils.run(['tdnf', '--repo={}'.format(reponame),
+                     '--download-metadata',
+                     'reposync'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    synced_dir = os.path.join(workdir, reponame)
+    assert(os.path.isdir(synced_dir))
+    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
+    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    baseurl = "file://{}".format(synced_dir)
+
+    utils.create_repoconf(filename, baseurl, "synced-repo")
+
+    ret = utils.run(['tdnf',
+                     '--repo=synced-repo',
+                     'makecache'],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--repo=synced-repo',
+                     'install', pkgname ],
+                    cwd=workdir)
+    assert(ret['retval'] == 0)
+    assert(utils.check_package(pkgname) == True)
+

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -57,19 +57,6 @@ def check_synced_repo(utils, reponame, synced_dir):
     for rpm in local_rpms:
         assert(os.path.isfile(os.path.join(synced_dir, 'RPMS', ARCH, rpm)))
 
-def create_repoconf(filename, baseurl, name):
-    templ = """
-[{name}]
-name=Test Repo
-baseurl={baseurl}
-enabled=1
-gpgcheck=0
-metadata_expire=86400
-ui_repoid_vars=basearch
-"""
-    with open(filename, "w") as f:
-        f.write(templ.format(name=name, baseurl=baseurl))
-
 # reposync with no options - sync to local directory
 def test_reposync(utils):
     reponame = TESTREPO
@@ -337,7 +324,7 @@ def test_reposync_create_repo(utils):
     filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
     baseurl = "file://{}".format(synced_dir)
 
-    create_repoconf(filename, baseurl, "synced-repo")
+    utils.create_repoconf(filename, baseurl, "synced-repo")
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo=synced-repo',

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -41,14 +41,6 @@ def teardown_test(utils):
     if os.path.isdir(os.path.join('/', TESTREPO)):
         shutil.rmtree(os.path.join('/', TESTREPO))
 
-# helper to create directory tree without complains when it exists:
-def makedirs(d):
-    try:
-        os.makedirs(d)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-
 # helper to check a synced repo -
 # uses the local repository and compares the list of RPMs
 def check_synced_repo(utils, reponame, synced_dir):
@@ -82,7 +74,7 @@ ui_repoid_vars=basearch
 def test_reposync(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
@@ -100,7 +92,7 @@ def test_reposync(utils):
 def test_reposync_download_path(utils):
     reponame = TESTREPO
     downloaddir = DOWNLOADDIR
-    makedirs(downloaddir)
+    utils.makedirs(downloaddir)
     assert(os.path.isdir(downloaddir))
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
@@ -116,7 +108,7 @@ def test_reposync_download_path(utils):
 def test_reposync_download_path_slash(utils):
     reponame = TESTREPO
     downloaddir = DOWNLOADDIR + '/'
-    makedirs(downloaddir)
+    utils.makedirs(downloaddir)
     assert(os.path.isdir(downloaddir))
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
@@ -193,7 +185,7 @@ def xxxtest_reposync_download_path_norepopath_multiple_repos(utils):
 def test_reposync_metadata(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-metadata',
@@ -213,9 +205,9 @@ def test_reposync_metadata(utils):
 def test_reposync_metadata_path(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
     mdatadir = METADATADIR
-    makedirs(mdatadir)
+    utils.makedirs(mdatadir)
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-metadata',
@@ -235,10 +227,10 @@ def test_reposync_metadata_path(utils):
 def test_reposync_delete(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     synced_dir = os.path.join(workdir, reponame)
-    makedirs(synced_dir)
+    utils.makedirs(synced_dir)
 
     faked_rpm = os.path.join((synced_dir), 'faked-0.1.2.rpm')
     with open(faked_rpm, 'w') as f:
@@ -265,10 +257,10 @@ def test_reposync_delete(utils):
 def test_reposync_no_delete(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     synced_dir = os.path.join(workdir, reponame)
-    makedirs(synced_dir)
+    utils.makedirs(synced_dir)
 
     faked_rpm = os.path.join((synced_dir), 'faked-0.1.2.rpm')
     with open(faked_rpm, 'w') as f:
@@ -294,7 +286,7 @@ def test_reposync_no_delete(utils):
 def test_reposync_gpgcheck(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
@@ -313,7 +305,7 @@ def test_reposync_gpgcheck(utils):
 def test_reposync_urls(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
@@ -328,7 +320,7 @@ def test_reposync_urls(utils):
 def test_reposync_create_repo(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-metadata',
@@ -366,7 +358,7 @@ def test_reposync_create_repo(utils):
 def test_reposync_arch(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     synced_dir = os.path.join(workdir, reponame)
     if os.path.isdir(synced_dir):
@@ -390,7 +382,7 @@ def test_reposync_arch(utils):
 def test_reposync_arch_others(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     synced_dir = os.path.join(workdir, reponame)
     if os.path.isdir(synced_dir):
@@ -416,7 +408,7 @@ def test_reposync_arch_others(utils):
 def test_reposync_newest(utils):
     reponame = TESTREPO
     workdir = WORKDIR
-    makedirs(workdir)
+    utils.makedirs(workdir)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),

--- a/pytests/tests/test_setopt_reposdir.py
+++ b/pytests/tests/test_setopt_reposdir.py
@@ -25,24 +25,11 @@ def teardown_test(utils):
     if os.path.isdir(REPODIR):
         shutil.rmtree(REPODIR)
 
-def create_repoconf(filename, baseurl, name):
-    templ = """
-[{name}]
-name=Test Repo
-baseurl={baseurl}
-enabled=1
-gpgcheck=0
-metadata_expire=86400
-ui_repoid_vars=basearch
-"""
-    with open(filename, "w") as f:
-        f.write(templ.format(name=name, baseurl=baseurl))
-
 def test_setopt_reposdir(utils):
     utils.makedirs(REPODIR)
-    create_repoconf(os.path.join(REPODIR, REPOFILENAME),
-                    "http://foo.bar.com/packages",
-                    REPONAME)
+    utils.create_repoconf(os.path.join(REPODIR, REPOFILENAME),
+                          "http://foo.bar.com/packages",
+                          REPONAME)
     ret = utils.run(['tdnf', '--setopt=reposdir={}'.format(REPODIR), 'repolist'])
     assert(REPONAME in "\n".join(ret['stdout']))
 

--- a/pytests/tests/test_setopt_reposdir.py
+++ b/pytests/tests/test_setopt_reposdir.py
@@ -25,14 +25,6 @@ def teardown_test(utils):
     if os.path.isdir(REPODIR):
         shutil.rmtree(REPODIR)
 
-# helper to create directory tree without complains when it exists:
-def makedirs(d):
-    try:
-        os.makedirs(d)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
-
 def create_repoconf(filename, baseurl, name):
     templ = """
 [{name}]
@@ -47,7 +39,7 @@ ui_repoid_vars=basearch
         f.write(templ.format(name=name, baseurl=baseurl))
 
 def test_setopt_reposdir(utils):
-    makedirs(REPODIR)
+    utils.makedirs(REPODIR)
     create_repoconf(os.path.join(REPODIR, REPOFILENAME),
                     "http://foo.bar.com/packages",
                     REPONAME)

--- a/solv/defines.h
+++ b/solv/defines.h
@@ -2,7 +2,7 @@
 #define __SOLV_DEFINES_H__
 
 #define SYSTEM_REPO_NAME "@System"
-#define CMDLINE_REPO_NAME "@commandline"
+#define CMDLINE_REPO_NAME "@cmdline"
 #define SOLV_COOKIE_IDENT "tdnf"
 #define TDNF_SOLVCACHE_DIR_NAME "solvcache"
 #define SOLV_COOKIE_LEN   32

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -84,6 +84,9 @@ static struct option pstOptions[] =
     {"debugsolver",   no_argument, &_opt.nDebugSolver, 1}, //--debugsolver
     {"disablerepo",   required_argument, 0, 0},            //--disablerepo
     {"enablerepo",    required_argument, 0, 0},            //--enablerepo
+    {"repo",          required_argument, 0, 0},            //--repo
+    {"repoid",        required_argument, 0, 0},            //--repoid (same as --repo)
+    {"repofrompath",  required_argument, 0, 0},            //--repofrompath
     {"errorlevel",    required_argument, 0, 'e'},          //-e --errorlevel
     {"help",          no_argument, 0, 'h'},                //-h --help
     {"installroot",   required_argument, 0, 'i'},          //--installroot
@@ -390,11 +393,21 @@ ParseOption(
     }
     else if ((!strcasecmp(pszName, "metadata-path")) ||
              (!strcasecmp(pszName, "download-path")) ||
-             (!strcasecmp(pszName, "arch")))
+             (!strcasecmp(pszName, "arch")) ||
+             (!strcasecmp(pszName, "repofrompath")))
     {
         dwError = AddSetOptWithValues(pCmdArgs,
                             CMDOPT_KEYVALUE,
                             pszName,
+                            optarg);
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+    else if ((!strcasecmp(pszName, "repoid")) ||
+             (!strcasecmp(pszName, "repo")))
+    {
+        dwError = AddSetOptWithValues(pCmdArgs,
+                            CMDOPT_KEYVALUE,
+                            "repoid",
                             optarg);
         BAIL_ON_CLI_ERROR(dwError);
     }


### PR DESCRIPTION
This addresses issues #234 and #235 . Usages:
```
tdnf --repo=<repoid> ...
tdnd --repofrompath=<repoid>,<url> --repo=<repoid> ...
```
Tests are added as well.
