### PR TITLE
move jsondump lib to cli lib

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -46,7 +46,6 @@ add_library(${LIB_TDNF} SHARED
 
 target_link_libraries(${LIB_TDNF}
     ${LIB_TDNF_COMMON}
-    ${LIB_TDNF_JSONDUMP}
     ${LIB_TDNF_SOLV}
     ${RPM_LIBRARIES}
     ${LibSolv_LIBRARIES}

--- a/tools/cli/lib/CMakeLists.txt
+++ b/tools/cli/lib/CMakeLists.txt
@@ -28,6 +28,10 @@ add_library(${LIB_TDNF_CLI} SHARED
     updateinfocmd.c
 )
 
+target_link_libraries(${LIB_TDNF_CLI}
+    ${LIB_TDNF_JSONDUMP}
+)
+
 set_target_properties(${LIB_TDNF_CLI} PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}


### PR DESCRIPTION
The jsondump code needs to be in the cli lib. It's used only by the cli. This worked fine before, until trying to build pmd.

Tested pmd build using this change.