### PR TITLE
add --testonly option

### DIFF
--- a/client/init.c
+++ b/client/init.c
@@ -58,6 +58,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nDownloadOnly  = pCmdArgsIn->nDownloadOnly;
     pCmdArgs->nNoAutoRemove  = pCmdArgsIn->nNoAutoRemove;
     pCmdArgs->nJsonOutput    = pCmdArgsIn->nJsonOutput;
+    pCmdArgs->nTestOnly      = pCmdArgsIn->nTestOnly;
 
     pCmdArgs->nArgc = pCmdArgsIn->nArgc;
     pCmdArgs->ppszArgv = pCmdArgsIn->ppszArgv;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -223,6 +223,7 @@ typedef struct _TDNF_CMD_ARGS
     int nDownloadOnly;     //download packages only, no install
     int nNoAutoRemove;     //overide clean_requirements_on_remove config option
     int nJsonOutput;       //output in json format
+    int nTestOnly;         //run test transaction only
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/pytests/tests/test_history.py
+++ b/pytests/tests/test_history.py
@@ -95,6 +95,74 @@ def test_history_undo(utils):
     assert not utils.check_package(pkgname2)
 
 
+def test_history_undo_remove(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+
+    utils.erase_package(pkgname)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
+    assert utils.check_package(pkgname)
+
+    utils.run(['tdnf', 'remove', '-y', pkgname])
+    assert not utils.check_package(pkgname)
+
+    ret = utils.run(['tdnf', 'history'])
+    baseline = ret['stdout'][-1].split()[0]
+
+    # should undo remove of pkgname
+    utils.run(['tdnf', 'history', '-y', '--nogpgcheck', 'undo', '--from', str(int(baseline))])
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+
+
+def test_history_undo_downloadonly(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+
+    utils.erase_package(pkgname)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
+    assert utils.check_package(pkgname)
+
+    utils.run(['tdnf', 'remove', '-y', pkgname])
+    assert not utils.check_package(pkgname)
+
+    ret = utils.run(['tdnf', 'history'])
+    baseline = ret['stdout'][-1].split()[0]
+
+    # would undo remove of pkgname
+    utils.run(['tdnf', 'history', '-y', '--downloadonly', '--nogpgcheck', 'undo', '--from', str(int(baseline))])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+
+    # verify that there is no record of it either
+    ret = utils.run(['tdnf', 'history'])
+    assert baseline == ret['stdout'][-1].split()[0]
+
+
+def test_history_undo_testonly(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+
+    utils.erase_package(pkgname)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
+    assert utils.check_package(pkgname)
+
+    utils.run(['tdnf', 'remove', '-y', pkgname])
+    assert not utils.check_package(pkgname)
+
+    ret = utils.run(['tdnf', 'history'])
+    baseline = ret['stdout'][-1].split()[0]
+
+    # would undo remove of pkgname
+    utils.run(['tdnf', 'history', '-y', '--testonly', '--nogpgcheck', 'undo', '--from', str(int(baseline))])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+
+    # verify that there is no record of it either
+    ret = utils.run(['tdnf', 'history'])
+    assert baseline == ret['stdout'][-1].split()[0]
+
+
 def test_history_undo_multiple(utils):
     pkgname1 = utils.config["mulversion_pkgname"]
     pkgname2 = utils.config["sglversion_pkgname"]

--- a/pytests/tests/test_install.py
+++ b/pytests/tests/test_install.py
@@ -61,7 +61,15 @@ def test_dummy_requires(utils):
     assert ' nothing provides ' in ret['stderr'][0]
 
 
-def xxx_test_install_memcheck(utils):
+def test_install_testonly(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', '--testonly', pkgname])
+    assert not utils.check_package(pkgname)
+
+
+def test_install_memcheck(utils):
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -40,6 +40,7 @@ static const char *help_msg =
  "           [--skipdigest]\n"
  "           [--skipsignature]\n"
  "           [--skipobsoletes]\n"
+ "           [--testonly]\n"
  "           [--version]\n\n"
  "repoquery select options:\n"
  "           [--available]\n"

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -64,6 +64,7 @@ static struct option pstOptions[] =
     {"skipdigest",    no_argument, 0, 0},                  //--skipdigest to skip verifying RPM digest
     {"skipobsoletes", no_argument, 0, 0},                  //--skipobsoletes to skip obsolete problems
     {"skipsignature", no_argument, 0, 0},                  //--skipsignature to skip verifying RPM signatures
+    {"testonly",      no_argument, &_opt.nTestOnly, 1},
     {"verbose",       no_argument, &_opt.nVerbose, 1},     //-v --verbose
     {"version",       no_argument, &_opt.nShowVersion, 1}, //--version
     // reposync options
@@ -325,6 +326,7 @@ TDNFCopyOptions(
     pArgs->nDownloadOnly  = pOptionArgs->nDownloadOnly;
     pArgs->nNoAutoRemove  = pOptionArgs->nNoAutoRemove;
     pArgs->nJsonOutput    = pOptionArgs->nJsonOutput;
+    pArgs->nTestOnly      = pOptionArgs->nTestOnly;
 
 cleanup:
     return dwError;


### PR DESCRIPTION
Add the option `--testonly` to only test a transaction but not actually running it. This is similar to the `--test` for `rpm`.