### PR TITLE
do not mark packages as auto installed if only downloading

### DIFF
--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -99,10 +99,10 @@ TDNFRpmExecTransaction(
     if (!nDownloadOnly) {
         dwError = TDNFRunTransaction(&ts, pTdnf);
         BAIL_ON_TDNF_ERROR(dwError);
-    }
 
-    dwError = TDNFMarkAutoInstalled(pTdnf, pSolvedInfo);
-    BAIL_ON_TDNF_ERROR(dwError);
+        dwError = TDNFMarkAutoInstalled(pTdnf, pSolvedInfo);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
 cleanup:
     if(ts.pTS)


### PR DESCRIPTION
Packages should not be marked auto installed when we are just downloading.