### PR TITLE
Fix copyright years

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/client/api.c
+++ b/client/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/clean.c
+++ b/client/clean.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/client.c
+++ b/client/client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/config.c
+++ b/client/config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/defines.h
+++ b/client/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/init.c
+++ b/client/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/updateinfo.c
+++ b/client/updateinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/utils.c
+++ b/client/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/common/configreader.c
+++ b/common/configreader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/defines.h
+++ b/common/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/includes.h
+++ b/common/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/lock.c
+++ b/common/lock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2021-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/memory.c
+++ b/common/memory.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/setopt.c
+++ b/common/setopt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/strings.c
+++ b/common/strings.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnf-common-defines.h
+++ b/include/tdnf-common-defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfclierror.h
+++ b/include/tdnfclierror.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU Lesser General Public License v2.1 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_cfgreader.py
+++ b/pytests/tests/test_cfgreader.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_provides.py
+++ b/pytests/tests/test_provides.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/python/includes.h
+++ b/python/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/python/structs.h
+++ b/python/structs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/python/tdnfbase.c
+++ b/python/tdnfbase.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/python/tdnfmodule.c
+++ b/python/tdnfmodule.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/python/tdnfpycommands.c
+++ b/python/tdnfpycommands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/scripts/fix-copyright.py
+++ b/scripts/fix-copyright.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+# Author: Oliver Kurth <okurth@vmware.com>
+#
+# This script will go through all files in a git repo and fix the copyright years
+# in their headers.
+#
+# IMPORTANT:
+# This script needs to be enhanced to exclude commit ids that were created
+# by using this script. For example, if a file was corrected in the year 2022
+# to have 2015-2017, the next run of this script would wrongly autocorrect the
+# year to 2022.
+
+import os
+import re
+from datetime import datetime
+
+class Commit:
+    def __init__(self, id):
+        self.id = id
+        
+
+def get_files():
+    files = []
+    stream = os.popen('git ls-files')
+    for line in stream.readlines():
+        files.append(line.strip())
+    return files
+
+
+def get_latest_commit(file):
+    latest_commit = None
+    # Commits are not necessarily in chronological order,
+    # so we cannot just use the top most commit entry in the log
+    stream = os.popen('git log --pretty=fuller {}'.format(file))
+    for line in stream.readlines():
+        if line.startswith('commit'):
+            commit = Commit(line.split(' ')[1]).strip()
+        # We use the commit date, not the author date
+        # see https://stackoverflow.com/questions/11856983/why-git-authordate-is-different-from-commitdate
+        elif line.startswith('CommitDate:'):
+            date_str = line[len('CommitDate:'):].strip()
+            commit.date = datetime.strptime(date_str, '%a %b %d %H:%M:%S %Y %z')
+            if latest_commit is None or commit.date > latest_commit.date:
+                latest_commit = commit
+    return latest_commit
+
+
+def fix_file(file, actual_year):
+    saved_mode = os.stat(file).st_mode
+    tmpfile = "{}.cfix".format(file)
+    with open(file, 'rt') as fin:
+        with open(tmpfile, 'wt') as fout:
+            for line in fin.readlines():
+
+                # pattern with two years
+                m = re.search('^(.*)Copyright \(C\) (\d{3,4})\w?[-,\s]\w?(\d{4}) VMware, Inc\. All Rights Reserved', line)
+                if m is not None:
+                    prefix = m.group(1)
+                    y1 = m.group(2)
+                    y2 = m.group(3)
+                    fixed = "{prefix}Copyright (C) {y1}-{y2} VMware, Inc. All Rights Reserved.\n".format(prefix=prefix, y1=y1, y2=actual_year)
+                    fout.write(fixed)
+                    continue
+
+                # pattern with just one year
+                m = re.search('^(.*)Copyright \(C\) (\d{3,4}) VMware, Inc\. All Rights Reserved', line)
+                if m is not None:
+                    prefix = m.group(1)
+                    y1 = m.group(2)
+                    if y1 != actual_year:
+                        fixed = "{prefix}Copyright (C) {y1}-{y2} VMware, Inc. All Rights Reserved.\n".format(prefix=prefix, y1=y1, y2=actual_year)
+                    else:
+                        fixed = "{prefix}Copyright (C) {y1} VMware, Inc. All Rights Reserved.\n".format(prefix=prefix, y1=y1)
+                    fout.write(fixed)
+                    continue
+
+                fout.write(line)
+    os.rename(tmpfile, file)
+    os.chmod(file, saved_mode)
+
+if __name__ == '__main__':
+    files = get_files()
+    for f in files:
+        commit = get_latest_commit(f)
+        year = str(commit.date.year)
+        fix_file(f, year)

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfpool.c
+++ b/solv/tdnfpool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2019 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tdnf.spec.in
+++ b/tdnf.spec.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/includes.h
+++ b/tools/cli/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/CMakeLists.txt
+++ b/tools/cli/lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2018 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/includes.h
+++ b/tools/cli/lib/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/options.c
+++ b/tools/cli/lib/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/output.c
+++ b/tools/cli/lib/output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parsecleanargs.c
+++ b/tools/cli/lib/parsecleanargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parselistargs.c
+++ b/tools/cli/lib/parselistargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parserepolistargs.c
+++ b/tools/cli/lib/parserepolistargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parseupdateinfo.c
+++ b/tools/cli/lib/parseupdateinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/prototypes.h
+++ b/tools/cli/lib/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2019 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/updateinfocmd.c
+++ b/tools/cli/lib/updateinfocmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms


### PR DESCRIPTION
Change copyright years to the latest year (as from the "CommitDate" in `git log --pretty=fuller`) from the file's commit history.

The script can be found here: https://gist.github.com/oliverkurth/3dced0b2bee94483762bc9d3216868ee . Note that this PR, if merged, would make files modified this year, so future versions of the script need to account for that and filter out this commit.