### PR TITLE
add options for scope and mode for the list and updateinfo commands

### DIFF
--- a/pytests/tests/test_list.py
+++ b/pytests/tests/test_list.py
@@ -9,7 +9,7 @@
 import pytest
 
 
-@pytest.fixture(scope='module', autouse=True)
+@pytest.fixture(scope='function', autouse=True)
 def setup_test(utils):
     yield
     teardown_test(utils)
@@ -31,6 +31,10 @@ def helper_test_list_sub_cmd(utils, sub_cmd):
 
 
 def test_list_top(utils):
+    spkg = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'install', '-y', spkg])
+    assert(ret['retval'] == 0)
+
     ret = utils.run(['tdnf', 'list'])
     assert(ret['retval'] == 0)
     ret = utils.run(['tdnf', 'list', utils.config["sglversion_pkgname"]])
@@ -52,7 +56,20 @@ def test_list_sub_cmd(utils):
     helper_test_list_sub_cmd(utils, 'recent')
 
 
-def test_list_upgrades(utils):
+def test_list_options(utils):
+    spkg = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'install', '-y', spkg])
+    assert(ret['retval'] == 0)
+
+    helper_test_list_sub_cmd(utils, '--all')
+    helper_test_list_sub_cmd(utils, '--installed')
+    helper_test_list_sub_cmd(utils, '--available')
+    helper_test_list_sub_cmd(utils, '--obsoletes')
+    helper_test_list_sub_cmd(utils, '--extras')
+    helper_test_list_sub_cmd(utils, '--recent')
+
+
+def test_list_notinstalled(utils):
     mpkg = utils.config["mulversion_pkgname"]
     mpkg_version = utils.config["mulversion_lower"]
     spkg = utils.config["sglversion_pkgname"]
@@ -64,8 +81,10 @@ def test_list_upgrades(utils):
     ret = utils.run(['tdnf', 'list', 'upgrades', mpkg])
     assert(len(ret['stdout']) == 1)
 
-    ret = utils.run(['tdnf', 'list', 'upgrades', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    for cmd in ['updates', 'upgrades', 'downgrades', '--updates', '--upgrades', '--downgrades']:
+        ret = utils.run(['tdnf', 'list', cmd, 'invalid_package'])
+        assert(ret['retval'] == 1011)
 
-    ret = utils.run(['tdnf', 'list', 'upgrades', spkg])
-    assert(ret['retval'] == 1011)
+        # spkg is not installed, expect error
+        ret = utils.run(['tdnf', 'list', cmd, spkg])
+        assert(ret['retval'] == 1011)

--- a/pytests/tests/test_updateinfo.py
+++ b/pytests/tests/test_updateinfo.py
@@ -1,0 +1,75 @@
+#
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import pytest
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    mpkg = utils.config["mulversion_pkgname"]
+    spkg = utils.config["sglversion_pkgname"]
+    utils.run(['tdnf', 'erase', '-y', mpkg, spkg])
+
+
+def helper_test_updateinfo_sub_cmd(utils, sub_cmd):
+    ret = utils.run(['tdnf', 'updateinfo', sub_cmd])
+    assert(ret['retval'] == 0)
+    ret = utils.run(['tdnf', 'updateinfo', sub_cmd, utils.config["sglversion_pkgname"]])
+    assert(ret['retval'] == 0)
+    ret = utils.run(['tdnf', 'updateinfo', sub_cmd, 'invalid_package'])
+    assert(ret['retval'] == 1011)
+
+
+def test_updateinfo_top(utils):
+    spkg = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'install', '-y', spkg])
+    assert(ret['retval'] == 0)
+
+    ret = utils.run(['tdnf', 'updateinfo'])
+    assert(ret['retval'] == 0)
+    ret = utils.run(['tdnf', 'updateinfo', utils.config["sglversion_pkgname"]])
+    assert(ret['retval'] == 0)
+    ret = utils.run(['tdnf', 'updateinfo', 'invalid_package'])
+    assert(ret['retval'] == 1011)
+
+
+def test_updateinfo_sub_cmd(utils):
+    spkg = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'install', '-y', spkg])
+    assert(ret['retval'] == 0)
+
+    for arg in ['all', 'installed', 'available', 'obsoletes', 'extras', 'recent',
+                'summary', 'list', 'info']:
+        helper_test_updateinfo_sub_cmd(utils, arg)
+        helper_test_updateinfo_sub_cmd(utils, '--' + arg)
+
+
+def test_updateinfo_notinstalled(utils):
+    mpkg = utils.config["mulversion_pkgname"]
+    mpkg_version = utils.config["mulversion_lower"]
+    spkg = utils.config["sglversion_pkgname"]
+
+    ret = utils.run(['tdnf', 'updateinfo', 'upgrades'])
+    assert(ret['retval'] == 0)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', mpkg + '-' + mpkg_version])
+    ret = utils.run(['tdnf', 'updateinfo', 'upgrades', mpkg])
+    assert(len(ret['stdout']) == 1)
+
+    for cmd in ['updates', 'upgrades', 'downgrades', '--updates', '--upgrades', '--downgrades']:
+        ret = utils.run(['tdnf', 'updateinfo', cmd, 'invalid_package'])
+        assert(ret['retval'] == 1011)
+
+        # spkg is not installed, expect error
+        ret = utils.run(['tdnf', 'updateinfo', cmd, spkg])
+        assert(ret['retval'] == 1011)

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -69,6 +69,9 @@ static SetOptArgs OptValTable[] = {
     {CMDOPT_KEYVALUE, "whatenhances", NULL},
     {CMDOPT_KEYVALUE, "info", "1"},
     {CMDOPT_KEYVALUE, "summary", "1"},
+    {CMDOPT_KEYVALUE, "recent", "1"},
+    {CMDOPT_KEYVALUE, "updates", "1"},
+    {CMDOPT_KEYVALUE, "downgrades", "1"},
 };
 
 static TDNF_CMD_ARGS _opt = {0};
@@ -160,6 +163,10 @@ static struct option pstOptions[] =
     // update-info mode options (also 'list' from above)
     {"info",          no_argument, 0, 0},
     {"summary",       no_argument, 0, 0},
+    // scope options for list and update-info
+    {"recent",       no_argument, 0, 0},
+    {"updates",       no_argument, 0, 0},
+    {"downgrades",    no_argument, 0, 0},
     {0, 0, 0, 0}
 };
 

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -67,6 +67,8 @@ static SetOptArgs OptValTable[] = {
     {CMDOPT_KEYVALUE, "whatsuggests", NULL},
     {CMDOPT_KEYVALUE, "whatsupplements", NULL},
     {CMDOPT_KEYVALUE, "whatenhances", NULL},
+    {CMDOPT_KEYVALUE, "info", "1"},
+    {CMDOPT_KEYVALUE, "summary", "1"},
 };
 
 static TDNF_CMD_ARGS _opt = {0};
@@ -155,6 +157,9 @@ static struct option pstOptions[] =
     {"suggests",      no_argument, 0, 0},
     {"supplements",   no_argument, 0, 0},
     {"upgrades",      no_argument, 0, 0},
+    // update-info mode options (also 'list' from above)
+    {"info",          no_argument, 0, 0},
+    {"summary",       no_argument, 0, 0},
     {0, 0, 0, 0}
 };
 

--- a/tools/cli/lib/parselistargs.c
+++ b/tools/cli/lib/parselistargs.c
@@ -108,6 +108,7 @@ TDNFCliParseListArgs(
     BAIL_ON_CLI_ERROR(dwError);
 
     //Should have scope argument (tdnf list <scope> <pkgnamespecs>)
+    pListArgs->nScope = SCOPE_ALL;
     if(pCmdArgs->nCmdCount > 1)
     {
         nStartIndex = 2;
@@ -115,7 +116,6 @@ TDNFCliParseListArgs(
         if(dwError == ERROR_TDNF_CLI_NO_MATCH)
         {
             dwError = 0;
-            pListArgs->nScope = SCOPE_ALL;
             nStartIndex = 1;
         }
     }
@@ -198,10 +198,6 @@ cleanup:
     return dwError;
 
 error:
-    if(pnScope)
-    {
-        *pnScope = SCOPE_ALL;//Default
-    }
     goto cleanup;
 }
 

--- a/tools/cli/lib/parselistargs.c
+++ b/tools/cli/lib/parselistargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -92,6 +92,7 @@ TDNFCliParseListArgs(
 {
     uint32_t dwError = 0;
     PTDNF_LIST_ARGS pListArgs = NULL;
+    PTDNF_CMD_OPT pSetOpt = NULL;
     int nStartIndex = 1;
     int nPackageCount = 0;
     int nIndex = 0;
@@ -107,8 +108,27 @@ TDNFCliParseListArgs(
                   (void**)&pListArgs);
     BAIL_ON_CLI_ERROR(dwError);
 
-    //Should have scope argument (tdnf list <scope> <pkgnamespecs>)
     pListArgs->nScope = SCOPE_ALL;
+
+    /* scope can be given as an option */
+    for (pSetOpt = pCmdArgs->pSetOpt;
+         pSetOpt;
+         pSetOpt = pSetOpt->pNext)
+    {
+        if(pSetOpt->nType == CMDOPT_KEYVALUE)
+        {
+            dwError = TDNFCliParseScope(
+                          pSetOpt->pszOptName,
+                          &pListArgs->nScope);
+            if(dwError == ERROR_TDNF_CLI_NO_MATCH)
+            {
+                dwError = 0;
+            }
+            BAIL_ON_CLI_ERROR(dwError);
+        }
+    }
+
+    /* scope can also be given as an argument */
     if(pCmdArgs->nCmdCount > 1)
     {
         nStartIndex = 2;
@@ -166,6 +186,9 @@ TDNFCliParseScope(
         char* pszTypeName;
         int nType;
     };
+
+    /* Note: "extras", "obsoletes" and "recent"
+       have no effect */
     struct stTemp  stScopes[] =
     {
         {"all",       SCOPE_ALL},


### PR DESCRIPTION
Subcommands for `list` and `updateinfo` (scopes for `list`; and modes and scopes for `updateinfo`) should be available as options. For example, `tdnf list available` can also be written as `tdnf list --available`. Likewise, `tdnf updateinfo info available` can be written as `tdnf --info --available updateinfo`.