### PR TITLE
wait for lock until timeout

### DIFF
--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -27,6 +27,9 @@
  */
 #define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instance-lockfile"
 
+/* wait for lock retries, interval is 1s */
+#define TDNF_LOCK_MAX_RETRIES 300
+
 #define BAIL_ON_CLI_ERROR(unError) \
     do {                                                           \
         if (unError)                                               \


### PR DESCRIPTION
Generating the cache can take about a minute if the repository is large (Photon 3.0). On Photon there is a systemd unit that runs `update-info` on startup. This can break testing scripts that run right after booting. This change will make tdnf wait to acquire the lock for up to 5 minutes before timing out and exiting.