### PR TITLE
add tox.ini for flake8 options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ core*
 
 # vi backup
 *.swp
+
+# Apple forks
+._*
+

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -8,7 +8,7 @@ cmake .. && make -j32 && make python -j32
 
 make check -j32
 
-if ! flake8 --ignore E501 ../pytests; then
+if ! flake8 ../pytests ; then
   echo "flake8 tests failed"
   exit 1
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+exclude=._*
+ignore=E501


### PR DESCRIPTION
Use tox.ini for flake8 options. Ignore Apple file forks.