### PR TITLE
ci: exit if one of the cmake/make commands fail

### DIFF
--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -5,7 +5,7 @@ rm -rf build
 mkdir -p build
 cd build || exit 1
 
-cmake .. && make -j32 && make python -j32 && make check -j32
+cmake .. && make -j32 && make python -j32 && make check -j32 || exit
 
 if ! flake8 ../pytests ; then
   echo "flake8 tests failed"


### PR DESCRIPTION
Somehow the `set -` was not enough to make `ci/docker-entrypoint.sh` fail on failure. adding an extra `exit` of one of the commands to build and check fails.