### PR TITLE
move find_package calls to top level, remove redundant call for libxml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 ### External dependency: rpm-devel
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(RPM REQUIRED rpm)
+find_package(OpenSSL REQUIRED)
 pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
 include_directories(${RPM_INCLUDE_DIRS})
 include_directories(${LIBXML2_INCLUDE_DIRS})

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -8,10 +8,6 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-find_package(OpenSSL REQUIRED)
-
-find_package(LIBXML2 REQUIRED)
-
 #make config.h with
 #PACKAGE_NAME and PACKAGE_VERSION defined
 configure_file(


### PR DESCRIPTION
I tried building on Ubuntu 20.04 which does not ship a `cmake` file for `libxml` needed by `find_package`, so it needs `pkg_check_modules` - which we already use in the top level.

Also remove the redundant `find_package` for OpenSSL.

cmake still throws warnings about
```
  The package name passed to `find_package_handle_standard_args` (libssl)
  does not match the name of the calling package (OpenSSL).
```
 Should be fixed later.

