### PR TITLE
ensure spaces separate list columns

### DIFF
--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -232,7 +232,7 @@ TDNFCliListCommand(
             }
 
             pr_crit(
-                "%-*s%-*s%*s\n",
+                "%-*s %-*s %*s\n",
                 nColWidths[0],
                 szNameAndArch,
                 nColWidths[1],


### PR DESCRIPTION
Some package names are very long, so the list output might merge name, version and repo together if the screen width is not wide enough or output is not a tty:
```
rubygem-ffi.x86_64                          1.13.1-2.ph4        photon-updates
rubygem-fluent-plugin-kubernetes_metadata_filter.noarch2.5.2-3.ph4         photon-updates
rubygem-fluentd.noarch                      1.11.3-2.ph4        photon-updates
```
Fixed example:
```
rubygem-ffi.x86_64                           1.13.1-2.ph4         photon-updates
rubygem-fluent-plugin-kubernetes_metadata_filter.noarch 2.5.2-3.ph4          photon-updates
rubygem-fluentd.noarch                       1.11.3-2.ph4         photon-updates
```
