### PR TITLE
unify TDNFList()/TDNFInfo()

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1094,4 +1094,15 @@ TDNFFreeEventData(
     PTDNF_EVENT_DATA pData
     );
 
+/* api.c */
+uint32_t
+TDNFListInternal(
+    PTDNF pTdnf,
+    TDNF_SCOPE nScope,
+    char** ppszPackageNameSpecs,
+    PTDNF_PKG_INFO* ppPkgInfo,
+    uint32_t* pdwCount,
+    TDNF_PKG_DETAIL nDetail
+    );
+
 #endif /* __CLIENT_PROTOTYPES_H__ */


### PR DESCRIPTION
I noticed that the code for `TDNFList()` and `TDNFInfo()` was almost identical, except for a flag passed to `TDNFPopulatePkgInfoArray()`, and a fix for issue #94 in `TDNFList()`. The fix was missed for the `info` command. This change unifies the two functions, and thereby fixes #94 also for the `info` command.