### PR TITLE
optionally skip metadata parts

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -116,6 +116,9 @@ typedef enum
 #define TDNF_REPO_KEY_SSL_CA_CERT         "sslcacert"
 #define TDNF_REPO_KEY_SSL_CLI_CERT        "sslclientcert"
 #define TDNF_REPO_KEY_SSL_CLI_KEY         "sslclientkey"
+#define TDNF_REPO_KEY_SKIP_MD_FILELISTS   "skip_md_filelists"
+#define TDNF_REPO_KEY_SKIP_MD_UPDATEINFO  "skip_md_updateinfo"
+#define TDNF_REPO_KEY_SKIP_MD_OTHER       "skip_md_other"
 
 //setopt keys
 #define TDNF_SETOPT_KEY_REPOSDIR          "reposdir"
@@ -141,17 +144,20 @@ typedef enum
 #define TDNF_REPO_METADATA_EXPIRE_NEVER   "never"
 
 // repo default settings
-#define TDNF_REPO_DEFAULT_ENABLED         0
-#define TDNF_REPO_DEFAULT_SKIP            0
-#define TDNF_REPO_DEFAULT_GPGCHECK        1
-#define TDNF_REPO_DEFAULT_MINRATE         0
-#define TDNF_REPO_DEFAULT_THROTTLE        0
-#define TDNF_REPO_DEFAULT_TIMEOUT         0
-#define TDNF_REPO_DEFAULT_SSLVERIFY       1
-#define TDNF_REPO_DEFAULT_RETRIES         10
-#define TDNF_REPO_DEFAULT_PRIORITY        50
-#define TDNF_REPO_DEFAULT_METADATA_EXPIRE 172800 // 48 hours in seconds
+#define TDNF_REPO_DEFAULT_ENABLED            0
+#define TDNF_REPO_DEFAULT_SKIP               0
+#define TDNF_REPO_DEFAULT_GPGCHECK           1
+#define TDNF_REPO_DEFAULT_MINRATE            0
+#define TDNF_REPO_DEFAULT_THROTTLE           0
+#define TDNF_REPO_DEFAULT_TIMEOUT            0
+#define TDNF_REPO_DEFAULT_SSLVERIFY          1
+#define TDNF_REPO_DEFAULT_RETRIES            10
+#define TDNF_REPO_DEFAULT_PRIORITY           50
+#define TDNF_REPO_DEFAULT_METADATA_EXPIRE    172800 // 48 hours in seconds
 #define TDNF_REPO_DEFAULT_METADATA_EXPIRE_STR STRINGIFYX(TDNF_REPO_DEFAULT_METADATA_EXPIRE)
+#define TDNF_REPO_DEFAULT_SKIP_MD_FILELISTS  0
+#define TDNF_REPO_DEFAULT_SKIP_MD_UPDATEINFO 0
+#define TDNF_REPO_DEFAULT_SKIP_MD_OTHER      0
 
 // var names
 #define TDNF_VAR_RELEASEVER               "$releasever"

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -709,7 +709,7 @@ TDNFFreeRepoMetadata(
 uint32_t
 TDNFEnsureRepoMDParts(
     PTDNF pTdnf,
-    const char *pszBaseUrl,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
     PTDNF_REPO_METADATA pRepoMDRel,
     PTDNF_REPO_METADATA *ppRepoMD
     );

--- a/client/repo.c
+++ b/client/repo.c
@@ -967,7 +967,7 @@ TDNFGetRepoMD(
 
     dwError = TDNFEnsureRepoMDParts(
                   pTdnf,
-                  pRepoData->pszBaseUrl,
+                  pRepoData,
                   pRepoMDRel,
                   &pRepoMD);
     BAIL_ON_TDNF_ERROR(dwError);
@@ -1065,19 +1065,22 @@ error:
 uint32_t
 TDNFEnsureRepoMDParts(
     PTDNF pTdnf,
-    const char *pszBaseUrl,
+    PTDNF_REPO_DATA_INTERNAL pRepo,
     PTDNF_REPO_METADATA pRepoMDRel,
     PTDNF_REPO_METADATA *ppRepoMD
     )
 {
     uint32_t dwError = 0;
     PTDNF_REPO_METADATA pRepoMD = NULL;
+    const char *pszBaseUrl = NULL;
 
     if(!pTdnf || !pRepoMDRel || !ppRepoMD)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
+
+    pszBaseUrl = pRepo->pszBaseUrl;
 
     dwError = TDNFAllocateMemory(
                   1,
@@ -1102,7 +1105,7 @@ TDNFEnsureRepoMDParts(
                   pRepoMD->pszPrimary);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if(!IsNullOrEmptyString(pRepoMDRel->pszFileLists))
+    if(!pRepo->nSkipMDFileLists && !IsNullOrEmptyString(pRepoMDRel->pszFileLists))
     {
         dwError = TDNFAppendPath(
                       pRepoMDRel->pszRepoCacheDir,
@@ -1119,7 +1122,7 @@ TDNFEnsureRepoMDParts(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if(!IsNullOrEmptyString(pRepoMDRel->pszUpdateInfo))
+    if(!pRepo->nSkipMDUpdateInfo && !IsNullOrEmptyString(pRepoMDRel->pszUpdateInfo))
     {
         dwError = TDNFAppendPath(
                       pRepoMDRel->pszRepoCacheDir,
@@ -1136,7 +1139,7 @@ TDNFEnsureRepoMDParts(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if(!IsNullOrEmptyString(pRepoMDRel->pszOther))
+    if(!pRepo->nSkipMDOther && !IsNullOrEmptyString(pRepoMDRel->pszOther))
     {
         dwError = TDNFAppendPath(
                       pRepoMDRel->pszRepoCacheDir,

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -278,6 +278,9 @@ TDNFCreateRepo(
     pRepo->nMinrate = TDNF_REPO_DEFAULT_MINRATE;
     pRepo->nThrottle = TDNF_REPO_DEFAULT_THROTTLE;
     pRepo->nRetries = TDNF_REPO_DEFAULT_RETRIES;
+    pRepo->nSkipMDFileLists = TDNF_REPO_DEFAULT_SKIP_MD_FILELISTS;
+    pRepo->nSkipMDUpdateInfo = TDNF_REPO_DEFAULT_SKIP_MD_UPDATEINFO;
+    pRepo->nSkipMDOther = TDNF_REPO_DEFAULT_SKIP_MD_OTHER;
 
     *ppRepo = pRepo;
 cleanup:
@@ -539,6 +542,27 @@ TDNFLoadReposFromFile(
 
         TDNF_SAFE_FREE_MEMORY(pszMetadataExpire);
         pszMetadataExpire = NULL;
+
+        dwError = TDNFReadKeyValueBoolean(
+                      pSections,
+                      TDNF_REPO_KEY_SKIP_MD_FILELISTS,
+                      TDNF_REPO_DEFAULT_SKIP_MD_FILELISTS,
+                      &pRepo->nSkipMDFileLists);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValueBoolean(
+                      pSections,
+                      TDNF_REPO_KEY_SKIP_MD_UPDATEINFO,
+                      TDNF_REPO_DEFAULT_SKIP_MD_UPDATEINFO,
+                      &pRepo->nSkipMDUpdateInfo);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFReadKeyValueBoolean(
+                      pSections,
+                      TDNF_REPO_KEY_SKIP_MD_OTHER,
+                      TDNF_REPO_DEFAULT_SKIP_MD_OTHER,
+                      &pRepo->nSkipMDOther);
+        BAIL_ON_TDNF_ERROR(dwError);
 
         /* plugin event repo readconfig end */
         dwError = TDNFEventRepoReadConfigEnd(pTdnf, pSections);

--- a/client/structs.h
+++ b/client/structs.h
@@ -41,7 +41,9 @@ typedef struct _TDNF_REPO_DATA_INTERNAL_
     int nMinrate;
     int nThrottle;
     int nRetries;
-
+    int nSkipMDFileLists;
+    int nSkipMDUpdateInfo;
+    int nSkipMDOther;
     struct _TDNF_REPO_DATA_INTERNAL_* pNext;
 } TDNF_REPO_DATA_INTERNAL, *PTDNF_REPO_DATA_INTERNAL;
 

--- a/pytests/repo/tdnf-conflict-file0.spec
+++ b/pytests/repo/tdnf-conflict-file0.spec
@@ -1,0 +1,27 @@
+Summary:    Repoquery Test
+Name:       tdnf-conflict-file0
+Version:    1.0.1
+Release:    1
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Two packages containing one identical file.
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/usr/lib/conflict
+# for a file conflict, cntents of the files need to differ
+echo file0 > %_topdir/%buildroot/usr/lib/conflict/conflicting-file
+%files
+/usr/lib/conflict/conflicting-file
+
+%changelog
+*   Tue Jul 06 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-1
+-   first version

--- a/pytests/repo/tdnf-conflict-file1.spec
+++ b/pytests/repo/tdnf-conflict-file1.spec
@@ -1,0 +1,26 @@
+Summary:    Repoquery Test
+Name:       tdnf-conflict-file1
+Version:    1.0.1
+Release:    1
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Two packages containing one identical file.
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/usr/lib/conflict
+echo file > %_topdir/%buildroot/usr/lib/conflict/conflicting-file
+%files
+/usr/lib/conflict/conflicting-file
+
+%changelog
+*   Tue Jul 06 2021 Oliver Kurth <okurth@vmware.com> 1.0.1-1
+-   first version

--- a/pytests/tests/test_conflict.py
+++ b/pytests/tests/test_conflict.py
@@ -1,0 +1,39 @@
+#
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import pytest
+
+pkg0 = "tdnf-conflict-file0"
+pkg1 = "tdnf-conflict-file1"
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    utils.run(['tdnf', 'erase', '-y', pkg0])
+    utils.run(['tdnf', 'erase', '-y', pkg1])
+
+
+def test_install_conflict_file(utils):
+    ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg0])
+    print(ret)
+    assert(utils.check_package(pkg0))
+
+    ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg1])
+    print(ret)
+    assert(ret['retval'] == 1525)
+
+
+def test_install_conflict_file_atonce(utils):
+    ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg0, pkg1])
+    print(ret)
+    assert(ret['retval'] == 1525)

--- a/pytests/tests/test_skip_md.py
+++ b/pytests/tests/test_skip_md.py
@@ -1,0 +1,76 @@
+#
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+#   Author: Oliver Kurth <okurth@vmware.com>
+
+import os
+import pytest
+import glob
+
+
+REPOFILENAME = "photon-skip.repo"
+REPOID = "photon-skip"
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME))
+    pass
+
+
+def generate_repofile_skip_md(utils, newconfig, repoid, mdpart, value):
+    orig_repoconf = os.path.join(utils.config['repo_path'], "yum.repos.d", "photon-test.repo")
+    option = "skip_md_{}".format(mdpart)
+
+    with open(orig_repoconf, 'r') as fin:
+        with open(newconfig, 'w') as fout:
+            for line in fin:
+                if line.startswith('['):
+                    fout.write("[{}]".format(repoid))
+                elif line.startswith('enabled'):
+                    # we will enable this with the --repoid option
+                    fout.write('enabled=0\n')
+                elif not line.startswith(option):
+                    fout.write(line)
+            fout.write('{}={}\n'.format(option, '1' if value else '0'))
+
+    with open(newconfig, 'r') as fin:
+        for line in fin:
+            print(line)
+
+
+def get_cache_dir(utils):
+    conffile = os.path.join(utils.config['repo_path'], 'tdnf.conf')
+    with open(conffile, 'r') as fin:
+        for line in fin:
+            if line.startswith("cachedir"):
+                return line.split('=')[1].strip()
+    return '/var/cache/tdnf/'
+
+
+# enable/disable md part, expect/do not expect download of the associated file
+def check_skip_md_part(utils, mdpart, skipped):
+    repoconf = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    generate_repofile_skip_md(utils, repoconf, REPOID, mdpart, skipped)
+    utils.run(['tdnf', '--repoid={}'.format(REPOID), 'clean', 'all'])
+    utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
+
+    md_dir = os.path.join(get_cache_dir(utils), REPOID, 'repodata')
+    assert((len(glob.glob('{}/*{}*'.format(md_dir, mdpart))) == 0) == skipped)
+
+
+def test_skip_md_filelists(utils):
+    # we do not generate updateinfo in our tests
+    #    for mdpart in ['filelists', 'updateinfo', 'other']:
+    for mdpart in ['filelists', 'other']:
+        check_skip_md_part(utils, mdpart, True)
+        check_skip_md_part(utils, mdpart, False)


### PR DESCRIPTION
With repositories with a large number of packages, downloading and processing metadata can take a significant time. Most of this time is spent with downloading and processing the "filelists" part. These data are not strictly required, and only useful for queries. Therefore we can make it optional.

This change adds 3 options for the repo configurations:
* `skip_md_filelists`
* `skip_md_updateinfo`
* `skip_md_other`

These are `false` (`0`) be default.

Download plus processing time for the Photon 3.0 "photon-updates" repo is reduced from ~1 minute to ~2 seconds by skipping the "filelists" metadata (in a VM running in Fusion on a MacBook Pro).