### PR TITLE
make pytest arch independent

### DIFF
--- a/pytests/config.json.in
+++ b/pytests/config.json.in
@@ -15,5 +15,6 @@
     "requiring_package": "tdnf-test-dependson-base",
     "required_package": "tdnf-test-base",
     "dummy_requires_pkgname": "tdnf-test-dummy-requires",
-    "valgrind_minimum_version": "3.15.0"
+    "valgrind_minimum_version": "3.15.0",
+    "valgrind_minimum_version_aarch64": "3.17.0"
 }

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -25,7 +25,9 @@ from OpenSSL import crypto
 from urllib.parse import urlparse
 from multiprocessing import Process
 from http.server import SimpleHTTPRequestHandler, HTTPServer
+import platform
 
+ARCH=platform.machine()
 
 def StopTestRepoServer(server):
     server.terminate()
@@ -130,6 +132,15 @@ class TestUtils(object):
         if current_version < minimum_version:
             self.config['valgrind_disabled_reason'] = 'valgrind minimum version constraint not met'
             return
+
+        # some architectures may require a higher version
+        if 'valgrind_minimum_version_{}'.format(ARCH) in self.config:
+            minimum_version = \
+                self.version_str_to_int(self.config['valgrind_minimum_version_{}'.format(ARCH)])
+            if current_version < minimum_version:
+                self.config['valgrind_disabled_reason'] = \
+                    'valgrind minimum version constraint not met for this architecture'
+                return
 
         # All okay. Enable valgrind checks
         self.config['valgrind_disabled_reason'] = None

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -22,9 +22,11 @@ TEST_REPO_DIR=$1
 BUILD_PATH=${TEST_REPO_DIR}/build
 PUBLISH_PATH=${TEST_REPO_DIR}/photon-test
 
+ARCH=$(uname -m)
+
 mkdir -p ${BUILD_PATH}/BUILD \
 	 ${BUILD_PATH}/SRPMS \
-	 ${BUILD_PATH}/RPMS/x86_64 \
+	 ${BUILD_PATH}/RPMS/${ARCH} \
 	 ${BUILD_PATH}/RPMS/noarch \
 	 ${PUBLISH_PATH} \
 	 ${TEST_REPO_DIR}/yum.repos.d

--- a/pytests/tests/test_check_local.py
+++ b/pytests/tests/test_check_local.py
@@ -10,7 +10,9 @@ import os
 import tempfile
 import pytest
 import shutil
+import platform
 
+ARCH=platform.machine()
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_test(utils):
@@ -41,7 +43,7 @@ def test_check_local_empty_directory(utils):
 def test_check_local_with_local_rpm(utils):
     with tempfile.TemporaryDirectory() as tmpdir:
         dest = os.path.join(tmpdir, 'test.rpm')
-        src = os.path.join(utils.config['repo_path'], 'build/RPMS/x86_64/tdnf-test-two-1.0.1-1.x86_64.rpm')
+        src = os.path.join(utils.config['repo_path'], 'build', 'RPMS', ARCH, 'tdnf-test-two-1.0.1-1.{}.rpm'.format(ARCH))
         shutil.copyfile(src, dest)
 
         ret = utils.run(['tdnf', 'check-local', tmpdir])

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -11,7 +11,9 @@ import os
 import shutil
 import errno
 import pytest
+import platform
 
+ARCH = platform.machine()
 DOWNLOADDIR='/root/reposync/download'
 METADATADIR='/root/reposync/metadata'
 WORKDIR='/root/reposync/workdir'
@@ -51,7 +53,7 @@ def makedirs(d):
 # uses the local repository and compares the list of RPMs
 def check_synced_repo(utils, reponame, synced_dir):
 
-    local_dir = os.path.join(utils.config['repo_path'], reponame, 'RPMS', 'x86_64')
+    local_dir = os.path.join(utils.config['repo_path'], reponame, 'RPMS', ARCH)
 
     local_rpms = \
         list(filter(lambda f: os.path.isfile(os.path.join(local_dir, f)) and f.endswith('.rpm'), \
@@ -61,7 +63,7 @@ def check_synced_repo(utils, reponame, synced_dir):
     assert(len(local_rpms) > 0)
 
     for rpm in local_rpms:
-        assert(os.path.isfile(os.path.join(synced_dir, 'RPMS', 'x86_64', rpm)))
+        assert(os.path.isfile(os.path.join(synced_dir, 'RPMS', ARCH, rpm)))
 
 def create_repoconf(filename, baseurl, name):
     templ = """
@@ -361,7 +363,7 @@ def test_reposync_create_repo(utils):
     assert(utils.check_package(pkgname) == True)
 
 # reposync with arch option should not sync other archs
-def test_reposync_arch_x86_64(utils):
+def test_reposync_arch(utils):
     reponame = TESTREPO
     workdir = WORKDIR
     makedirs(workdir)
@@ -372,7 +374,7 @@ def test_reposync_arch_x86_64(utils):
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
-                     '--arch', 'x86_64',
+                     '--arch', ARCH,
                      'reposync'],
                      cwd=workdir)
     assert(ret['retval'] == 0)
@@ -385,7 +387,7 @@ def test_reposync_arch_x86_64(utils):
 
 
 # reposync with arch option should work for multiple archs
-def test_reposync_arch_x86_64_others(utils):
+def test_reposync_arch_others(utils):
     reponame = TESTREPO
     workdir = WORKDIR
     makedirs(workdir)
@@ -399,7 +401,7 @@ def test_reposync_arch_x86_64_others(utils):
                      '--arch', 'classic',
                      '--arch', 'baroque',
                      '--arch', 'modern',
-                     '--arch', 'x86_64',
+                     '--arch', ARCH,
                      'reposync'],
                      cwd=workdir)
     assert(ret['retval'] == 0)
@@ -426,7 +428,7 @@ def test_reposync_newest(utils):
     assert(os.path.isdir(synced_dir))
 
     mulversion_pkgname_found = False
-    for f in os.listdir(os.path.join(synced_dir, 'RPMS', 'x86_64')):
+    for f in os.listdir(os.path.join(synced_dir, 'RPMS', ARCH)):
         if f.startswith(utils.config['mulversion_pkgname']):
             assert(not utils.config['mulversion_lower'] in f)
             mulversion_pkgname_found = True

--- a/pytests/tests/test_rpm_cmdline.py
+++ b/pytests/tests/test_rpm_cmdline.py
@@ -8,6 +8,9 @@
 import os
 import glob
 import pytest
+import platform
+
+ARCH=platform.machine()
 
 @pytest.fixture(scope='function', autouse=True)
 def setup_test_function(utils):
@@ -23,12 +26,12 @@ def teardown_test(utils):
     os.rmdir(os.path.join(utils.config['repo_path'], 'dummydir'))
 
 def get_pkg_file_path(utils, pkgname):
-    dir = os.path.join(utils.config['repo_path'], 'photon-test', 'RPMS', 'x86_64')
+    dir = os.path.join(utils.config['repo_path'], 'photon-test', 'RPMS', ARCH)
     matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
     return matches[0]
 
 def get_pkg_file_path_with_doubledots(utils, pkgname):
-    dir = os.path.join(utils.config['repo_path'], 'dummydir', '..', 'photon-test', 'RPMS', 'x86_64')
+    dir = os.path.join(utils.config['repo_path'], 'dummydir', '..', 'photon-test', 'RPMS', ARCH)
     matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
     return matches[0]
 


### PR DESCRIPTION
Fixes issue #256

* determine the architecture with `platform.machine()` (python) or `uname -m` (shell) for package suffixes and directory names
* check valgrind version if suitable for architecture: arm needs >= 3.17.0