### PR TITLE
tdnf-python: fix regression in tdnf.repolist()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,23 @@
 #
-# Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms
 # of the License are located in the COPYING file of this distribution.
 #
-#   Author: Siddharth Chandrasekaran <csiddharth@vmware.com>
 
 CMAKE_MINIMUM_REQUIRED(VERSION 3.0 FATAL_ERROR)
 
 project(tdnf VERSION 3.1.0 LANGUAGES C)
 set(VERSION ${PROJECT_VERSION})
 set(PROJECT_YEAR 2021)
+
+# needed for spec file
+execute_process (
+    COMMAND bash -c "uname -r | cut -d'.' -f4"
+    OUTPUT_VARIABLE dist
+)
+set(DIST .${dist})
 
 # Ensure correct directory paths are used for installation
 include(GNUInstallDirs)

--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,7 +1,4 @@
-FROM fedora:32
-
-MAINTAINER csiddharth@vmware.com
-
+FROM fedora:latest
 
 RUN dnf -q -y upgrade
 RUN dnf -q -y install gcc make cmake libcurl-devel rpm-devel rpm-build libsolv-devel \

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 rm -rf build
-mkdir build && cd build
-cmake .. && make && make python
-make check
+mkdir -p build
+cd build || exit 1
+cmake .. && make -j32 && make python -j32
+make check -j32

--- a/client/api.c
+++ b/client/api.c
@@ -1213,7 +1213,7 @@ TDNFRepoSync(
             if (pReposyncArgs->nDelete && dwError == 0)
             {
                 /* if "delete" option is given, create a marker file to protect
-                   what we just downloaded. Later all *.rpm files that do not 
+                   what we just downloaded. Later all *.rpm files that do not
                    have a marker file will be deleted */
                 dwError = TDNFAllocateStringPrintf(&pszKeepFile, "%s.reposync-keep", pszFilePath);
                 BAIL_ON_TDNF_ERROR(dwError);
@@ -1332,7 +1332,7 @@ cleanup:
     TDNF_SAFE_FREE_MEMORY(pszFilePath);
     TDNFFreePackageInfoArray(pPkgInfos, dwCount);
     return dwError;
-error: 
+error:
     if(dwError == ERROR_TDNF_NO_MATCH)
     {
         dwError = ERROR_TDNF_NO_DATA;

--- a/pytests/tests/test_tdnf_python.py
+++ b/pytests/tests/test_tdnf_python.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import sys
+import pytest
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    global mulpkgname
+    mulpkgname = utils.config['mulversion_pkgname']
+
+    global sglpkgname
+    sglpkgname = utils.config['sglversion_pkgname']
+
+    global config
+    config = utils.config['repo_path'] + '/tdnf.conf'
+
+    path = '{builddir}/python/build/lib.linux-{arch}-{pymajor}.{pyminor}'
+
+    path = path.format(builddir=utils.config['build_dir'],
+                       arch=os.uname().machine,
+                       pymajor=str(sys.version_info.major),
+                       pyminor=str(sys.version_info.minor))
+
+    sys.path.append(path)
+
+    global tdnf
+    import tdnf
+
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    utils.run(['tdnf', 'erase', '-y', sglpkgname])
+    utils.run(['tdnf', 'erase', '-y', mulpkgname])
+    assert (utils.check_package(sglpkgname) == False)
+    assert (utils.check_package(mulpkgname) == False)
+
+
+def tdnf_py_erase(pkgs, quiet=False, refresh=False, cfg=None):
+    conf = cfg if cfg else config
+    pkgs = [x for x in pkgs if x]
+    for p in pkgs:
+        try:
+            tdnf.erase(pkgs=[p], quiet=quiet, refresh=refresh, config=conf)
+        except Exception as e:
+            pass
+
+def tdnf_py_install(pkgs, quiet=False, refresh=False, cfg=None):
+    pkgs = [x for x in pkgs if x]
+    conf = cfg if cfg else config
+    tdnf.install(pkgs=pkgs, quiet=quiet, refresh=refresh, config=conf)
+
+
+def tdnf_py_repolist(filter=None, cfg=None):
+    conf = cfg if cfg else config
+    if filter:
+        return tdnf.repolist(filter=filter, config=conf)
+
+    return tdnf.repolist(config=conf)
+
+
+def tdnf_py_distro_sync(quiet=False, refresh=False, cfg=None):
+    conf = cfg if cfg else config
+    tdnf.distro_sync(quiet=quiet, refresh=refresh, config=conf)
+
+
+def tdnf_py_downgrade(pkgs, quiet=False, refresh=False, cfg=None):
+    pkgs = [x for x in pkgs if x]
+    conf = cfg if cfg else config
+    tdnf.downgrade(pkgs=pkgs, quiet=quiet, refresh=refresh, config=conf)
+
+
+def tdnf_py_update(pkgs=[], quiet=False, refresh=False, cfg=None):
+    pkgs = [x for x in pkgs if x]
+    conf = cfg if cfg else config
+    if pkgs:
+        tdnf.update(pkgs=pkgs, quiet=quiet, refresh=refresh, config=conf)
+    else:
+        tdnf.update(quiet=quiet, refresh=refresh, config=conf)
+
+
+def test_tdnf_python_install_single(utils):
+    pkgs = [sglpkgname]
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    tdnf_py_install(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == True)
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    tdnf_py_install(pkgs=pkgs, refresh=True)
+    assert (utils.check_package(sglpkgname) == True)
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    tdnf_py_install(pkgs=pkgs, refresh=True, quiet=True)
+    assert (utils.check_package(sglpkgname) == True)
+
+
+def test_tdnf_python_install_multiple(utils):
+    pkgs = [sglpkgname, mulpkgname]
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    assert (utils.check_package(mulpkgname) == False)
+    tdnf_py_install(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == True)
+    assert (utils.check_package(mulpkgname) == True)
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    assert (utils.check_package(mulpkgname) == False)
+    tdnf_py_install(pkgs=pkgs, refresh=True)
+    assert (utils.check_package(sglpkgname) == True)
+    assert (utils.check_package(mulpkgname) == True)
+
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    assert (utils.check_package(mulpkgname) == False)
+    tdnf_py_install(pkgs=pkgs, refresh=True, quiet=True)
+    assert (utils.check_package(sglpkgname) == True)
+    assert (utils.check_package(mulpkgname) == True)
+
+
+def test_tdnf_python_erase_single(utils):
+    pkgs = [sglpkgname]
+
+    tdnf_py_install(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == True)
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+
+
+def test_tdnf_python_erase_multiple(utils):
+    pkgs = [sglpkgname, mulpkgname]
+
+    tdnf_py_install(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == True)
+    assert (utils.check_package(mulpkgname) == True)
+    tdnf_py_erase(pkgs=pkgs)
+    assert (utils.check_package(sglpkgname) == False)
+    assert (utils.check_package(mulpkgname) == False)
+
+
+def check_repodata(data, filter=0):
+    if filter != 2:
+        assert(data.enabled == 1)
+        assert(data.name.decode('utf-8') == 'basic')
+        assert(data.id.decode('utf-8') == 'photon-test')
+        assert(data.baseurl.decode('utf-8') == 'http://localhost:8080/photon-test')
+    else:
+        assert(data.enabled == 0)
+        assert(data.name.decode('utf-8') == '@cmdline')
+        assert(data.id.decode('utf-8') == '@cmdline')
+        assert(hasattr(data, 'baseurl') == False)
+
+
+def test_tdnf_python_repolist(utils):
+    check_repodata(tdnf_py_repolist()[0])
+
+    for i in [0, 1, 2, -1, 10]:
+        check_repodata(tdnf_py_repolist(i)[0], i)
+
+
+def test_tdnf_python_update_single(utils):
+    pkgs = [sglpkgname]
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_update(pkgs=pkgs)
+    tdnf_py_update(pkgs=pkgs, quiet=True)
+    tdnf_py_update(pkgs=pkgs, quiet=True, refresh=True)
+
+
+def test_tdnf_python_update_multiple(utils):
+    pkgs = [sglpkgname, mulpkgname+'-'+utils.config['mulversion_lower']]
+
+    tdnf_py_erase(pkgs=[sglpkgname, mulpkgname])
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_update(pkgs=pkgs)
+
+    tdnf_py_erase(pkgs=[sglpkgname, mulpkgname])
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_update(pkgs=pkgs, quiet=True)
+
+    tdnf_py_erase(pkgs=[sglpkgname, mulpkgname])
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_update(pkgs=pkgs, quiet=True, refresh=True)
+
+
+def test_tdnf_python_update_all(utils):
+    tdnf_py_update()
+
+
+def test_tdnf_python_downgrade_single(utils):
+    pkgs = [mulpkgname]
+    tdnf_py_erase(pkgs=pkgs)
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_downgrade(pkgs=pkgs, refresh=True)
+    tdnf_py_downgrade(pkgs=pkgs, quiet=True, refresh=True)
+
+
+def test_tdnf_python_downgrade_multiple(utils):
+    pkgs = [sglpkgname, mulpkgname]
+    tdnf_py_erase(pkgs=pkgs)
+    tdnf_py_install(pkgs=pkgs)
+    tdnf_py_downgrade(pkgs=pkgs, refresh=True)
+    tdnf_py_downgrade(pkgs=pkgs, quiet=True, refresh=True)
+
+
+def test_tdnf_python_distro_sync(utils):
+    tdnf_py_distro_sync(quiet=True)
+    tdnf_py_distro_sync(refresh=True, quiet=True)
+
+
+def test_tdnf_python_repofilter(utils):
+    assert (tdnf.REPOLISTFILTER_ALL == 0)
+    assert (tdnf.REPOLISTFILTER_ENABLED == 1)
+    assert (tdnf.REPOLISTFILTER_DISABLED == 2)

--- a/python/README.md
+++ b/python/README.md
@@ -22,7 +22,7 @@ returns a python list of repodata types.
 example:
 ```
 root [ / ]# python3
-Python 3.7.3 (default, Jun 20 2019, 03:44:05) 
+Python 3.7.3 (default, Jun 20 2019, 03:44:05)
 [GCC 7.3.0] on linux
 Type "help", "copyright", "credits" or "license" for more information.
 >>> import tdnf
@@ -109,10 +109,10 @@ synchronize installed packages to the latest available versions
 
 ##parameter (optional): quiet
 ```
-tdnf.distro-sync(quiet=True)
+tdnf.distro_sync(quiet=True)
 ```
 
 ##parameter (optional): refresh
 ```
-tdnf.distro-sync(refresh=True)
+tdnf.distro_sync(refresh=True)
 ```

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,20 +1,21 @@
 #
-# Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms
 # of the License are located in the COPYING file of this distribution.
 #
 
-from distutils.core import setup, Extension
 import os
+from distutils.core import setup
+from distutils.core import Extension
 
 cflags = [
     '-I@PYTDNF_INC_DIR@'
 ]
 
 link_args = [
-    '-Wl,-L@PYTDNF_LIB_DIR@'
+    '-Wl,-rpath=@PYTDNF_LIB_DIR@'
 ]
 
 pytdnf_sources = [
@@ -27,6 +28,7 @@ pytdnf_sources = [
 
 tdnfmodule = Extension('tdnf._tdnf',
                        libraries = ['tdnf'],
+                       library_dirs = ['${PYTDNF_LIB_DIR}'],
                        sources = pytdnf_sources,
                        extra_compile_args = cflags,
                        extra_link_args = link_args)

--- a/python/tdnfmodule.c
+++ b/python/tdnfmodule.c
@@ -25,34 +25,40 @@ static PyMethodDef TDNFPyMethods[] =
 {
     {"repolist", (PyCFunction)TDNFPyRepoList, METH_VARARGS|METH_KEYWORDS,
      "repolist() -- returns a list of enabled repositories\n\n"
-     "repolist(filter=tdnf.REPOLISTFILTER_ALL) -- returns a list of all repositories"},
+     "repolist(filter=tdnf.REPOLISTFILTER_ALL) -- returns a list of all repositories\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {"install", (PyCFunction)TDNFPyInstall, METH_VARARGS|METH_KEYWORDS,
      "install(list of package names) -- install packages\n\n"
-     "Eg: import tdnf;tdnf.install(pkgs=['curl','curl-devel'])\n\n"
+     "Eg: import tdnf; tdnf.install(pkgs=['curl','curl-devel'])\n\n"
      "options: quiet=True -- dont print progress\n\n"
-     "options: refresh=True -- refresh cache before install\n\n"},
+     "options: refresh=True -- refresh cache before install\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {"update", (PyCFunction)TDNFPyUpdate, METH_VARARGS|METH_KEYWORDS,
      "update(optional list of package names) -- update packages\n\n"
-     "Eg: import tdnf;tdnf.update() -- update all\n\n"
-     "Eg: import tdnf;tdnf.update(pkgs=['curl']) -- update curl\n\n"
+     "Eg: import tdnf; tdnf.update() -- update all\n\n"
+     "Eg: import tdnf; tdnf.update(pkgs=['curl']) -- update curl\n\n"
      "options: quiet=True -- dont print progress\n\n"
-     "options: refresh=True -- refresh cache before update\n\n"},
+     "options: refresh=True -- refresh cache before update\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {"downgrade", (PyCFunction)TDNFPyDowngrade, METH_VARARGS|METH_KEYWORDS,
      "downgrade(optional list of package names) -- downgrade packages\n\n"
-     "Eg: import tdnf;tdnf.downgrade() -- downgrade all\n\n"
-     "Eg: import tdnf;tdnf.downgrade(pkgs=['curl']) -- downgrade curl\n\n"
+     "Eg: import tdnf; tdnf.downgrade() -- downgrade all\n\n"
+     "Eg: import tdnf; tdnf.downgrade(pkgs=['curl']) -- downgrade curl\n\n"
      "options: quiet=True -- dont print progress\n\n"
-     "options: refresh=True -- refresh cache before downgrade\n\n"},
+     "options: refresh=True -- refresh cache before downgrade\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {"erase", (PyCFunction)TDNFPyErase, METH_VARARGS|METH_KEYWORDS,
      "erase(list of package names) -- erase packages\n\n"
-     "Eg: import tdnf;tdnf.erase(['wget']) -- erase wget\n\n"
+     "Eg: import tdnf; tdnf.erase(['wget']) -- erase wget\n\n"
      "options: quiet=True -- dont print progress\n\n"
-     "options: refresh=True -- refresh cache before remove\n\n"},
+     "options: refresh=True -- refresh cache before remove\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {"distro_sync", (PyCFunction)TDNFPyDistroSync, METH_VARARGS|METH_KEYWORDS,
      "distro_sync() -- distro sync installed packages\n\n"
-     "Eg: import tdnf;tdnf.distro_sync() -- distro sync all\n\n"
+     "Eg: import tdnf; tdnf.distro_sync() -- distro sync all\n\n"
      "options: quiet=True -- dont print progress\n\n"
-     "options: refresh=True -- refresh cache before distro sync\n\n"},
+     "options: refresh=True -- refresh cache before distro sync\n\n"
+     "options: config=<abs_path> -- tdnf config file path\n\n"},
     {NULL}  /* Sentinel */
 };
 

--- a/python/tdnfpyrepodata.c
+++ b/python/tdnfpyrepodata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -135,13 +135,14 @@ TDNFPyRepoDataRepr(
     PPY_TDNF_REPODATA pRepoData = NULL;
 
     pRepoData = (PPY_TDNF_REPODATA)self;
+
     dwError = TDNFAllocateStringPrintf(
                   &pszRepr,
-                  "{id: %s, name: %s, baseurl: %s, enabled: %d}",
-                  pRepoData->id ? PyBytes_AsString(pRepoData->id) : "",
-                  pRepoData->name ? PyBytes_AsString(pRepoData->name) : "",
-                  pRepoData->baseurl ? PyBytes_AsString(pRepoData->baseurl) : "",
-                  pRepoData->metalink ? PyBytes_AsString(pRepoData->metalink) : "",
+                  "{id: %s, name: %s, baseurl: %s, metalink: %s, enabled: %d}",
+                  pRepoData->id ? PyBytes_AsString(pRepoData->id) : "''",
+                  pRepoData->name ? PyBytes_AsString(pRepoData->name) : "''",
+                  pRepoData->baseurl ? PyBytes_AsString(pRepoData->baseurl) : "''",
+                  pRepoData->metalink ? PyBytes_AsString(pRepoData->metalink) : "''",
                   pRepoData->enabled);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -190,11 +191,28 @@ TDNFPyMakeRepoData(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    pPyRepoData->id = PyBytes_FromString(pRepoData->pszId);
-    pPyRepoData->name = PyBytes_FromString(pRepoData->pszName);
-    pPyRepoData->baseurl = PyBytes_FromString(pRepoData->pszBaseUrl);
-    pPyRepoData->metalink = PyBytes_FromString(pRepoData->pszMetaLink);
+    if (pRepoData->pszId)
+    {
+        pPyRepoData->id = PyBytes_FromString(pRepoData->pszId);
+    }
+
+    if (pRepoData->pszName)
+    {
+        pPyRepoData->name = PyBytes_FromString(pRepoData->pszName);
+    }
+
+    if (pRepoData->pszBaseUrl)
+    {
+        pPyRepoData->baseurl = PyBytes_FromString(pRepoData->pszBaseUrl);
+    }
+
+    if (pRepoData->pszMetaLink)
+    {
+        pPyRepoData->metalink = PyBytes_FromString(pRepoData->pszMetaLink);
+    }
+
     pPyRepoData->enabled = pRepoData->nEnabled;
+
 
     *ppPyRepoData = (PyObject *)pPyRepoData;
 cleanup:

--- a/tdnf.spec.in
+++ b/tdnf.spec.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms
@@ -10,6 +10,8 @@
 %{!?python3_sitelib: %define python3_sitelib %(python3 -c "from distutils.sysconfig import get_python_lib;print(get_python_lib())")}
 
 %define _tdnfpluginsdir %{_libdir}/%{name}-plugins
+
+%define dist @DIST@
 
 Summary:        dnf/yum equivalent using C libs
 Name:           @PROJECT_NAME@


### PR DESCRIPTION
repo->pszMetaLink can be null and PyBytes_FromString doesn't validate
null pointers which was resulting in a seg fault.

Other changes:

1. Added dist flag support to spec (which helps in reinstalling tdnf if
   needed)
2. Fixed a typo in python/README.md
3. Improvements to pytests/conftest.py
4. Added config file parameter support to tdnf-python

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>