### PR TITLE
implement autoremove feature

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1580,12 +1580,6 @@ TDNFResolve(
         queue_init(&queueGoal);
     }
 
-    if(nAlterType == ALTER_AUTOERASE)
-    {
-        dwError = ERROR_TDNF_AUTOERASE_UNSUPPORTED;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
     dwError = TDNFValidateCmdArgs(pTdnf);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/config.c
+++ b/client/config.c
@@ -586,37 +586,3 @@ cleanup:
 error:
     goto cleanup;
 }
-
-/* read all lines in file pszFile and store in string array
- * pointed to by pppszArray, one entry for each line */
-uint32_t
-TDNFReadFileToStringArray(
-    const char *pszFile,
-    char ***pppszArray
-    )
-{
-    uint32_t dwError = 0;
-    int nLength = 0;
-    char *pszText = NULL;
-    char **ppszArray = NULL;
-
-    if (!pszFile || !pppszArray)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    dwError = TDNFFileReadAllText(pszFile, &pszText, &nLength);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    dwError = TDNFSplitStringToArray(pszText, "\n", &ppszArray);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    *pppszArray = ppszArray;
-cleanup:
-    TDNF_SAFE_FREE_MEMORY(pszText);
-    return dwError;
-error:
-    TDNF_SAFE_FREE_STRINGARRAY(ppszArray);
-    goto cleanup;
-}

--- a/client/defines.h
+++ b/client/defines.h
@@ -127,6 +127,9 @@ typedef enum
 #define TDNF_REPO_METALINK_FILE_NAME      "metalink"
 #define TDNF_REPO_BASEURL_FILE_NAME       "baseurl"
 
+#define TDNF_AUTOINSTALLED_FILE           "autoinstalled"
+#define TDNF_DEFAULT_DATA_LOCATION        "/var/lib/tdnf"
+
 // repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
 #define TDNF_DEFAULT_CACHE_LOCATION       "/var/cache/tdnf"

--- a/client/goal.c
+++ b/client/goal.c
@@ -357,6 +357,12 @@ TDNFGoal(
     {
         nFlags = nFlags | SOLVER_FORCEBEST;
     }
+
+    if (pTdnf->pConf->nCleanRequirementsOnRemove)
+    {
+        nFlags = nFlags | SOLVER_CLEANDEPS;
+    }
+
     dwError = SolvAddFlagsToJobs(&queueJobs, nFlags);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/goal.c
+++ b/client/goal.c
@@ -420,7 +420,7 @@ TDNFGoal(
 
         if (nAlterType == ALTER_UPGRADE && dwExcludeCount != 0 && ppszExcludes)
         {
-            /* if we had packages to exclude, then we'd have disabled ones too */
+            /* if we had packages to exclude, then we'd have inactive ones too */
             dwSkipProblem |= SKIPPROBLEM_DISABLED;
         }
 
@@ -671,17 +671,16 @@ TDNFMarkAutoInstalled(
             fprintf(fp, "%s\n", ppszAutoInstalled[i]);
         }
     }
-    fclose(fp);
 
 cleanup:
-    TDNF_SAFE_FREE_MEMORY(pszAutoFile);
-    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
-    return dwError;
-error:
     if (fp)
     {
         fclose(fp);
     }
+    TDNF_SAFE_FREE_MEMORY(pszAutoFile);
+    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
+    return dwError;
+error:
     goto cleanup;
 }
 

--- a/client/goal.c
+++ b/client/goal.c
@@ -316,6 +316,7 @@ TDNFGoal(
     int nProblems = 0;
     char** ppszExcludes = NULL;
     uint32_t dwExcludeCount = 0;
+    char **ppszAutoInstalled = NULL;
 
     if(!pTdnf || !ppInfo || !pQueuePkgList)
     {
@@ -357,8 +358,9 @@ TDNFGoal(
     {
         nFlags = nFlags | SOLVER_FORCEBEST;
     }
-
-    if (pTdnf->pConf->nCleanRequirementsOnRemove)
+    if ((pTdnf->pConf->nCleanRequirementsOnRemove &&
+         !pTdnf->pArgs->nNoAutoRemove) ||
+        nAlterType == ALTER_AUTOERASE)
     {
         nFlags = nFlags | SOLVER_CLEANDEPS;
     }
@@ -394,6 +396,12 @@ TDNFGoal(
        nAlterType == ALTER_ERASE ||
        nAlterType == ALTER_AUTOERASE)
     {
+        dwError = TDNFReadAutoInstalled(pTdnf, &ppszAutoInstalled);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvAddUserInstalledToJobs(&queueJobs, pTdnf->pSack->pPool, ppszAutoInstalled);
+        BAIL_ON_TDNF_ERROR(dwError);
+
         solver_set_flag(pSolv, SOLVER_FLAG_ALLOW_UNINSTALL, 1);
     }
     solver_set_flag(pSolv, SOLVER_FLAG_BEST_OBEY_POLICY, 1);
@@ -412,7 +420,7 @@ TDNFGoal(
 
         if (nAlterType == ALTER_UPGRADE && dwExcludeCount != 0 && ppszExcludes)
         {
-            /* if we had packages to exclude, then we'd have diabled ones too */
+            /* if we had packages to exclude, then we'd have disabled ones too */
             dwSkipProblem |= SKIPPROBLEM_DISABLED;
         }
 
@@ -434,16 +442,22 @@ TDNFGoal(
     }
 
     dwError = TDNFGoalGetAllResultsIgnoreNoData(
-                  nAlterType,
                   pTrans,
                   pSolv,
                   &pInfoTemp,
                   pTdnf);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    if (nAlterType == ALTER_INSTALL)
+    {
+        dwError = TDNFAddUserInstall(pTdnf, pQueuePkgList, pInfoTemp);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     *ppInfo = pInfoTemp;
 
 cleanup:
+    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
     TDNF_SAFE_FREE_STRINGARRAY(ppszExcludes);
     queue_free(&queueJobs);
     if(pTrans)
@@ -465,6 +479,211 @@ error:
     goto cleanup;
 }
 
+uint32_t
+TDNFAddUserInstall(
+    PTDNF pTdnf,
+    Queue* pQueueGoal,
+    PTDNF_SOLVED_PKG_INFO ppInfo
+    )
+{
+    uint32_t dwError = 0;
+    int i;
+    char **ppszPkgsUserInstall = NULL;
+
+    if (!pTdnf || !pQueueGoal || !ppInfo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFAllocateMemory(pQueueGoal->count + 1,
+                                 sizeof(char **),
+                                 (void **)&ppszPkgsUserInstall);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    for (i = 0; i < pQueueGoal->count; i++)
+    {
+        dwError = SolvGetPkgNameFromId(
+                       pTdnf->pSack,
+                       pQueueGoal->elements[i],
+                       &ppszPkgsUserInstall[i]);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    ppInfo->ppszPkgsUserInstall = ppszPkgsUserInstall;
+cleanup:
+    return dwError;
+error:
+    TDNF_SAFE_FREE_MEMORY(ppszPkgsUserInstall);
+    goto cleanup;
+}
+
+uint32_t
+TDNFMarkAutoInstalledSinglePkg(
+    PTDNF pTdnf,
+    const char *pszPkgName
+)
+{
+    uint32_t dwError = 0;
+    char **ppszAutoInstalled = NULL;
+    char *pszAutoFile = NULL;
+    int i;
+    FILE *fp = NULL;
+
+    if (!pTdnf || !pszPkgName)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFReadAutoInstalled(pTdnf, &ppszAutoInstalled);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFJoinPath(&pszAutoFile,
+                           pTdnf->pArgs->pszInstallRoot,
+                           TDNF_DEFAULT_DATA_LOCATION,
+                           TDNF_AUTOINSTALLED_FILE,
+                           NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    fp = fopen(pszAutoFile, "w");
+    if(!fp)
+    {
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+    }
+
+    for (i = 0; ppszAutoInstalled[i]; i++)
+    {
+        if (strcmp(ppszAutoInstalled[i], pszPkgName) == 0)
+        {
+            pr_info("marking %s as user installed\n", pszPkgName);
+            continue;
+        }
+        fprintf(fp, "%s\n", ppszAutoInstalled[i]);
+    }
+    fclose(fp);
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszAutoFile);
+    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
+    return dwError;
+error:
+    if (fp)
+    {
+        fclose(fp);
+    }
+    goto cleanup;
+}
+
+uint32_t
+TDNFMarkAutoInstalled(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO ppInfo
+    )
+{
+    uint32_t dwError = 0;
+    PTDNF_PKG_INFO pPkgInfo = NULL;
+    char **ppszAutoInstalled = NULL;
+    int i, j;
+    int nCount = 0;
+    int nCountOld = 0;
+    FILE *fp = NULL;
+    char *pszAutoFile = NULL;
+    char *pszDataDir = NULL;
+
+    if (!pTdnf || !ppInfo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFReadAutoInstalled(pTdnf, &ppszAutoInstalled);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    if (ppszAutoInstalled != NULL)
+    {
+        dwError = TDNFStringArrayCount(ppszAutoInstalled, &nCount);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    nCountOld = nCount;
+    for (pPkgInfo = ppInfo->pPkgsToInstall; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
+    {
+        nCount++;
+    }
+
+    dwError = TDNFReAllocateMemory((nCount+1) * sizeof(char **), (void **)&ppszAutoInstalled);
+    BAIL_ON_TDNF_ERROR(dwError);
+    ppszAutoInstalled[nCount] = NULL;
+
+    for (pPkgInfo = ppInfo->pPkgsToInstall; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
+    {
+        dwError = TDNFAllocateString(pPkgInfo->pszName, &ppszAutoInstalled[nCountOld++]);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFStringArraySort(ppszAutoInstalled);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFJoinPath(&pszDataDir,
+                           pTdnf->pArgs->pszInstallRoot,
+                           TDNF_DEFAULT_DATA_LOCATION,
+                           NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFUtilsMakeDir(pszDataDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFJoinPath(&pszAutoFile,
+                           pTdnf->pArgs->pszInstallRoot,
+                           TDNF_DEFAULT_DATA_LOCATION,
+                           TDNF_AUTOINSTALLED_FILE,
+                           NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    fp = fopen(pszAutoFile, "w");
+    if(!fp)
+    {
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+    }
+
+    for (i = 0; ppszAutoInstalled[i]; i++)
+    {
+        if (i > 0 && strcmp(ppszAutoInstalled[i-1], ppszAutoInstalled[i]) == 0)
+        {
+            continue;
+        }
+        if (ppInfo->ppszPkgsUserInstall)
+        {
+            for (j = 0; ppInfo->ppszPkgsUserInstall[j]; j++)
+            {
+                if (strcmp(ppszAutoInstalled[i],
+                           ppInfo->ppszPkgsUserInstall[j]) == 0)
+                {
+                    break;
+                }
+            }
+        }
+        if (!ppInfo->ppszPkgsUserInstall || ppInfo->ppszPkgsUserInstall[j] == NULL)
+        {
+            fprintf(fp, "%s\n", ppszAutoInstalled[i]);
+        }
+    }
+    fclose(fp);
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszAutoFile);
+    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
+    return dwError;
+error:
+    if (fp)
+    {
+        fclose(fp);
+    }
+    goto cleanup;
+}
 
 uint32_t
 TDNFAddGoal(
@@ -521,6 +740,7 @@ TDNFAddGoal(
             BAIL_ON_TDNF_ERROR(dwError);
             break;
         case ALTER_ERASE:
+        case ALTER_AUTOERASE:
             dwError = SolvAddPkgEraseJob(pQueueJobs, dwId);
             BAIL_ON_TDNF_ERROR(dwError);
             break;
@@ -528,10 +748,6 @@ TDNFAddGoal(
         case ALTER_INSTALL:
         case ALTER_UPGRADE:
             dwError = SolvAddPkgInstallJob(pQueueJobs, dwId);
-            BAIL_ON_TDNF_ERROR(dwError);
-            break;
-        case ALTER_AUTOERASE:
-            dwError = SolvAddPkgUserInstalledJob(pQueueJobs, dwId);
             BAIL_ON_TDNF_ERROR(dwError);
             break;
         default:
@@ -549,7 +765,6 @@ error:
 
 uint32_t
 TDNFGoalGetAllResultsIgnoreNoData(
-    int nResolveFor,
     Transaction* pTrans,
     Solver* pSolv,
     PTDNF_SOLVED_PKG_INFO* ppInfo,
@@ -596,14 +811,6 @@ TDNFGoalGetAllResultsIgnoreNoData(
                   &pInfo->pPkgsToRemove);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if(nResolveFor == ALTER_AUTOERASE)
-    {
-        dwError = TDNFGetUnneededPackages(
-                      pSolv,
-                      pTdnf,
-                      &pInfo->pPkgsUnNeeded);
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
     dwError = TDNFGetReinstallPackages(
                   pTrans,
                   pTdnf,

--- a/client/init.c
+++ b/client/init.c
@@ -57,6 +57,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nIPv6          = pCmdArgsIn->nIPv6;
     pCmdArgs->nDisableExcludes = pCmdArgsIn->nDisableExcludes;
     pCmdArgs->nDownloadOnly  = pCmdArgsIn->nDownloadOnly;
+    pCmdArgs->nNoAutoRemove  = pCmdArgsIn->nNoAutoRemove;
 
     dwError = TDNFAllocateString(
                   pCmdArgsIn->pszInstallRoot,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -608,12 +608,6 @@ TDNFReadConfFilesFromDir(
     char ***pppszMinVersions
     );
 
-uint32_t
-TDNFReadFileToStringArray(
-    const char *pszFile,
-    char ***pppszArray
-    );
-
 //repo.c
 uint32_t
 TDNFInitRepoFromMetadata(

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -448,6 +448,25 @@ TDNFGoal(
     );
 
 uint32_t
+TDNFAddUserInstall(
+    PTDNF pTdnf,
+    Queue* pQueueGoal,
+    PTDNF_SOLVED_PKG_INFO ppInfo
+    );
+
+uint32_t
+TDNFMarkAutoInstalledSinglePkg(
+    PTDNF pTdnf,
+    const char *pszPkgName
+);
+
+uint32_t
+TDNFMarkAutoInstalled(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO ppInfo
+    );
+
+uint32_t
 TDNFAddGoal(
     PTDNF pTdnf,
     TDNF_ALTERTYPE nAlterType,
@@ -459,7 +478,6 @@ TDNFAddGoal(
 
 uint32_t
 TDNFGoalGetAllResultsIgnoreNoData(
-    int nResolveFor,
     Transaction* pTrans,
     Solver* pSolv,
     PTDNF_SOLVED_PKG_INFO* ppInfo,
@@ -1074,6 +1092,12 @@ TDNFGetCmdOpt(
     PTDNF pTdnf,
     TDNF_CMDOPT_TYPE cmdType,
     PTDNF_CMD_OPT *ppOpt
+    );
+
+uint32_t
+TDNFReadAutoInstalled(
+    PTDNF pTdnf,
+    char ***pppszAutoInstalled
     );
 
 //validate.c

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -385,8 +385,12 @@ TDNFPrepareSinglePkg(
                       pszPkgName);
         if (dwError == ERROR_TDNF_ALREADY_INSTALLED)
         {
+            /* the package may have been already installed as a dependency,
+               but now the user wants it on its own */
             dwError = TDNFMarkAutoInstalledSinglePkg(pTdnf, pszPkgName);
             BAIL_ON_TDNF_ERROR(dwError);
+            /* if TDNFMarkAutoInstalledSinglePkg() was successful, restore
+               the original error */
             dwError = ERROR_TDNF_ALREADY_INSTALLED;
         }
         BAIL_ON_TDNF_ERROR(dwError);

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -84,10 +84,9 @@ TDNFPrepareAllPackages(
     pCmdArgs = pTdnf->pArgs;
     nAlterType = *pAlterType;
 
-    if(nAlterType == ALTER_DOWNGRADEALL ||
-       nAlterType == ALTER_AUTOERASE)
+    if(nAlterType == ALTER_DOWNGRADEALL)
     {
-        dwError =  TDNFFilterPackages(
+        dwError = TDNFFilterPackages(
                        pTdnf,
                        nAlterType,
                        ppszPkgsNotResolved,
@@ -384,6 +383,12 @@ TDNFPrepareSinglePkg(
                       pSack,
                       queueGoal,
                       pszPkgName);
+        if (dwError == ERROR_TDNF_ALREADY_INSTALLED)
+        {
+            dwError = TDNFMarkAutoInstalledSinglePkg(pTdnf, pszPkgName);
+            BAIL_ON_TDNF_ERROR(dwError);
+            dwError = ERROR_TDNF_ALREADY_INSTALLED;
+        }
         BAIL_ON_TDNF_ERROR(dwError);
     }
     else if (nAlterType == ALTER_UPGRADE)

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -102,6 +102,9 @@ TDNFRpmExecTransaction(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    dwError = TDNFMarkAutoInstalled(pTdnf, pSolvedInfo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
 cleanup:
     if(ts.pTS)
     {

--- a/client/utils.c
+++ b/client/utils.c
@@ -775,10 +775,11 @@ TDNFReadAutoInstalled(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFAllocateStringPrintf(&pszAutoFile, "%s/%s/%s",
+    dwError = TDNFJoinPath(&pszAutoFile,
             pTdnf->pArgs->pszInstallRoot,
             TDNF_DEFAULT_DATA_LOCATION,
-            TDNF_AUTOINSTALLED_FILE);
+            TDNF_AUTOINSTALLED_FILE,
+            NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFReadFileToStringArray(pszAutoFile, &ppszAutoInstalled);

--- a/client/utils.c
+++ b/client/utils.c
@@ -759,3 +759,41 @@ error:
     return dwError;
 }
 
+uint32_t
+TDNFReadAutoInstalled(
+    PTDNF pTdnf,
+    char ***pppszAutoInstalled
+    )
+{
+    uint32_t dwError = 0;
+    char **ppszAutoInstalled = NULL;
+    char *pszAutoFile = NULL;
+
+    if (!pTdnf || !pppszAutoInstalled)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFAllocateStringPrintf(&pszAutoFile, "%s/%s/%s",
+            pTdnf->pArgs->pszInstallRoot,
+            TDNF_DEFAULT_DATA_LOCATION,
+            TDNF_AUTOINSTALLED_FILE);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFReadFileToStringArray(pszAutoFile, &ppszAutoInstalled);
+    if (dwError == ERROR_TDNF_SYSTEM_BASE + ENOENT)
+    {
+        dwError = 0;
+    }
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    *pppszAutoInstalled = ppszAutoInstalled;
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszAutoFile);
+    return dwError;
+error:
+    TDNF_SAFE_FREE_STRINGARRAY(ppszAutoInstalled);
+    goto cleanup;
+}
+

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -259,6 +259,12 @@ uint32_t
 TDNFJoinPath(
     char **ppszPath, ...);
 
+uint32_t
+TDNFReadFileToStringArray(
+    const char *pszFile,
+    char ***pppszArray
+    );
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/common/strings.c
+++ b/common/strings.c
@@ -99,7 +99,7 @@ TDNFStringSepCount(
     uint32_t dwError = 0;
     const char *pszTemp = NULL;
 
-    if (IsNullOrEmptyString(pszBuf) || IsNullOrEmptyString(pszSep))
+    if (!pszBuf || IsNullOrEmptyString(pszSep))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -143,7 +143,7 @@ TDNFSplitStringToArray(
     size_t nCount = 0;
     size_t nIndex = 0;
 
-    if (IsNullOrEmptyString(pszBuf) || IsNullOrEmptyString(pszSep))
+    if (!pszBuf || IsNullOrEmptyString(pszSep))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -538,7 +538,7 @@ TDNFStringArraySort(
     uint32_t dwError = 0;
     int nCount;
 
-    if (IsNullOrEmptyString(ppszArray))
+    if (!ppszArray)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);

--- a/common/utils.c
+++ b/common/utils.c
@@ -858,3 +858,37 @@ error:
     goto cleanup;
 }
 
+/* read all lines in file pszFile and store in string array
+ * pointed to by pppszArray, one entry for each line */
+uint32_t
+TDNFReadFileToStringArray(
+    const char *pszFile,
+    char ***pppszArray
+    )
+{
+    uint32_t dwError = 0;
+    int nLength = 0;
+    char *pszText = NULL;
+    char **ppszArray = NULL;
+
+    if (!pszFile || !pppszArray)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFFileReadAllText(pszFile, &pszText, &nLength);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFSplitStringToArray(pszText, "\n", &ppszArray);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    *pppszArray = ppszArray;
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszText);
+    return dwError;
+error:
+    TDNF_SAFE_FREE_STRINGARRAY(ppszArray);
+    goto cleanup;
+}
+

--- a/common/utils.c
+++ b/common/utils.c
@@ -260,7 +260,6 @@ TDNFFreeSolvedPackageInfo(
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
     )
 {
-    int i = 0;
     if(pSolvedPkgInfo)
     {
         TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsNotAvailable);
@@ -274,15 +273,8 @@ TDNFFreeSolvedPackageInfo(
         TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsObsoleted);
         TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsRemovedByDowngrade);
 
-        if(pSolvedPkgInfo->ppszPkgsNotResolved)
-        {
-            while(pSolvedPkgInfo->ppszPkgsNotResolved[i])
-            {
-                TDNF_SAFE_FREE_MEMORY(
-                    pSolvedPkgInfo->ppszPkgsNotResolved[i++]);
-            }
-        }
-        TDNF_SAFE_FREE_MEMORY(pSolvedPkgInfo->ppszPkgsNotResolved);
+        TDNF_SAFE_FREE_STRINGARRAY(pSolvedPkgInfo->ppszPkgsNotResolved);
+        TDNF_SAFE_FREE_STRINGARRAY(pSolvedPkgInfo->ppszPkgsUserInstall);
     }
     TDNF_SAFE_FREE_MEMORY(pSolvedPkgInfo);
 }

--- a/common/utils.c
+++ b/common/utils.c
@@ -274,16 +274,6 @@ TDNFFreeSolvedPackageInfo(
         TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsObsoleted);
         TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsRemovedByDowngrade);
 
-        if(pSolvedPkgInfo->ppszPkgsNotInstalled)
-        {
-            while(pSolvedPkgInfo->ppszPkgsNotInstalled[i])
-            {
-                TDNF_SAFE_FREE_MEMORY(
-                    pSolvedPkgInfo->ppszPkgsNotInstalled[i++]);
-            }
-        }
-        TDNF_SAFE_FREE_MEMORY(pSolvedPkgInfo->ppszPkgsNotInstalled);
-
         if(pSolvedPkgInfo->ppszPkgsNotResolved)
         {
             while(pSolvedPkgInfo->ppszPkgsNotResolved[i])

--- a/etc/tdnf/tdnf.conf
+++ b/etc/tdnf/tdnf.conf
@@ -1,6 +1,5 @@
 [main]
 gpgcheck=1
 installonly_limit=3
-clean_requirements_on_remove=true
 repodir=/etc/yum.repos.d
 cachedir=/var/cache/tdnf

--- a/etc/tdnf/tdnf.conf
+++ b/etc/tdnf/tdnf.conf
@@ -1,5 +1,6 @@
 [main]
 gpgcheck=1
 installonly_limit=3
+clean_requirements_on_remove=0
 repodir=/etc/yum.repos.d
 cachedir=/var/cache/tdnf

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -199,7 +199,6 @@ typedef struct _TDNF_SOLVED_PKG_INFO
     PTDNF_PKG_INFO pPkgsObsoleted;
     PTDNF_PKG_INFO pPkgsRemovedByDowngrade;
     char** ppszPkgsNotResolved;
-    char** ppszPkgsNotInstalled;
 }TDNF_SOLVED_PKG_INFO, *PTDNF_SOLVED_PKG_INFO;
 
 /*

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -199,6 +199,7 @@ typedef struct _TDNF_SOLVED_PKG_INFO
     PTDNF_PKG_INFO pPkgsObsoleted;
     PTDNF_PKG_INFO pPkgsRemovedByDowngrade;
     char** ppszPkgsNotResolved;
+    char** ppszPkgsUserInstall;
 }TDNF_SOLVED_PKG_INFO, *PTDNF_SOLVED_PKG_INFO;
 
 /*
@@ -249,6 +250,7 @@ typedef struct _TDNF_CMD_ARGS
     int nIPv6;             //resolve to IPv6 addresses only
     int nDisableExcludes;  //disable excludes from tdnf.conf
     int nDownloadOnly;     //download packages only, no install
+    int nNoAutoRemove;     //overide clean_requirements_on_remove config option
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/pytests/repo/tdnf-test-cleanreq-leaf1.spec
+++ b/pytests/repo/tdnf-test-cleanreq-leaf1.spec
@@ -1,0 +1,35 @@
+#
+# tdnf-test-one spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-test-cleanreq-leaf1
+Version:    1.0.1
+Release:    3
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+Requires:   tdnf-test-cleanreq-required
+
+%description
+Part of tdnf test spec. Basic install/remove/upgrade test
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/lib/cleanreq/
+touch %_topdir/%buildroot/lib/cleanreq/%name
+
+%files
+/lib/cleanreq/%name
+
+%changelog
+*   Thu Nov 04 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-3
+-   clean req test
+*   Tue Nov 15 2016 Xiaolin Li <xiaolinl@vmware.com> 1.0.1-2
+-   Add a service file for whatprovides test.
+*   Tue Dec 15 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0
+-   Initial build.  First version

--- a/pytests/repo/tdnf-test-cleanreq-leaf2.spec
+++ b/pytests/repo/tdnf-test-cleanreq-leaf2.spec
@@ -1,0 +1,35 @@
+#
+# tdnf-test-one spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-test-cleanreq-leaf2
+Version:    1.0.1
+Release:    3
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+Requires:   tdnf-test-cleanreq-required
+
+%description
+Part of tdnf test spec. Basic install/remove/upgrade test
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/lib/cleanreq/
+touch %_topdir/%buildroot/lib/cleanreq/%name
+
+%files
+/lib/cleanreq/%name
+
+%changelog
+*   Thu Nov 04 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-3
+-   clean req test
+*   Tue Nov 15 2016 Xiaolin Li <xiaolinl@vmware.com> 1.0.1-2
+-   Add a service file for whatprovides test.
+*   Tue Dec 15 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0
+-   Initial build.  First version

--- a/pytests/repo/tdnf-test-cleanreq-required.spec
+++ b/pytests/repo/tdnf-test-cleanreq-required.spec
@@ -26,9 +26,5 @@ touch %_topdir/%buildroot/lib/cleanreq/required
 /lib/cleanreq/required
 
 %changelog
-*   Thu Nov 04 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-3
+*   Thu Nov 04 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-1
 -   clean req test
-*   Tue Nov 15 2016 Xiaolin Li <xiaolinl@vmware.com> 1.0.1-2
--   Add a service file for whatprovides test.
-*   Tue Dec 15 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0
--   Initial build.  First version

--- a/pytests/repo/tdnf-test-cleanreq-required.spec
+++ b/pytests/repo/tdnf-test-cleanreq-required.spec
@@ -1,0 +1,34 @@
+#
+# tdnf-test-one spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-test-cleanreq-required
+Version:    1.0.1
+Release:    3
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Basic install/remove/upgrade test
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/lib/cleanreq/
+touch %_topdir/%buildroot/lib/cleanreq/required
+
+%files
+/lib/cleanreq/required
+
+%changelog
+*   Thu Nov 04 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-3
+-   clean req test
+*   Tue Nov 15 2016 Xiaolin Li <xiaolinl@vmware.com> 1.0.1-2
+-   Add a service file for whatprovides test.
+*   Tue Dec 15 2015 Priyesh Padmavilasom <ppadmavilasom@vmware.com> 1.0
+-   Initial build.  First version

--- a/pytests/tests/test_autoremove.py
+++ b/pytests/tests/test_autoremove.py
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import shutil
+import pytest
+
+CONFDIR='/root/cleanreq'
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    utils.makedirs(CONFDIR)
+    yield
+    teardown_test(utils)
+
+def teardown_test(utils):
+    utils.erase_package('tdnf-test-cleanreq-leaf1')
+    utils.erase_package('tdnf-test-cleanreq-leaf2')
+    utils.erase_package('tdnf-test-cleanreq-required')
+    shutil.rmtree(CONFDIR)
+
+def generate_config_cleanreq(utils, newconfig, value):
+    orig_conffile = os.path.join(utils.config['repo_path'], 'tdnf.conf')
+
+    with open(orig_conffile, 'r') as fin:
+        with open(newconfig, 'w') as fout:
+            for l in fin:
+                if not l.startswith('clean_requirements_on_remove'):
+                    fout.write(l)
+                else:
+                    fout.write('clean_requirements_on_remove={}\n'.format('1' if value else '0'))
+
+    with open(newconfig, 'r') as fin:
+        for l in fin:
+            print(l)
+
+# leaf1 pulls in a dependency, this should be removed when leaf1 is
+# autoremoved
+def test_autoremove(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+    utils.install_package(pkgname)
+
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(not utils.check_package(pkgname_req))
+
+# When the required package is installed first, removing the
+# leaf should not uninstall it.
+def test_autoremove_req_is_user_installed(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+    utils.install_package(pkgname_req)
+    utils.install_package(pkgname)
+
+    assert(utils.check_package(pkgname_req))
+    assert(utils.check_package(pkgname))
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(utils.check_package(pkgname_req))
+
+# When the required package has been installed as a dependency
+# an attempt to install it (although it already is) should
+# mark it has user installed, and removing leaf should not uninstall it.
+def test_autoremove_req_is_user_installed2(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+    utils.install_package(pkgname)
+    utils.install_package(pkgname_req)
+
+    assert(utils.check_package(pkgname))
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(utils.check_package(pkgname_req))
+
+# leaf1 pulls in a dependency. leaf2 has the same dependency.
+# The required package should not be removed when leaf1 is uninstalled
+# only when leaf2 is uninstalled too.
+def test_autoremove2(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname2 = 'tdnf-test-cleanreq-leaf2'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    utils.install_package(pkgname2)
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+    assert(not utils.check_package(pkgname))
+
+    # actual test:
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname2])
+
+    # actual test:
+    assert(not utils.check_package(pkgname_req))
+
+# like autoremove, but in config file
+def test_autoremove_conf_true(utils):
+    conffile = os.path.join(CONFDIR, 'tdnf.conf')
+    generate_config_cleanreq(utils, conffile, True)
+
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', '-c', conffile, 'remove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(not utils.check_package(pkgname_req))
+
+# autoremove disabled in config file
+def test_autoremove_conf_false(utils):
+    conffile = os.path.join(CONFDIR, 'tdnf.conf')
+    generate_config_cleanreq(utils, conffile, False)
+
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', '-c', conffile, 'remove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(utils.check_package(pkgname_req))
+
+# autoremove enabled in config file, but --noautoremove in cmd line
+def test_autoremove_conf_noautoremove(utils):
+    conffile = os.path.join(CONFDIR, 'tdnf.conf')
+    generate_config_cleanreq(utils, conffile, True)
+
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', '-c', conffile, '--noautoremove', 'remove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(utils.check_package(pkgname_req))
+
+# autoremove disabled in config file, 'autoremove' should still
+# do the clean up
+def test_autoremove_conf_false_autoremove(utils):
+    conffile = os.path.join(CONFDIR, 'tdnf.conf')
+    generate_config_cleanreq(utils, conffile, False)
+
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', '-c', conffile, 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test:
+    assert(not utils.check_package(pkgname_req))
+

--- a/pytests/tests/test_autoremove.py
+++ b/pytests/tests/test_autoremove.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms
@@ -11,7 +11,9 @@ import os
 import shutil
 import pytest
 
-CONFDIR='/root/cleanreq'
+
+CONFDIR = '/tmp/cleanreq'
+
 
 @pytest.fixture(scope='function', autouse=True)
 def setup_test(utils):
@@ -19,26 +21,29 @@ def setup_test(utils):
     yield
     teardown_test(utils)
 
+
 def teardown_test(utils):
     utils.erase_package('tdnf-test-cleanreq-leaf1')
     utils.erase_package('tdnf-test-cleanreq-leaf2')
     utils.erase_package('tdnf-test-cleanreq-required')
     shutil.rmtree(CONFDIR)
 
+
 def generate_config_cleanreq(utils, newconfig, value):
     orig_conffile = os.path.join(utils.config['repo_path'], 'tdnf.conf')
 
     with open(orig_conffile, 'r') as fin:
         with open(newconfig, 'w') as fout:
-            for l in fin:
-                if not l.startswith('clean_requirements_on_remove'):
-                    fout.write(l)
+            for line in fin:
+                if not line.startswith('clean_requirements_on_remove'):
+                    fout.write(line)
                 else:
                     fout.write('clean_requirements_on_remove={}\n'.format('1' if value else '0'))
 
     with open(newconfig, 'r') as fin:
-        for l in fin:
-            print(l)
+        for line in fin:
+            print(line)
+
 
 # leaf1 pulls in a dependency, this should be removed when leaf1 is
 # autoremoved
@@ -54,6 +59,7 @@ def test_autoremove(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(not utils.check_package(pkgname_req))
+
 
 # When the required package is installed first, removing the
 # leaf should not uninstall it.
@@ -72,6 +78,7 @@ def test_autoremove_req_is_user_installed(utils):
     # actual test:
     assert(utils.check_package(pkgname_req))
 
+
 # When the required package has been installed as a dependency
 # an attempt to install it (although it already is) should
 # mark it has user installed, and removing leaf should not uninstall it.
@@ -89,6 +96,7 @@ def test_autoremove_req_is_user_installed2(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(utils.check_package(pkgname_req))
+
 
 # leaf1 pulls in a dependency. leaf2 has the same dependency.
 # The required package should not be removed when leaf1 is uninstalled
@@ -112,6 +120,7 @@ def test_autoremove2(utils):
     # actual test:
     assert(not utils.check_package(pkgname_req))
 
+
 # like autoremove, but in config file
 def test_autoremove_conf_true(utils):
     conffile = os.path.join(CONFDIR, 'tdnf.conf')
@@ -128,6 +137,7 @@ def test_autoremove_conf_true(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(not utils.check_package(pkgname_req))
+
 
 # autoremove disabled in config file
 def test_autoremove_conf_false(utils):
@@ -146,6 +156,7 @@ def test_autoremove_conf_false(utils):
     # actual test:
     assert(utils.check_package(pkgname_req))
 
+
 # autoremove enabled in config file, but --noautoremove in cmd line
 def test_autoremove_conf_noautoremove(utils):
     conffile = os.path.join(CONFDIR, 'tdnf.conf')
@@ -162,6 +173,7 @@ def test_autoremove_conf_noautoremove(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(utils.check_package(pkgname_req))
+
 
 # autoremove disabled in config file, 'autoremove' should still
 # do the clean up
@@ -180,4 +192,3 @@ def test_autoremove_conf_false_autoremove(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(not utils.check_package(pkgname_req))
-

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -445,6 +445,13 @@ SolvAddPkgUserInstalledJob(
     );
 
 uint32_t
+SolvAddUserInstalledToJobs(
+    Queue* pQueueJobs,
+    Pool *pPool,
+    char **ppszAutoInstalled
+    );
+
+uint32_t
 SolvGetUpdateAdvisories(
     PSolvSack pSack,
     Id dwPkgIdpkg,

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -115,6 +115,7 @@ static struct option pstOptions[] =
     {"disableexcludes", no_argument, &_opt.nDisableExcludes, 1}, //--disableexcludes
     {"downloadonly",  no_argument, &_opt.nDownloadOnly, 1}, //--downloadonly
     {"downloaddir",   required_argument, 0, 0},            //--downloaddir
+    {"noautoremove",  no_argument, &_opt.nNoAutoRemove, 1},
     // reposync options
     {"arch",          required_argument, 0, 0},
     {"delete",        no_argument, 0, 0},
@@ -344,6 +345,7 @@ TDNFCopyOptions(
     pArgs->nIPv6          = pOptionArgs->nIPv6;
     pArgs->nDisableExcludes = pOptionArgs->nDisableExcludes;
     pArgs->nDownloadOnly  = pOptionArgs->nDownloadOnly;
+    pArgs->nNoAutoRemove  = pOptionArgs->nNoAutoRemove;
 
 cleanup:
     return dwError;


### PR DESCRIPTION
This implements the autoremove feature. This makes tdnf remove automatically installed packages, that is packages that were installed to satisfy dependencies. This can be done in one of three ways:

* enable it in the config with `clean_requirements_on_remove=true`(This was the default, but it took no effect. This change  removes the flag to prevent unintentional package removals)
* use the `--autoremove` flag for any command that may remove packages
* use the `autoremove` command instead of `remove` or `erase`.

This implementation uses the file `/var/lib/tdnf/autoinstalled` for a list of all automatically installed packages. Whenever a package may be removed, this list is checked and all installed packages that are not in the list will be considered _user installed_. (Therefore if the file does not exist, all installed packages are considered user installed). The list of user installed files is passed on to the libsolv API, and the flag `SOLVER_CLEANDEPS` is set. This will make libsolv add orphaned dependencies to the list of packages to be removed.

Newly installed packages will be marked as user installed, but not any dependencies. If a package is already installed it will be marked as user installed even if it was automatically installed before.
