### PR TITLE
fix repoquery segfault

### DIFF
--- a/pytests/tests/test_repoquery.py
+++ b/pytests/tests/test_repoquery.py
@@ -206,3 +206,12 @@ def test_list1(utils):
                               'tdnf-repoquery-{}'.format(dep)
                               ])
     assert(ret['retval'] == 0)
+
+
+# fail with ore than one pkg spec
+def test_two_args(utils):
+    ret = utils.run(['tdnf',
+                     'repoquery',
+                     'foo',
+                     'bar'])
+    assert(ret['retval'] == 902)

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -671,7 +671,7 @@ TDNFCliRepoQueryCommand(
 {
     uint32_t dwError = 0;
     uint32_t dwCount = 0;
-    PTDNF_REPOQUERY_ARGS pRepoqueryArgs;
+    PTDNF_REPOQUERY_ARGS pRepoqueryArgs = NULL;
     PTDNF_PKG_INFO pPkgInfo = NULL;
     PTDNF_PKG_INFO pPkgInfos = NULL;
     int nCount = 0, i, j, k;

--- a/tools/cli/lib/parserepoqueryargs.c
+++ b/tools/cli/lib/parserepoqueryargs.c
@@ -168,6 +168,7 @@ TDNFCliParseRepoQueryArgs(
 cleanup:
     return dwError;
 error:
+    *ppRepoqueryArgs = NULL;
     TDNFCliFreeRepoQueryArgs(pRepoqueryArgs);
     goto cleanup;
 }


### PR DESCRIPTION
The `repoquery` command crashed when given more than one spec (arguments). For example:
```
# tdnf repoquery foo bar
Error(902) : Invalid argument.
Segmentation fault (core dumped)
```
Reason was trying to free an uninitialized `PTDNF_REPOQUERY_ARGS` pointer.