### PR TITLE
add minversions config option

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1426,6 +1426,9 @@ TDNFResolve(
     dwError = TDNFCheckProtectedPkgs(pSolvedPkgInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFCheckMinVersions(pTdnf, pSolvedPkgInfo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     pSolvedPkgInfo->nNeedAction =
         pSolvedPkgInfo->pPkgsToInstall ||
         pSolvedPkgInfo->pPkgsToUpgrade ||

--- a/client/config.c
+++ b/client/config.c
@@ -127,6 +127,12 @@ TDNFReadConfig(
                   &pConf->ppszExcludes);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFReadKeyValueStringArray(
+                  pSection,
+                  TDNF_CONF_KEY_MINVERSIONS,
+                  &pConf->ppszMinVersions);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFConfigReadProxySettings(
                   pSection,
                   pConf);

--- a/client/defines.h
+++ b/client/defines.h
@@ -80,6 +80,7 @@ typedef enum
 #define TDNF_CONF_KEY_PLUGIN_CONF_PATH    "pluginconfpath"
 #define TDNF_PLUGIN_CONF_KEY_ENABLED      "enabled"
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
+#define TDNF_CONF_KEY_MINVERSIONS         "minversions"
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"
 #define TDNF_REPO_KEY_ENABLED             "enabled"
@@ -205,6 +206,9 @@ typedef enum
     {ERROR_TDNF_RPM_CHECK,           "ERROR_TDNF_RPM_CHECK",           "rpm check reported errors"}, \
     {ERROR_TDNF_METADATA_EXPIRE_PARSE, "ERROR_TDNF_METADATA_EXPIRE_PARSE", "metadata_expire value could not be parsed. Check your repo files."},\
     {ERROR_TDNF_SELF_ERASE, "ERROR_TDNF_SELF_ERASE", "The operation would result in removing the protected package : tdnf"},\
+    {ERROR_TDNF_DOWNGRADE_NOT_ALLOWED,\
+	    "ERROR_TDNF_DOWNGRADE_NOT_ALLOWED",\
+	    "a downgrade is not allowed below the minimal version. Check 'minversions' in the configuration."},\
     {ERROR_TDNF_PERM, "ERROR_TDNF_PERM", "Operation not permitted. You have to be root."},\
     {ERROR_TDNF_OPT_NOT_FOUND, "ERROR_TDNF_OPT_NOT_FOUND", "A required option was not found"},\
     {ERROR_TDNF_OPERATION_ABORTED, "ERROR_TDNF_OPERATION_ABORTED", "Operation aborted."},\

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -949,6 +949,7 @@ TDNFHasMinVersionInList(
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszTemp);
     TDNF_SAFE_FREE_STRINGARRAY(ppszTokens);
+    return dwError;
 error:
     goto cleanup;
 }

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -901,6 +901,84 @@ error:
 }
 
 uint32_t
+TDNFHasMinVersionInList(
+    PTDNF pTdnf,
+    PTDNF_PKG_INFO pPkgInfos
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_PKG_INFO pPkgInfo;
+    char **ppszMinVersions = NULL;
+    char **ppszTokens = NULL;
+    char *pszTemp = NULL;
+    int i;
+
+    if(!pTdnf || !pPkgInfos)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    ppszMinVersions = pTdnf->pConf->ppszMinVersions;
+
+    for (i = 0; ppszMinVersions[i]; i++)
+    {
+        dwError = TDNFAllocateString(ppszMinVersions[i], &pszTemp);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFSplitStringToArray(pszTemp, "=", &ppszTokens);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        if (ppszTokens[0] && ppszTokens[1])
+        {
+            for(pPkgInfo = pPkgInfos; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
+            {
+                if (strcmp(ppszTokens[0], pPkgInfo->pszName) == 0)
+                {
+                    if (rpmvercmp(ppszTokens[1], pPkgInfo->pszEVR) > 0)
+                    {
+                        dwError = ERROR_TDNF_DOWNGRADE_NOT_ALLOWED;
+                        BAIL_ON_TDNF_ERROR(dwError);
+                    }
+                }
+            }
+        }
+        TDNF_SAFE_FREE_MEMORY(pszTemp);
+        TDNF_SAFE_FREE_STRINGARRAY(ppszTokens);
+    }
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszTemp);
+    TDNF_SAFE_FREE_STRINGARRAY(ppszTokens);
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFCheckMinVersions(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
+    )
+{
+    uint32_t dwError = 0;
+
+    if(!pTdnf || !pSolvedPkgInfo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(pSolvedPkgInfo->pPkgsToDowngrade &&
+       pTdnf->pConf && pTdnf->pConf->ppszMinVersions)
+    {
+        dwError = TDNFHasMinVersionInList(pTdnf, pSolvedPkgInfo->pPkgsToDowngrade);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+error:
+    return dwError;
+}
+
+uint32_t
 TDNFPopulatePkgInfos(
     PSolvSack pSack,
     PSolvPackageList pPkgList,
@@ -946,7 +1024,7 @@ TDNFPopulatePkgInfos(
                       &pPkgInfo->pszVersion,
                       &pPkgInfo->pszRelease,
                       &pPkgInfo->pszArch,
-                      NULL);
+                      &pPkgInfo->pszEVR);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = SolvGetPkgRepoNameFromId(

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -424,6 +424,12 @@ TDNFCheckProtectedPkgs(
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
     );
 
+uint32_t
+TDNFCheckMinVersions(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
+    );
+
 //goal.c
 uint32_t
 TDNFGoal(

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -580,6 +580,18 @@ TDNFConfigReplaceVars(
     char** pszString
     );
 
+uint32_t
+TDNFReadMinVersionsFiles(
+    char *pszDir,
+    char ***pppszMinVersions
+    );
+
+uint32_t
+TDNFReadFileToStringArray(
+    const char *pszFile,
+    char ***pppszArray
+    );
+
 //repo.c
 void
 TDNFFreeMetalinkUrlsList(

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -116,6 +116,12 @@ void
 TDNFFreeStringArrayWithCount(
     char **ppszArray,
     int nCount
+    );
+
+uint32_t
+TDNFStringArrayCount(
+    char **ppszStringArray,
+    int *pnCount
     );
 
 //configreader.c

--- a/common/strings.c
+++ b/common/strings.c
@@ -495,7 +495,32 @@ TDNFStringEndsWith(
 
 cleanup:
     return dwError;
-
 error:
     goto cleanup;
 }
+
+uint32_t
+TDNFStringArrayCount(
+    char **ppszStringArray,
+    int *pnCount
+)
+{
+    uint32_t dwError = 0;
+    int nCount;
+
+    if (!ppszStringArray || !pnCount)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    for(nCount = 0; ppszStringArray[nCount]; nCount++);
+
+    *pnCount = nCount;
+
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}
+

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -64,6 +64,7 @@ extern "C" {
 #define ERROR_TDNF_SELF_ERASE               1030
 #define ERROR_TDNF_ERASE_NEEDS_INSTALL      1031
 #define ERROR_TDNF_OPERATION_ABORTED        1032
+#define ERROR_TDNF_DOWNGRADE_NOT_ALLOWED    1033
 
 // for invalid input on interactive questions
 #define ERROR_TDNF_INVALID_INPUT            1033

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -264,7 +264,7 @@ typedef struct _TDNF_CONF
     char* pszVarReleaseVer;
     char* pszVarBaseArch;
     char** ppszExcludes;
-    char **ppszMinVersions;
+    char** ppszMinVersions;
 }TDNF_CONF, *PTDNF_CONF;
 
 typedef struct _TDNF_REPO_DATA

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -264,6 +264,7 @@ typedef struct _TDNF_CONF
     char* pszVarReleaseVer;
     char* pszVarBaseArch;
     char** ppszExcludes;
+    char **ppszMinVersions;
 }TDNF_CONF, *PTDNF_CONF;
 
 typedef struct _TDNF_REPO_DATA

--- a/pytests/tests/test_minversions.py
+++ b/pytests/tests/test_minversions.py
@@ -1,0 +1,89 @@
+#
+# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import pytest
+import errno
+import shutil
+
+TESTREPO='photon-test'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    dirname = os.path.join(utils.config['repo_path'], 'minversions.d')
+    if os.path.isdir(dirname):
+        shutil.rmtree(dirname)
+
+    utils.tdnf_config.remove_option('main', 'minversions')
+    filename = os.path.join(utils.config['repo_path'], 'tdnf.conf')
+    with open(filename, 'w') as f:
+        utils.tdnf_config.write(f, space_around_delimiters=False)
+
+# helper to create directory tree without complains when it exists:
+def makedirs(d):
+    try:
+        os.makedirs(d)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+def set_minversions_conf(utils, value):
+    utils.tdnf_config['main']['minversions'] = value
+    filename = os.path.join(utils.config['repo_path'], 'tdnf.conf')
+    with open(filename, 'w') as f:
+        utils.tdnf_config.write(f, space_around_delimiters=False)
+
+def set_minversions_file(utils, value):
+    utils.tdnf_config['main']['minversions'] = value
+    dirname = os.path.join(utils.config['repo_path'], 'minversions.d')
+    makedirs(dirname)
+    filename = os.path.join(dirname, 'test.conf')
+    with open(filename, 'w') as f:
+        f.write(value)
+
+def test_minversions_conf(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    set_minversions_conf(utils, "{}={}".format(pkgname, utils.config["mulversion_higher"]))
+    utils.install_package(pkgname)
+    ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
+    print (ret)
+    assert(ret['retval'] == 1033)
+
+def test_minversions_conf_multiple(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    set_minversions_conf(utils, "bogus=1.2.3 {}={}".format(pkgname, utils.config["mulversion_higher"]))
+    utils.install_package(pkgname)
+    ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
+    print (ret)
+    assert(ret['retval'] == 1033)
+
+def test_minversions_file(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    set_minversions_file(utils, "{}={}".format(pkgname, utils.config["mulversion_higher"]))
+    utils.install_package(pkgname)
+    ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
+    print (ret)
+    assert(ret['retval'] == 1033)
+
+def test_minversions_file_multiple(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    set_minversions_file(utils, "bogus=1.2.3\n{}={}".format(pkgname, utils.config["mulversion_higher"]))
+    utils.install_package(pkgname)
+    ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
+    print (ret)
+    assert(ret['retval'] == 1033)
+
+


### PR DESCRIPTION
This adds a config option to prevent downgrades below a specified version. This can be configured in the main config file (`/etc/tdnf/tdnf.conf`) like:
```
minversions=tdnf=3.1.4-1
```
Multiple packages can be specified separated by spaces.

Alternatively, packages can be set in files with names match `*.conf` in the directory `/etc/tdnf/minversions.d`, with one package per line:
```
tdnf=3.1.4-1
```
These can be easily added (and owned) by packages.
