### PR TITLE
Move instance running check to TDNFOpenHandle()

### DIFF
--- a/ci/Dockerfile.fedora
+++ b/ci/Dockerfile.fedora
@@ -1,10 +1,10 @@
 FROM fedora:34
 
-RUN dnf -q -y upgrade
-RUN dnf -q -y install gcc make cmake libcurl-devel rpm-devel rpm-build libsolv-devel \
-                      popt-devel sed createrepo_c glib2-devel libxml2 findutils \
-                      python3-pytest python3-requests python3-urllib3 python3-pyOpenSSL \
-                      python3 python3-devel valgrind gpgme-devel libxml2-devel \
-                      openssl-devel rpm-sign which
+RUN dnf -y upgrade
+RUN dnf -y install gcc make cmake libcurl-devel rpm-devel rpm-build \
+        libsolv-devel popt-devel sed createrepo_c glib2-devel libxml2 \
+        findutils python3-pytest python3-requests python3-urllib3 \
+        python3-pyOpenSSL python3 python3-devel valgrind gpgme-devel \
+        libxml2-devel openssl-devel rpm-sign which python3-pip
 
 CMD ["/bin/bash"]

--- a/ci/Dockerfile.photon
+++ b/ci/Dockerfile.photon
@@ -1,17 +1,16 @@
 FROM photon:latest
 
-MAINTAINER csiddharth@vmware.com
-
-RUN tdnf update  -q -y
-RUN tdnf remove  -q -y toybox
-RUN tdnf install -q -y --enablerepo=photon-debuginfo \
-                       build-essential cmake curl-devel rpm-build libsolv-devel \
-                       popt-devel sed createrepo_c glib libxml2 findutils \
-                       python3 python3-pip python3-setuptools python3-devel \
-                       valgrind gpgme-devel glibc-debuginfo libxml2-devel \
-                       openssl-devel zlib-devel which
+RUN tdnf update  -y
+RUN tdnf remove  -y toybox
+RUN tdnf install -y --enablerepo=photon-debuginfo \
+               build-essential cmake curl-devel rpm-build \
+               libsolv-devel popt-devel sed createrepo_c glib libxml2 \
+               findutils python3 python3-pip python3-setuptools \
+               python3-devel valgrind gpgme-devel glibc-debuginfo \
+               libxml2-devel openssl-devel zlib-devel which \
+               python3-requests python3-urllib3 python3-pyOpenSSL
 
 # python build/test dependencies
-RUN pip3 install -q requests urllib3 pyOpenSSL pytest
+RUN pip3 install -q pytest
 
 CMD ["/bin/bash"]

--- a/ci/Dockerfile.photon-3.0
+++ b/ci/Dockerfile.photon-3.0
@@ -1,17 +1,16 @@
 FROM photon:3.0
 
-MAINTAINER okurth@vmware.com
+RUN tdnf update  -y
+RUN tdnf remove  -y toybox
+RUN tdnf install -y --enablerepo=photon-debuginfo \
+               build-essential cmake curl-devel rpm-build \
+               libsolv-devel popt-devel sed createrepo_c glib libxml2 \
+               findutils python3 python3-setuptools python3-devel \
+               valgrind gpgme-devel glibc-debuginfo libxml2-devel \
+               openssl-devel zlib-devel which python3-requests \
+               python3-urllib3 python3-pyOpenSSL python3-pip
 
-RUN tdnf update  -q -y
-RUN tdnf remove  -q -y toybox
-RUN tdnf install -q -y --enablerepo=photon-debuginfo \
-                       build-essential cmake curl-devel rpm-build libsolv-devel \
-                       popt-devel sed createrepo_c glib libxml2 findutils \
-                       python3 python3-pip python3-setuptools python3-devel \
-                       valgrind gpgme-devel glibc-debuginfo libxml2-devel \
-                       openssl-devel zlib-devel which
-
-# python build/test dependencies
-RUN pip3 install -q requests urllib3 pyOpenSSL pytest
+# TODO: we need to fix pytest in Ph3, after that this can be removed
+RUN pip3 install -q pytest
 
 CMD ["/bin/bash"]

--- a/client/defines.h
+++ b/client/defines.h
@@ -22,6 +22,15 @@
 
 #include "config.h"
 
+/*
+ * creating this under /var/run because /var/run/lock doesn't exist
+ * in fedora docker images and as a result ci fails
+ */
+#define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instance-lockfile"
+
+/* wait for lock retries, interval is 1s */
+#define TDNF_LOCK_MAX_RETRIES 300
+
 typedef enum
 {
     /* this should be a bitmask */

--- a/client/includes.h
+++ b/client/includes.h
@@ -30,12 +30,13 @@
 #include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <ftw.h>
 #include <time.h>
 #include <utime.h>
 #include <fnmatch.h>
 #include <libgen.h>
 #include <ctype.h>
-//
+#include <sys/file.h>
 #include <sys/utsname.h>
 
 #include <dirent.h>
@@ -66,6 +67,8 @@
 #include "../common/structs.h"
 #include "../common/prototypes.h"
 #include "prototypes.h"
+
+#include "config.h"
 
 // Enum in order of preference
 enum {

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -15,4 +15,5 @@ add_library(${LIB_TDNF_COMMON}
     strings.c
     utils.c
     log.c
+    lock.c
 )

--- a/common/includes.h
+++ b/common/includes.h
@@ -17,6 +17,9 @@
 #include <string.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include <tdnftypes.h>
 #include <tdnferror.h>

--- a/common/lock.c
+++ b/common/lock.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#include "includes.h"
+
+static void tdnflock_free(tdnflock lock);
+static void tdnflock_release(tdnflock lock);
+static int tdnflock_acquire(tdnflock lock, int mode);
+static tdnflock tdnflock_new(const char *lock_path, const char *descr);
+
+static tdnflock tdnflock_new(const char *lock_path, const char *descr)
+{
+	mode_t oldmask;
+	uint32_t dwErr = 0;
+	tdnflock lock = NULL;
+
+	if (IsNullOrEmptyString(lock_path) || IsNullOrEmptyString(descr))
+	{
+		goto error;
+	}
+
+	dwErr = TDNFAllocateMemory(1, sizeof(*lock), (void *)&lock);
+	if (dwErr)
+	{
+		goto error;
+	}
+
+	oldmask = umask(022);
+	lock->fd = open(lock_path, O_RDWR|O_CREAT, 0644);
+	(void) umask(oldmask);
+
+	if (lock->fd < 0)
+	{
+		if (errno == EACCES)
+		{
+			lock->fd = open(lock_path, O_RDONLY);
+		}
+
+		if (lock->fd < 0)
+		{
+			TDNF_SAFE_FREE_MEMORY(lock);
+			return NULL;
+		}
+		else
+		{
+			lock->openmode = TDNFLOCK_READ;
+		}
+	}
+	else
+	{
+		lock->openmode = TDNFLOCK_WRITE | TDNFLOCK_READ;
+	}
+
+	lock->fdrefs = 1;
+	dwErr = TDNFAllocateString(lock_path, &lock->path);
+	BAIL_ON_TDNF_ERROR(dwErr);
+	dwErr = TDNFAllocateString(descr, &lock->descr);
+	BAIL_ON_TDNF_ERROR(dwErr);
+
+	return lock;
+
+error:
+	tdnflock_free(lock);
+
+	return lock;
+}
+
+static void tdnflock_free(tdnflock lock)
+{
+	if (lock && --lock->fdrefs == 0)
+	{
+		TDNF_SAFE_FREE_MEMORY(lock->path);
+		TDNF_SAFE_FREE_MEMORY(lock->descr);
+		if (lock->fd >= 0)
+		{
+			(void) close(lock->fd);
+		}
+		TDNF_SAFE_FREE_MEMORY(lock);
+	}
+}
+
+static int tdnflock_acquire(tdnflock lock, int mode)
+{
+	int res = 0;
+
+	if (!lock || mode < 0)
+	{
+		goto end;
+	}
+
+	if (!(mode & lock->openmode))
+		return res;
+
+	if (lock->fdrefs > 1) {
+		res = 1;
+	} else {
+		int cmd;
+		struct flock info;
+
+		if (mode & TDNFLOCK_WAIT)
+		{
+			cmd = F_SETLKW;
+		}
+		else
+		{
+			cmd = F_SETLK;
+		}
+		if (mode & TDNFLOCK_READ)
+		{
+			info.l_type = F_RDLCK;
+		}
+		else
+		{
+			info.l_type = F_WRLCK;
+		}
+		info.l_whence = SEEK_SET;
+		info.l_start = 0;
+		info.l_len = 0;
+		info.l_pid = 0;
+
+		if (fcntl(lock->fd, cmd, &info) != -1)
+		{
+			res = 1;
+		}
+	}
+
+	lock->fdrefs += res;
+
+end:
+	return res;
+}
+
+static void tdnflock_release(tdnflock lock)
+{
+	if (!lock || lock->fdrefs <= 1)
+	{
+		return;
+	}
+
+	if (--lock->fdrefs == 1)
+	{
+		struct flock info;
+		info.l_type = F_UNLCK;
+		info.l_whence = SEEK_SET;
+		info.l_start = 0;
+		info.l_len = 0;
+		info.l_pid = 0;
+		(void) fcntl(lock->fd, F_SETLK, &info);
+	}
+}
+
+/* External interface */
+tdnflock tdnflockNew(const char *lock_path, const char *descr)
+{
+	tdnflock lock = NULL;
+
+	if (IsNullOrEmptyString(lock_path) || IsNullOrEmptyString(descr))
+	{
+		goto end;
+	}
+
+	lock = tdnflock_new(lock_path, descr);
+	if (!lock)
+	{
+		pr_err("can't create %s lock on %s (%s)\n",
+				descr, lock_path, strerror(errno));
+	}
+
+end:
+	return lock;
+}
+
+int tdnflockAcquire(tdnflock lock)
+{
+	int locked = 0; /* assume failure */
+
+	if (!lock)
+	{
+		return locked;
+	}
+
+	locked = tdnflock_acquire(lock, TDNFLOCK_WRITE);
+	if (!locked && (lock->openmode & TDNFLOCK_WRITE))
+	{
+		pr_crit("waiting for %s lock on %s\n", lock->descr, lock->path);
+		locked = tdnflock_acquire(lock, (TDNFLOCK_WRITE|TDNFLOCK_WAIT));
+	}
+
+	if (!locked)
+	{
+		pr_err("can't create %s lock on %s (%s)\n", lock->descr, lock->path,
+													strerror(errno));
+	}
+
+	return locked;
+}
+
+void tdnflockRelease(tdnflock lock)
+{
+	if (lock)
+	{
+		tdnflock_release(lock);
+	}
+}
+
+tdnflock tdnflockNewAcquire(const char *lock_path, const char *descr)
+{
+	tdnflock lock = NULL;
+
+	if (IsNullOrEmptyString(lock_path) || IsNullOrEmptyString(descr))
+	{
+		goto end;
+	}
+
+	lock = tdnflockNew(lock_path, descr);
+
+	if (!tdnflockAcquire(lock))
+	{
+		lock = tdnflockFree(lock);
+	}
+
+end:
+	return lock;
+}
+
+tdnflock tdnflockFree(tdnflock lock)
+{
+	if (lock)
+	{
+		tdnflock_release(lock);
+		tdnflock_free(lock);
+	}
+
+	return NULL;
+}

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -328,4 +328,22 @@ log_console(
     ...
     );
 
+int tdnflockAcquire(tdnflock lock);
+
+void tdnflockRelease(tdnflock lock);
+
+tdnflock tdnflockFree(tdnflock lock);
+
+tdnflock
+tdnflockNew(
+    const char *lock_path,
+    const char *descr
+    );
+
+tdnflock
+tdnflockNewAcquire(
+    const char *lock_path,
+    const char *descr
+    );
+
 #endif /* __COMMON_PROTOTYPES_H__ */

--- a/common/structs.h
+++ b/common/structs.h
@@ -33,3 +33,16 @@ typedef uint32_t
     const char *pszValue
     );
 
+typedef struct tdnflock_s {
+    int fd;
+    int openmode;
+    char *path;
+    char *descr;
+    int fdrefs;
+} *tdnflock;
+
+enum {
+    TDNFLOCK_READ   = 1 << 0,
+    TDNFLOCK_WRITE  = 1 << 1,
+    TDNFLOCK_WAIT   = 1 << 2,
+};

--- a/pytests/tests/test_lock.py
+++ b/pytests/tests/test_lock.py
@@ -1,0 +1,113 @@
+#
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import time
+import pytest
+from threading import Thread
+from subprocess import Popen, PIPE
+
+proc = None
+t1_started = False
+t2_started = False
+t3_started = False
+
+t1_failed = False
+t2_failed = False
+t3_failed = False
+
+expected_str = 'waiting for tdnf_instance lock on /var/run/.tdnf-instance-lockfile'
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['tdnf', 'erase', '-y', pkgname])
+
+
+def run_tdnf_blocking_cmd(utils, pkgname):
+    try:
+        cmd = ['tdnf', 'install', pkgname]
+        utils._decorate_tdnf_cmd_for_test(cmd)
+        print(cmd)
+        global t1_started
+        global proc
+        proc = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+        t1_started = True
+        proc.wait()
+        out, err = proc.communicate()
+        out = out.decode().strip().split('\n')
+        err = err.decode().strip().split('\n')
+        print('\n\n\n', out, err)
+        assert('Installing:' in out)
+    except Exception:
+        global t1_failed
+        t1_failed = True
+
+
+def run_tdnf_search_cmd(utils, pkgname):
+    cmd = ['tdnf', 'search', pkgname]
+    utils._decorate_tdnf_cmd_for_test(cmd)
+    global t2_started
+    t2_started = True
+    ret = utils.run(cmd)  # this gets blocked till install finishes
+    try:
+        assert(expected_str in ret['stdout'])
+        assert('tdnf-test-one : basic install test file.' in ret['stdout'])
+    except Exception:
+        global t2_failed
+        t2_failed = True
+
+
+def run_tdnf_info_cmd(utils, pkgname):
+    cmd = ['tdnf', 'info', pkgname]
+    utils._decorate_tdnf_cmd_for_test(cmd)
+    global t3_started
+    t3_started = True
+    ret = utils.run(cmd)  # this gets blocked till install finishes
+    print(ret['stdout'])
+    try:
+        assert(expected_str in ret['stdout'])
+        assert('Name          : tdnf-test-one' in ret['stdout'])
+    except Exception:
+        global t3_failed
+        t3_failed = True
+
+
+def test_lock_basic(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['tdnf', 'erase', '-y', pkgname])
+
+    t1 = Thread(target=run_tdnf_blocking_cmd, args=(utils, pkgname, ))
+    t2 = Thread(target=run_tdnf_search_cmd, args=(utils, pkgname, ))
+    t3 = Thread(target=run_tdnf_info_cmd, args=(utils, pkgname, ))
+
+    t1.start()
+    while not t1_started:
+        time.sleep(0.5)
+    print(proc.pid)
+
+    t2.start()
+    t3.start()
+    while not t2_started or not t3_started:
+        time.sleep(0.5)
+
+    time.sleep(1)
+
+    # write 'n' to stdin of install pid
+    os.system("echo n > /proc/" + str(proc.pid) + "/fd/0")
+    t1.join()
+    t2.join()
+    t3.join()
+
+    assert(not t1_failed and not t2_failed and not t3_failed)

--- a/python/tdnfpycommands.c
+++ b/python/tdnfpycommands.c
@@ -152,7 +152,6 @@ _TDNFPyGetAlterArgs(TDNF_ALTERTYPE type, PyObject *args,
 
     pCmdArgs->nRefresh = pyRefresh ? PyObject_IsTrue(pyRefresh) : 0;
     pCmdArgs->nQuiet = pyQuiet ? PyObject_IsTrue(pyQuiet) : 0;
-    GlobalSetQuiet(pCmdArgs->nQuiet);
     pCmdArgs->nCmdCount = nPkgCount;
 
 error:

--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -21,15 +21,6 @@
 
 #pragma once
 
-/*
- * creating this under /var/run because /var/run/lock doesn't exist
- * in fedora docker images and as a result ci fails
- */
-#define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instance-lockfile"
-
-/* wait for lock retries, interval is 1s */
-#define TDNF_LOCK_MAX_RETRIES 300
-
 #define BAIL_ON_CLI_ERROR(unError) \
     do {                                                           \
         if (unError)                                               \

--- a/tools/cli/includes.h
+++ b/tools/cli/includes.h
@@ -33,8 +33,6 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdbool.h>
-#include <sys/file.h>
-#include <fcntl.h>
 
 #include <tdnf.h>
 #include <tdnfcli.h>


### PR DESCRIPTION
This will ensure that any tdnf api usage will create a instance lock file

Implement a new utility for locking.

Signed-off-by: Shreenidhi Shedi <sshedi@vmware.com>