### PR TITLE
De-duplicate error code for ERROR_TDNF_DOWNGRADE_NOT_ALLOWED

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -219,6 +219,7 @@ typedef enum
     {ERROR_TDNF_PERM, "ERROR_TDNF_PERM", "Operation not permitted. You have to be root."},\
     {ERROR_TDNF_OPT_NOT_FOUND, "ERROR_TDNF_OPT_NOT_FOUND", "A required option was not found"},\
     {ERROR_TDNF_OPERATION_ABORTED, "ERROR_TDNF_OPERATION_ABORTED", "Operation aborted."},\
+    {ERROR_TDNF_INVALID_INPUT, "ERROR_TDNF_INVALID_INPUT", "Invalid input."},\
     {ERROR_TDNF_CACHE_DISABLED, "ERROR_TDNF_CACHE_DISABLED", "cache only is set, but no repo data found"},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to deactivate all plugins or --disableplugin=<plugin> to deactivate a specific one. You can permanently deactivate an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to deactivate all plugins or --disableplugin=<plugin> to deactivate a specific one. You can permanently deactivate an offending plugin by setting enable=0 in the plugin config file."},\

--- a/common/utils.c
+++ b/common/utils.c
@@ -464,7 +464,6 @@ TDNFYesOrNo(
         opt = tolower(opt);
         if (opt != 'y' && opt != 'n')
         {
-            pr_err("Invalid input\n");
             dwError = ERROR_TDNF_INVALID_INPUT;
             BAIL_ON_TDNF_ERROR(dwError);
         }

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -64,13 +64,11 @@ extern "C" {
 #define ERROR_TDNF_SELF_ERASE               1030
 #define ERROR_TDNF_ERASE_NEEDS_INSTALL      1031
 #define ERROR_TDNF_OPERATION_ABORTED        1032
-#define ERROR_TDNF_DOWNGRADE_NOT_ALLOWED    1033
-
 // for invalid input on interactive questions
 #define ERROR_TDNF_INVALID_INPUT            1033
-
 // cache only set, but no cache available
 #define ERROR_TDNF_CACHE_DISABLED           1034
+#define ERROR_TDNF_DOWNGRADE_NOT_ALLOWED    1035
 
 //curl errors
 #define ERROR_TDNF_CURL_INIT                  1200

--- a/pytests/tests/test_minversions.py
+++ b/pytests/tests/test_minversions.py
@@ -60,7 +60,7 @@ def test_minversions_conf(utils):
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
     print (ret)
-    assert(ret['retval'] == 1033)
+    assert(ret['retval'] == 1035)
 
 def test_minversions_conf_multiple(utils):
     pkgname = utils.config["mulversion_pkgname"]
@@ -68,7 +68,7 @@ def test_minversions_conf_multiple(utils):
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
     print (ret)
-    assert(ret['retval'] == 1033)
+    assert(ret['retval'] == 1035)
 
 def test_minversions_file(utils):
     pkgname = utils.config["mulversion_pkgname"]
@@ -76,7 +76,7 @@ def test_minversions_file(utils):
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
     print (ret)
-    assert(ret['retval'] == 1033)
+    assert(ret['retval'] == 1035)
 
 def test_minversions_file_multiple(utils):
     pkgname = utils.config["mulversion_pkgname"]
@@ -84,6 +84,6 @@ def test_minversions_file_multiple(utils):
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
     print (ret)
-    assert(ret['retval'] == 1033)
+    assert(ret['retval'] == 1035)
 
 


### PR DESCRIPTION
Error code for ERROR_TDNF_DOWNGRADE_NOT_ALLOWED was same as ERROR_TDNF_INVALID_INPUT, so the error message for an invalid input was wrong:
```
# tdnf remove lsof

Removing:
lsof                                     aarch64              4.91-1.ph4                  @System              202.36k 207218

Total installed size: 202.36k 207218
Is this ok [y/N]: X
Invalid input
Error(1033) : a downgrade is not allowed below the minimal version. Check 'minversions' in the configuration.
```

Fixing this. Also, add the message to the list of error strings, instead of printing it out from `TDNFYesOrNo()`.

Example:
```
# ./bin/tdnf remove lsof

Removing:
lsof                                     aarch64              4.91-1.ph4                  @System              202.36k 207218

Total installed size: 202.36k 207218
Is this ok [y/N]: X
Error(1033) : Invalid input.
```


