### PR TITLE
add package lock feature

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -53,6 +53,8 @@ TDNFReadConfig(
     PCONF_SECTION pSection = NULL;
     char *pszConfFileCopy = NULL;
     char *pszMinVersionsDir = NULL;
+    char *pszConfFileCopy2 = NULL;
+    char *pszPkgLocksDir = NULL;
 
     if(!pTdnf ||
        IsNullOrEmptyString(pszConfFile) ||
@@ -155,6 +157,15 @@ TDNFReadConfig(
     dwError = TDNFReadConfFilesFromDir(pszMinVersionsDir, &pConf->ppszMinVersions);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFAllocateString(pszConfFile, &pszConfFileCopy2);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFJoinPath(&pszPkgLocksDir, dirname(pszConfFileCopy2), "locks.d", NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFReadConfFilesFromDir(pszPkgLocksDir, &pConf->ppszPkgLocks);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     pTdnf->pConf = pConf;
 
 cleanup:
@@ -163,7 +174,9 @@ cleanup:
         TDNFFreeConfigData(pData);
     }
     TDNF_SAFE_FREE_MEMORY(pszConfFileCopy);
+    TDNF_SAFE_FREE_MEMORY(pszConfFileCopy2);
     TDNF_SAFE_FREE_MEMORY(pszMinVersionsDir);
+    TDNF_SAFE_FREE_MEMORY(pszPkgLocksDir);
     return dwError;
 
 error:
@@ -314,6 +327,7 @@ TDNFFreeConfig(
         TDNF_SAFE_FREE_MEMORY(pConf->pszBaseArch);
         TDNF_SAFE_FREE_STRINGARRAY(pConf->ppszExcludes);
         TDNF_SAFE_FREE_STRINGARRAY(pConf->ppszMinVersions);
+        TDNF_SAFE_FREE_STRINGARRAY(pConf->ppszPkgLocks);
         TDNFFreeMemory(pConf);
     }
 }

--- a/client/config.c
+++ b/client/config.c
@@ -152,7 +152,7 @@ TDNFReadConfig(
     dwError = TDNFJoinPath(&pszMinVersionsDir, dirname(pszConfFileCopy), "minversions.d", NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFReadMinVersionsFiles(pszMinVersionsDir, &pConf->ppszMinVersions);
+    dwError = TDNFReadConfFilesFromDir(pszMinVersionsDir, &pConf->ppszMinVersions);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pTdnf->pConf = pConf;
@@ -460,27 +460,27 @@ error:
 
 /*
  * Read all minimal versions files from pszDir, and store results into
- * string array pointed to by pppszMinVersions. pppszMinVersions may already
+ * string array pointed to by pppszLines. pppszLines may already
  * have values set from the config file, which are preserved.
  */
 uint32_t
-TDNFReadMinVersionsFiles(
+TDNFReadConfFilesFromDir(
     char *pszDir,
-    char ***pppszMinVersions
+    char ***pppszLines
     )
 {
     uint32_t dwError = 0;
     DIR *pDir = NULL;
     struct dirent *pEnt = NULL;
     char *pszFile = NULL;
-    char **ppszNewMinVersions = NULL;
+    char **ppszNewLines = NULL;
     char ***pppszArrayList = NULL;
     int nFileCount = 0;
     int i, j, k;
     int nLineCount = 0;
     int nTmp = 0;
 
-    if(IsNullOrEmptyString(pszDir) || !pppszMinVersions)
+    if(IsNullOrEmptyString(pszDir) || !pppszLines)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -534,7 +534,7 @@ TDNFReadMinVersionsFiles(
     pDir = NULL;
 
     /* append values that are already set */
-    pppszArrayList[i] = *pppszMinVersions;
+    pppszArrayList[i] = *pppszLines;
 
     /* each file can have multiple lines, count them */
     for (i = 0; pppszArrayList[i]; i++)
@@ -546,20 +546,20 @@ TDNFReadMinVersionsFiles(
     }
 
     /* move the lines from 2 dimensional pppszArrayList to
-     * flat pointer list ppszMinVersions */
-    dwError = TDNFAllocateMemory(nLineCount+1, sizeof(char *), (void **)&ppszNewMinVersions);
+     * flat pointer list ppszLines */
+    dwError = TDNFAllocateMemory(nLineCount+1, sizeof(char *), (void **)&ppszNewLines);
     BAIL_ON_TDNF_ERROR(dwError);
 
     for (i = 0, k = 0; pppszArrayList[i]; i++)
     {
         for (j = 0; pppszArrayList[i][j]; j++)
         {
-            ppszNewMinVersions[k++] = pppszArrayList[i][j];
+            ppszNewLines[k++] = pppszArrayList[i][j];
         }
         TDNF_SAFE_FREE_MEMORY(pppszArrayList[i]);
     }
 
-    *pppszMinVersions = ppszNewMinVersions;
+    *pppszLines = ppszNewLines;
 
 cleanup:
     if (pDir)

--- a/client/goal.c
+++ b/client/goal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -631,15 +631,8 @@ TDNFSolvAddPkgLocks(
     )
 {
     uint32_t dwError = 0;
-    char *pszLocksDir;
-    char *pszConfFileCopy;
     char **ppszPackages = NULL;
-    char *pszPkg = NULL;
-    Id idPkg;
-    Id p;
-    Solvable *s;
     int i;
-    int nFound = 0;
 
     if(!pTdnf || !pQueueJobs || !pPool)
     {
@@ -647,41 +640,28 @@ TDNFSolvAddPkgLocks(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    /* We need a copy of pszConfFile because dirname() modifies its argument */
-    dwError = TDNFAllocateString(pTdnf->pArgs->pszConfFile, &pszConfFileCopy);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    dwError = TDNFJoinPath(&pszLocksDir, dirname(pszConfFileCopy), "locks.d", NULL);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    dwError = TDNFReadConfFilesFromDir(pszLocksDir, &ppszPackages);
-    BAIL_ON_TDNF_ERROR(dwError);
+    ppszPackages = pTdnf->pConf->ppszPkgLocks;
 
     for (i = 0; ppszPackages && ppszPackages[i]; i++)
     {
-        pszPkg = ppszPackages[i];
-        idPkg = pool_str2id(pPool, pszPkg, 1);
+        char *pszPkg = ppszPackages[i];
+        Id idPkg = pool_str2id(pPool, pszPkg, 1);
         if (idPkg)
         {
+            Id p;
+            Solvable *s;
             FOR_REPO_SOLVABLES(pPool->installed, p, s)
             {
                 if (idPkg == s->name)
                 {
-                    nFound = 1;
+                    queue_push2(pQueueJobs, SOLVER_SOLVABLE_NAME|SOLVER_LOCK, idPkg);
                     break;
                 }
-            }
-            if (nFound)
-            {
-                queue_push2(pQueueJobs, SOLVER_SOLVABLE_NAME|SOLVER_LOCK, idPkg);
             }
         }
     }
 
 cleanup:
-    TDNF_SAFE_FREE_MEMORY(pszConfFileCopy);
-    TDNF_SAFE_FREE_MEMORY(pszLocksDir);
-    TDNF_SAFE_FREE_STRINGARRAY(ppszPackages);
     return dwError;
 error:
     goto cleanup;

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -595,7 +595,7 @@ TDNFConfigReplaceVars(
     );
 
 uint32_t
-TDNFReadMinVersionsFiles(
+TDNFReadConfFilesFromDir(
     char *pszDir,
     char ***pppszMinVersions
     );

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -536,6 +536,13 @@ TDNFPkgsToExclude(
     char***  pppszExclude
     );
 
+uint32_t
+TDNFSolvAddPkgLocks(
+    PTDNF pTdnf,
+    Queue* pQueueJobs,
+    Pool *pPool
+    );
+
 //config.c
 int
 TDNFConfGetRpmVerbosity(

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -277,6 +277,7 @@ typedef struct _TDNF_CONF
     char* pszVarBaseArch;
     char** ppszExcludes;
     char** ppszMinVersions;
+    char** ppszPkgLocks;
 }TDNF_CONF, *PTDNF_CONF;
 
 typedef struct _TDNF_REPO_DATA

--- a/pytests/tests/test_locks.py
+++ b/pytests/tests/test_locks.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import pytest
+import errno
+import shutil
+
+TESTREPO='photon-test'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    dirname = os.path.join(utils.config['repo_path'], 'locks.d')
+    if os.path.isdir(dirname):
+        shutil.rmtree(dirname)
+
+    utils.erase_package(utils.config["sglversion_pkgname"])
+    utils.erase_package(utils.config["mulversion_pkgname"])
+
+# helper to create directory tree without complains when it exists:
+def makedirs(d):
+    try:
+        os.makedirs(d)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
+
+def set_locks_file(utils, value):
+    dirname = os.path.join(utils.config['repo_path'], 'locks.d')
+    makedirs(dirname)
+    filename = os.path.join(dirname, 'test.conf')
+    with open(filename, 'w') as f:
+        f.write(value)
+
+def test_locks_conf_erase(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    set_locks_file(utils, pkgname)
+    utils.install_package(pkgname)
+
+    # sanity check
+    assert(utils.check_package(pkgname))
+
+    # test - uninstalling should fail
+    utils.run(['tdnf', '-y', '--nogpgcheck', 'remove', pkgname])
+    assert(utils.check_package(pkgname))
+
+
+def test_locks_conf_update(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    version_low = utils.config["mulversion_lower"]
+    version_high = utils.config["mulversion_higher"]
+    set_locks_file(utils, pkgname)
+
+    utils.install_package(pkgname, pkgversion=version_low)
+    assert(utils.check_package(pkgname))
+   
+    # test - update should fail
+    utils.run(['tdnf', '-y', '--nogpgcheck', 'update', pkgname])
+    assert(utils.check_package(pkgname, version=version_low))
+


### PR DESCRIPTION
This adds the package lock feature. An installed package can be "locked", which means that it cannot be removed, updated or downgraded with tdnf.

To use it, create a directory `locks.d` in the same directory as the tdnf config file (usually `/etc/tdnf/` , unless overwritten with the `-c` option), and create a file with the extension `.conf` with one package name per line. For example:
```
tdnf install lsof
mkdir /etc/tdnf/locks.d
echo lsof > /etc/tdnf/locks.d/lsof.conf
```

