### PR TITLE
ci: use Fedora 34 because of gpg issues

### DIFF
--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:34
 
 RUN dnf -q -y upgrade
 RUN dnf -q -y install gcc make cmake libcurl-devel rpm-devel rpm-build libsolv-devel \


### PR DESCRIPTION
With Fedora 35, generating gpg keys with the config in `pytests/repo/setup-repo.sh` is no longer working (`gpg: key generation failed: Unknown elliptic curve`). This causes signature tests to fail. Until we found a config that works, let's stay with Fedora 34.