### PR TITLE
check file from command line for rpm extension

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -775,12 +775,16 @@ TDNFAddCmdLinePackages(
 
     for(nCmdIndex = 1; nCmdIndex < pCmdArgs->nCmdCount; ++nCmdIndex)
     {
+        /* Add packages with URLs or filenames on the command line
+         * to our virtual @cmdline repo */
         pszPkgName = pCmdArgs->ppszCmds[nCmdIndex];
 
         dwError = TDNFIsFileOrSymlink(pszPkgName, &nIsFile);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        if (nIsFile)
+        /* if it's a file and matches *.rpm it's to be installed
+         * directly as a file. No need to download. */
+        if (nIsFile && (fnmatch("*.rpm", pszPkgName, 0) == 0))
         {
             pszRPMPath = realpath(pszPkgName, NULL);
             if (pszRPMPath == NULL)
@@ -791,36 +795,38 @@ TDNFAddCmdLinePackages(
         }
         else
         {
-             dwError = TDNFUriIsRemote(pszPkgName, &nIsRemote);
-             if (dwError == ERROR_TDNF_URL_INVALID)
-             {
-                 /* not a URL => normal pkg name, nothing to do here */
-                 dwError = 0;
-                 continue;
-             }
-             BAIL_ON_TDNF_ERROR(dwError);
-             if (!nIsRemote)
-             {
-                 dwError = TDNFPathFromUri(pszPkgName, &pszRPMPath);
-                 BAIL_ON_TDNF_ERROR(dwError);
-             }
-             else
-             {
-                 dwError = TDNFAllocateString(pszPkgName,
-                                              &pszCopyOfPkgName);
-                 BAIL_ON_TDNF_ERROR(dwError);
+            dwError = TDNFUriIsRemote(pszPkgName, &nIsRemote);
+            if (dwError == ERROR_TDNF_URL_INVALID)
+            {
+                /* not a URL => normal pkg name, nothing to do here */
+                dwError = 0;
+                continue;
+            }
+            BAIL_ON_TDNF_ERROR(dwError);
+            if (!nIsRemote)
+            {
+                /* non-remote URL, like "file:///", no need to download */
+                dwError = TDNFPathFromUri(pszPkgName, &pszRPMPath);
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+            else
+            {
+                /* remote URL, we need to download */
+                dwError = TDNFAllocateString(pszPkgName,
+                                             &pszCopyOfPkgName);
+                BAIL_ON_TDNF_ERROR(dwError);
 
-                 dwError = TDNFDownloadPackageToCache(
-                               pTdnf,
-                               pszPkgName,
-                               basename(pszCopyOfPkgName),
-                               CMDLINE_REPO_NAME,
-                               &pszRPMPath
-                           );
-                 BAIL_ON_TDNF_ERROR(dwError);
+                dwError = TDNFDownloadPackageToCache(
+                              pTdnf,
+                              pszPkgName,
+                              basename(pszCopyOfPkgName),
+                              CMDLINE_REPO_NAME,
+                              &pszRPMPath
+                          );
+                BAIL_ON_TDNF_ERROR(dwError);
 
-                 TDNF_SAFE_FREE_MEMORY(pszCopyOfPkgName);
-             }
+                TDNF_SAFE_FREE_MEMORY(pszCopyOfPkgName);
+	    }
         }
         id = repo_add_rpm(pTdnf->pSolvCmdLineRepo, pszRPMPath,
             REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE|RPM_ADD_WITH_HDRID|RPM_ADD_WITH_SHA256SUM);

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -173,7 +173,7 @@ TDNFPrepareAllPackages(
                dwError = TDNFIsFileOrSymlink(pszPkgName, &nIsFile);
                BAIL_ON_TDNF_ERROR(dwError);
 
-               if (nIsFile)
+               if (nIsFile && (fnmatch("*.rpm", pszPkgName, 0) == 0))
                {
                    continue;
                }

--- a/pytests/tests/test_rpm_cmdline.py
+++ b/pytests/tests/test_rpm_cmdline.py
@@ -125,7 +125,12 @@ def test_install_as_mixed(utils):
     assert(utils.check_package(pkgname) == True)
     assert(utils.check_package(pkgname2) == True)
 
-
-
-
-
+# test installing a package that has the same name as a file
+# example: touch foo; tdnf install foo
+# (file needs to have "*.rpm" extension to qualify)
+def test_install_same_as_filname(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['touch', pkgname])
+    ret = utils.run([ 'tdnf', 'install', '-y', '--nogpgcheck', pkgname])
+    assert(ret['retval']  == 0)
+    assert(utils.check_package(pkgname) == True)


### PR DESCRIPTION
Check file from command line for "*.rpm" extension to avoid confusing a file with a package name. Add a test and comments.

Note to reviewers: there are only two changed lines in functional code, the rest is comments and white space fixes, plus the test code. The only change is changing
`if (nIsFile)`
to
`if (nIsFile && (fnmatch("*.rpm", pszPkgName, 0) == 0))`
in two places.

Closes #270