### PR TITLE
lock early and long

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -220,5 +220,6 @@ typedef enum
     {ERROR_TDNF_CURLE_UNSUPPORTED_PROTOCOL,          "ERROR_TDNF_CURLE_UNSUPPORTED_PROTOCOL",          "Curl doesn't Support this protocol"},\
     {ERROR_TDNF_CURLE_FAILED_INIT,                   "ERROR_TDNF_CURLE_FAILED_INIT",                   "Curl Init Failed"},\
     {ERROR_TDNF_CURLE_URL_MALFORMAT,                 "ERROR_TDNF_CURLE_URL_MALFORMAT",                 "URL seems to be corrupted. Please clean all and makecache"},\
+    {ERROR_TDNF_RPMTS_LOCK_FAILED,                   "ERROR_TDNF_RPMTS_LOCK_FAILED",                   "Failed to lock the RPM database"},\
     {ERROR_TDNF_SYSTEM_BASE,                         "ERROR_TDNF_SYSTEM_BASE",                         "unknown system error"},\
 };

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -145,6 +145,7 @@ extern "C" {
 #define ERROR_TDNF_NO_PLUGIN_ERROR           1522
 #define ERROR_TDNF_NO_GPGKEY_CONF_ENTRY      1523
 #define ERROR_TDNF_URL_INVALID               1524
+#define ERROR_TDNF_RPMTS_LOCK_FAILED         1525
 
 //RPM Transaction
 #define ERROR_TDNF_TRANSACTION_FAILED        1525


### PR DESCRIPTION
This is another way than pr #258 to lock the db database. This locks it as early as possible and releases it as late as possible. This still runs into the same issue as https://github.com/rpm-software-management/rpm/issues/1761 , but this most likely cannot be addressed in tdnf.