### PR TITLE
suggest to 'tdnf makecache' on download failure

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -651,7 +651,8 @@ TDNFDownloadFile(
     if(lStatus >= 400)
     {
         pr_err(
-                "Error: %ld when downloading %s\n. Please check repo url.\n",
+                "Error: %ld when downloading %s\n. Please check repo url "
+                "or refresh metadata with 'tdnf makecache'.\n",
                 lStatus,
                 pszFileUrl);
         dwError = ERROR_TDNF_INVALID_PARAMETER;


### PR DESCRIPTION
Fixes issue #309 . This hopefully gives users an immediate solution if the cache is outdated.

Example with wrong URL:
```
# ./bin/tdnf install gdb

Installing:
gdb                                         x86_64                10.1-2.ph4                    photon-updates         10.54M 11051654

Total installed size:  10.54M 11051654
Is this ok [y/N]: y

Downloading:
Error: 404 when downloading https://packages.vmware.com/photonx/4.0/photon_updates_4.0_x86_64/x86_64/gdb-10.1-2.ph4.x86_64.rpm
. Please check repo url or refresh metadata with 'tdnf makecache'.
Error processing package: x86_64/gdb-10.1-2.ph4.x86_64.rpm
Error(1622) : Invalid argument
```