### PR TITLE
merge TDNF_REPO_DATA_INTERNAL and TDNF_REPO_DATA

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -948,7 +948,7 @@ TDNFRepoList(
     PTDNF_REPO_DATA pRepoTemp = NULL;
     PTDNF_REPO_DATA pRepoCurrent = NULL;
 
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if(!pTdnf || !pTdnf->pRepos || !ppReposAll)
     {
@@ -1074,7 +1074,7 @@ TDNFRepoSync(
     int ret;
     PTDNF_PKG_INFO pPkgInfos = NULL;
     PTDNF_PKG_INFO pPkgInfo = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     char *pszRepoDir = NULL;
     PSolvQuery pQuery = NULL;
     PSolvPackageList pPkgList = NULL;

--- a/client/clean.c
+++ b/client/clean.c
@@ -22,13 +22,13 @@
 
 uint32_t
 TDNFCopyEnabledRepos(
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     char*** pppszReposUsed
     )
 {
     uint32_t dwError = 0;
     char** ppszReposUsed = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepoTemp = NULL;
+    PTDNF_REPO_DATA pRepoTemp = NULL;
     int nCount = 0;
 
     if(!pRepoData || !pppszReposUsed)

--- a/client/init.c
+++ b/client/init.c
@@ -221,8 +221,8 @@ error:
 static
 int _repo_compare(const void *ppRepo1, const void *ppRepo2)
 {
-    return (*(PTDNF_REPO_DATA_INTERNAL*)(ppRepo1))->nPriority -
-           (*(PTDNF_REPO_DATA_INTERNAL*)(ppRepo2))->nPriority;
+    return (*(PTDNF_REPO_DATA*)(ppRepo1))->nPriority -
+           (*(PTDNF_REPO_DATA*)(ppRepo2))->nPriority;
 }
 
 uint32_t
@@ -235,8 +235,8 @@ TDNFRefreshSack(
     uint32_t dwError = 0;
     char* pszRepoCacheDir = NULL;
     int nMetadataExpired = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
-    PTDNF_REPO_DATA_INTERNAL *ppRepoArray = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
+    PTDNF_REPO_DATA *ppRepoArray = NULL;
     uint32_t nCount = 0;
     uint32_t i = 0;
 
@@ -267,7 +267,7 @@ TDNFRefreshSack(
     /* nCount may be 0 if --disablerepo=* is used */
     if (nCount > 0)
     {
-        dwError = TDNFAllocateMemory(nCount, sizeof(PTDNF_REPO_DATA_INTERNAL),
+        dwError = TDNFAllocateMemory(nCount, sizeof(PTDNF_REPO_DATA),
                                      (void **)&ppRepoArray);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -280,7 +280,7 @@ TDNFRefreshSack(
             ppRepoArray[i++] = pRepo;
         }
 
-        qsort(ppRepoArray, nCount, sizeof(PTDNF_REPO_DATA_INTERNAL), _repo_compare);
+        qsort(ppRepoArray, nCount, sizeof(PTDNF_REPO_DATA), _repo_compare);
     }
 
     for (i = 0; i < nCount; i++)

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -31,7 +31,7 @@ extern uid_t gEuid;
 //clean.c
 uint32_t
 TDNFCopyEnabledRepos(
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     char*** pppszReposUsed
     );
 
@@ -116,7 +116,7 @@ uint32_t
 TDNFRefreshRepo(
     PTDNF pTdnf,
     int nCleanMetadata,
-    PTDNF_REPO_DATA_INTERNAL pRepo
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
@@ -148,7 +148,7 @@ TDNFRepoGetBaseUrl(
 uint32_t
 TDNFRepoSetBaseUrl(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pszRepo,
+    PTDNF_REPO_DATA pszRepo,
     const char *pszBaseUrlFile
     );
 
@@ -203,7 +203,7 @@ TDNFRemoveKeysCache(
 
 uint32_t
 TDNFRepoApplyDownloadSettings(
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     CURL *pCurl
     );
 
@@ -215,7 +215,7 @@ TDNFRepoApplyProxySettings(
 
 uint32_t
 TDNFRepoApplySSLSettings(
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     CURL *pCurl
     );
 
@@ -223,7 +223,7 @@ uint32_t
 TDNFFindRepoById(
     PTDNF pTdnf,
     const char* pszRepo,
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     );
 
 uint32_t
@@ -640,7 +640,7 @@ TDNFInitRepoFromMetadata(
 uint32_t
 TDNFInitRepo(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     PSolvSack pSack
     );
 
@@ -681,13 +681,13 @@ uint32_t
 TDNFGetRepoById(
     PTDNF pTdnf,
     const char* pszName,
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     );
 
 uint32_t
 TDNFGetRepoMD(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     const char *pszRepoDataDir,
     PTDNF_REPO_METADATA *ppRepoMD
     );
@@ -712,7 +712,7 @@ TDNFFreeRepoMetadata(
 uint32_t
 TDNFEnsureRepoMDParts(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     PTDNF_REPO_METADATA pRepoMDRel,
     PTDNF_REPO_METADATA *ppRepoMD
     );
@@ -743,7 +743,7 @@ TDNFReplaceFile(
 uint32_t
 TDNFDownloadMetadata(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     const char *pszRepoDir,
     int nPrintOnly
     );
@@ -752,7 +752,7 @@ uint32_t
 TDNFDownloadRepoMDParts(
     PTDNF pTdnf,
     Repo *pSolvRepo,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     const char *pszDir,
     int nPrintOnly
     );
@@ -762,24 +762,24 @@ uint32_t
 TDNFLoadReposFromFile(
     PTDNF pTdnf,
     char* pszRepoFile,
-    PTDNF_REPO_DATA_INTERNAL* ppRepos
+    PTDNF_REPO_DATA* ppRepos
     );
 
 uint32_t
 TDNFCreateCmdLineRepo(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     );
 
 uint32_t
 TDNFCreateRepoFromPath(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    PTDNF_REPO_DATA* ppRepo,
     const char *pzsId,
     const char *pszPath
     );
 
 uint32_t
 TDNFCreateRepo(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    PTDNF_REPO_DATA* ppRepo,
     const char *pszId
     );
 
@@ -787,7 +787,7 @@ uint32_t
 TDNFLoadRepoData(
     PTDNF pTdnf,
     TDNF_REPOLISTFILTER nFilter,
-    PTDNF_REPO_DATA_INTERNAL* ppReposAll
+    PTDNF_REPO_DATA* ppReposAll
     );
 
 uint32_t
@@ -797,20 +797,20 @@ TDNFRepoListFinalize(
 
 uint32_t
 TDNFAlterRepoState(
-    PTDNF_REPO_DATA_INTERNAL pRepos,
+    PTDNF_REPO_DATA pRepos,
     int nEnable,
     const char* pszId
     );
 
 uint32_t
 TDNFCloneRepo(
-    PTDNF_REPO_DATA_INTERNAL pRepoIn,
+    PTDNF_REPO_DATA pRepoIn,
     PTDNF_REPO_DATA* ppRepo
     );
 
 void
 TDNFFreeReposInternal(
-    PTDNF_REPO_DATA_INTERNAL pRepos
+    PTDNF_REPO_DATA pRepos
     );
 
 //resolve.c

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -573,7 +573,7 @@ TDNFDownloadFile(
     char *pszFileTmp = NULL;
     /* lStatus reads CURLINFO_RESPONSE_CODE. Must be long */
     long lStatus = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo;
+    PTDNF_REPO_DATA pRepo;
     int i;
 
     /* TDNFFetchRemoteGPGKey sends pszProgressData as NULL */

--- a/client/repo.c
+++ b/client/repo.c
@@ -24,7 +24,7 @@
 uint32_t
 TDNFInitRepo(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     PSolvSack pSack
     )
 {
@@ -222,7 +222,7 @@ TDNFGetGPGCheck(
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     int nGPGCheck = 0;
 
     if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pnGPGCheck)
@@ -342,7 +342,7 @@ TDNFGetGPGSignatureCheck(
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     int nGPGSigCheck = 0;
     uint32_t dwSkipSignature = 0;
     char** ppszUrlGPGKeys = NULL;
@@ -405,12 +405,12 @@ uint32_t
 TDNFGetRepoById(
     PTDNF pTdnf,
     const char* pszId,
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if(!pTdnf || IsNullOrEmptyString(pszId) || !ppRepo)
     {
@@ -506,7 +506,7 @@ TDNFStoreBaseURLFromMetalink(
 {
     uint32_t dwError = 0;
     char *pszBaseUrlFile = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if (!pTdnf ||
         !pTdnf->pConf ||
@@ -636,7 +636,7 @@ error:
 uint32_t
 TDNFGetRepoMD(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepoData,
+    PTDNF_REPO_DATA pRepoData,
     const char *pszRepoDataDir,
     PTDNF_REPO_METADATA *ppRepoMD
     )
@@ -1070,7 +1070,7 @@ error:
 uint32_t
 TDNFEnsureRepoMDParts(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     PTDNF_REPO_METADATA pRepoMDRel,
     PTDNF_REPO_METADATA *ppRepoMD
     )
@@ -1374,7 +1374,7 @@ error:
 uint32_t
 TDNFDownloadMetadata(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     const char *pszRepoDir,
     int nPrintOnly
     )
@@ -1475,7 +1475,7 @@ uint32_t
 TDNFDownloadRepoMDParts(
     PTDNF pTdnf,
     Repo *pSolvRepo,
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     const char *pszDir,
     int nPrintOnly
     )

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -25,14 +25,14 @@ uint32_t
 TDNFLoadRepoData(
     PTDNF pTdnf,
     TDNF_REPOLISTFILTER nFilter,
-    PTDNF_REPO_DATA_INTERNAL* ppReposAll
+    PTDNF_REPO_DATA* ppReposAll
     )
 {
     uint32_t dwError = 0;
     char* pszRepoFilePath = NULL;
-    PTDNF_REPO_DATA_INTERNAL pReposAll = NULL;
-    PTDNF_REPO_DATA_INTERNAL pReposTemp = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pReposAll = NULL;
+    PTDNF_REPO_DATA pReposTemp = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
     PTDNF_CONF pConf = NULL;
     PTDNF_CMD_OPT pSetOpt = NULL;
     DIR *pDir = NULL;
@@ -150,11 +150,11 @@ error:
 
 uint32_t
 TDNFCreateCmdLineRepo(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     )
 {
     uint32_t dwError;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
 
     if(!ppRepo)
     {
@@ -181,13 +181,13 @@ error:
 
 uint32_t
 TDNFCreateRepoFromPath(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    PTDNF_REPO_DATA* ppRepo,
     const char *pszId,
     const char *pszPath
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     int nIsDir = 0;
     int nDummy = 0;
 
@@ -244,12 +244,12 @@ error:
 
 uint32_t
 TDNFCreateRepo(
-    PTDNF_REPO_DATA_INTERNAL* ppRepo,
+    PTDNF_REPO_DATA* ppRepo,
     const char *pszId
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
 
     if(!ppRepo || !pszId)
     {
@@ -259,7 +259,7 @@ TDNFCreateRepo(
 
     dwError = TDNFAllocateMemory(
                   1,
-                  sizeof(TDNF_REPO_DATA_INTERNAL),
+                  sizeof(TDNF_REPO_DATA),
                   (void**)&pRepo);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -367,15 +367,15 @@ uint32_t
 TDNFLoadReposFromFile(
     PTDNF pTdnf,
     char* pszRepoFile,
-    PTDNF_REPO_DATA_INTERNAL* ppRepos
+    PTDNF_REPO_DATA* ppRepos
     )
 {
     char *pszRepo = NULL;
     uint32_t dwError = 0;
     char *pszMetadataExpire = NULL;
 
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
 
     PCONF_DATA pData = NULL;
     PCONF_SECTION pSections = NULL;
@@ -394,7 +394,7 @@ TDNFLoadReposFromFile(
 
         dwError = TDNFAllocateMemory(
                       1,
-                      sizeof(TDNF_REPO_DATA_INTERNAL),
+                      sizeof(TDNF_REPO_DATA),
                       (void**)&pRepo);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -600,7 +600,7 @@ TDNFRepoListFinalize(
 {
     uint32_t dwError = 0;
     PTDNF_CMD_OPT pSetOpt = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     int nRepoidSeen = 0;
 
     if(!pTdnf || !pTdnf->pArgs || !pTdnf->pRepos)
@@ -679,7 +679,7 @@ error:
 
 uint32_t
 TDNFAlterRepoState(
-    PTDNF_REPO_DATA_INTERNAL pRepos,
+    PTDNF_REPO_DATA pRepos,
     int nEnable,
     const char* pszId
     )
@@ -725,7 +725,7 @@ error:
 
 uint32_t
 TDNFCloneRepo(
-    PTDNF_REPO_DATA_INTERNAL pRepoIn,
+    PTDNF_REPO_DATA pRepoIn,
     PTDNF_REPO_DATA* ppRepo
     )
 {
@@ -741,6 +741,7 @@ TDNFCloneRepo(
     dwError = TDNFAllocateMemory(1, sizeof(TDNF_REPO_DATA), (void**)&pRepo);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    /* cli needs just nEnabled, pszId, pszName */
     pRepo->nEnabled = pRepoIn->nEnabled;
 
     dwError = TDNFSafeAllocateString(pRepoIn->pszId, &pRepo->pszId);
@@ -749,6 +750,7 @@ TDNFCloneRepo(
     dwError = TDNFSafeAllocateString(pRepoIn->pszName, &pRepo->pszName);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    /* python needs also pszBaseUrl and pszMetaLink */
     dwError = TDNFSafeAllocateString(pRepoIn->pszBaseUrl, &pRepo->pszBaseUrl);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -756,13 +758,6 @@ TDNFCloneRepo(
                   pRepoIn->pszMetaLink,
                   &pRepo->pszMetaLink);
     BAIL_ON_TDNF_ERROR(dwError);
-
-    if (pRepoIn->ppszUrlGPGKeys) {
-        dwError = TDNFAllocateStringArray(
-                      pRepoIn->ppszUrlGPGKeys,
-                      &pRepo->ppszUrlGPGKeys);
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
 
     *ppRepo = pRepo;
 
@@ -783,10 +778,10 @@ error:
 
 void
 TDNFFreeReposInternal(
-    PTDNF_REPO_DATA_INTERNAL pRepos
+    PTDNF_REPO_DATA pRepos
     )
 {
-    PTDNF_REPO_DATA_INTERNAL pRepo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
     while(pRepos)
     {
         pRepo = pRepos;

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -42,7 +42,7 @@ error:
 uint32_t
 TDNFRepoSetBaseUrl(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA_INTERNAL pszRepo,
+    PTDNF_REPO_DATA pszRepo,
     const char *pszBaseUrlFile
     )
 {
@@ -77,7 +77,7 @@ TDNFRepoGetBaseUrl(
 {
     uint32_t dwError = 0;
     char* pszBaseUrl = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if(!pTdnf || IsNullOrEmptyString(pszRepo) || !ppszBaseUrl)
     {
@@ -130,7 +130,7 @@ TDNFRepoGetUserPass(
 {
     uint32_t dwError = 0;
     char* pszUserPass = NULL;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if(!pTdnf || IsNullOrEmptyString(pszRepo) || !ppszUserPass)
     {
@@ -483,7 +483,7 @@ error:
 
 uint32_t
 TDNFRepoApplyDownloadSettings(
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     CURL *pCurl
     )
 {
@@ -540,7 +540,7 @@ error:
 
 uint32_t
 TDNFRepoApplySSLSettings(
-    PTDNF_REPO_DATA_INTERNAL pRepo,
+    PTDNF_REPO_DATA pRepo,
     CURL *pCurl
     )
 {
@@ -617,11 +617,11 @@ uint32_t
 TDNFFindRepoById(
     PTDNF pTdnf,
     const char* pszRepo,
-    PTDNF_REPO_DATA_INTERNAL* ppRepo
+    PTDNF_REPO_DATA* ppRepo
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPO_DATA_INTERNAL pRepos = NULL;
+    PTDNF_REPO_DATA pRepos = NULL;
 
     if(!pTdnf || IsNullOrEmptyString(pszRepo))
     {

--- a/client/structs.h
+++ b/client/structs.h
@@ -19,40 +19,12 @@ typedef struct _TDNF_PLUGIN_
     struct _TDNF_PLUGIN_ *pNext;
 } TDNF_PLUGIN, *PTDNF_PLUGIN;
 
-typedef struct _TDNF_REPO_DATA_INTERNAL_
-{
-    int nEnabled;
-    int nSkipIfUnavailable;
-    int nGPGCheck;
-    int nSSLVerify;
-    long lMetadataExpire;
-    char* pszId;
-    char* pszName;
-    char* pszBaseUrl;
-    char* pszMetaLink;
-    char* pszSSLCaCert;
-    char* pszSSLClientCert;
-    char* pszSSLClientKey;
-    char** ppszUrlGPGKeys;
-    char* pszUser;
-    char* pszPass;
-    int nPriority;
-    int nTimeout;
-    int nMinrate;
-    int nThrottle;
-    int nRetries;
-    int nSkipMDFileLists;
-    int nSkipMDUpdateInfo;
-    int nSkipMDOther;
-    struct _TDNF_REPO_DATA_INTERNAL_* pNext;
-} TDNF_REPO_DATA_INTERNAL, *PTDNF_REPO_DATA_INTERNAL;
-
 typedef struct _TDNF_
 {
     PSolvSack pSack;
     PTDNF_CMD_ARGS pArgs;
     PTDNF_CONF pConf;
-    PTDNF_REPO_DATA_INTERNAL pRepos;
+    PTDNF_REPO_DATA pRepos;
     Repo *pSolvCmdLineRepo;
     Queue queueCmdLinePkgs;
     PTDNF_PLUGIN pPlugins;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -292,6 +292,20 @@ typedef struct _TDNF_REPO_DATA
     char* pszBaseUrl;
     char* pszMetaLink;
     char** ppszUrlGPGKeys;
+    int nSSLVerify;
+    char* pszSSLCaCert;
+    char* pszSSLClientCert;
+    char* pszSSLClientKey;
+    char* pszUser;
+    char* pszPass;
+    int nPriority;
+    int nTimeout;
+    int nMinrate;
+    int nThrottle;
+    int nRetries;
+    int nSkipMDFileLists;
+    int nSkipMDUpdateInfo;
+    int nSkipMDOther;
 
     struct _TDNF_REPO_DATA* pNext;
 }TDNF_REPO_DATA, *PTDNF_REPO_DATA;


### PR DESCRIPTION
There were two different structures to track the repository configurations. Unifying them.