### PR TITLE
add "mark" command 

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(${LIB_TDNF}
     ${METALINK_LIBRARIES}
     ${OPENSSL_LIBRARIES}
     ${LIBXML2_LIBRARIES}
+    ${SQLITE3_LIBRARIES}
 )
 
 set_target_properties(${LIB_TDNF} PROPERTIES

--- a/client/api.c
+++ b/client/api.c
@@ -183,13 +183,40 @@ TDNFAlterCommand(
     )
 {
     uint32_t dwError = 0;
+
+    UNUSED(nAlterType);
+
     if(!pTdnf || !pSolvedInfo)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFRpmExecTransaction(pTdnf, pSolvedInfo, nAlterType);
+    dwError = TDNFRpmExecTransaction(pTdnf, pSolvedInfo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+cleanup:
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFAlterHistoryCommand(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedInfo,
+    PTDNF_HISTORY_ARGS pHistoryArgs
+    )
+{
+    uint32_t dwError = 0;
+    if(!pTdnf || !pSolvedInfo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFRpmExecHistoryTransaction(pTdnf, pSolvedInfo, pHistoryArgs);
     BAIL_ON_TDNF_ERROR(dwError);
 
 cleanup:
@@ -1401,6 +1428,7 @@ TDNFRepoQuery(
     int nDetail;
     uint32_t dwCount = 0;
     TDNF_SCOPE nScope = SCOPE_ALL;
+    struct history_ctx *pHistoryCtx = NULL;
 
     if(!pTdnf || !pTdnf->pSack || !pRepoqueryArgs ||
        !ppPkgInfo || !pdwCount)
@@ -1424,6 +1452,12 @@ TDNFRepoQuery(
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* userinstalled implies installed */
+    if (pRepoqueryArgs->nUserInstalled)
+    {
+        pRepoqueryArgs->nInstalled = 1;
     }
 
     dwError = TDNFRefresh(pTdnf);
@@ -1472,6 +1506,15 @@ TDNFRepoQuery(
     else if (pRepoqueryArgs->nDuplicates)
     {
         dwError = SolvApplyDuplicatesFilter(pQuery);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if (pRepoqueryArgs->nUserInstalled)
+    {
+        dwError = TDNFGetHistoryCtx(pTdnf, &pHistoryCtx, 0);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvApplyUserInstalledFilter(pQuery, pHistoryCtx);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -1543,6 +1586,10 @@ cleanup:
     if(pPkgList)
     {
         SolvFreePackageList(pPkgList);
+    }
+    if (pHistoryCtx)
+    {
+        destroy_history_ctx(pHistoryCtx);
     }
     return dwError;
 error:
@@ -1937,6 +1984,7 @@ TDNFHistoryResolve(
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo = NULL;
     struct history_ctx *ctx = NULL;
     struct history_delta *hd = NULL;
+    struct history_flags_delta *hfd;
     struct history_nevra_map *hnm = NULL;
     rpmts ts = NULL;
     Queue qInstall = {0};
@@ -2012,12 +2060,15 @@ TDNFHistoryResolve(
             goto cleanup;
         case HISTORY_CMD_ROLLBACK:
             hd = history_get_delta(ctx, pHistoryArgs->nTo);
+            hfd = history_get_flags_delta(ctx, ctx->trans_id, pHistoryArgs->nTo - 1);
             break;
         case HISTORY_CMD_UNDO:
             hd = history_get_delta_range(ctx, pHistoryArgs->nFrom - 1, pHistoryArgs->nTo);
+            hfd = history_get_flags_delta(ctx, pHistoryArgs->nTo, pHistoryArgs->nFrom - 1);
             break;
         case HISTORY_CMD_REDO:
             hd = history_get_delta_range(ctx, pHistoryArgs->nTo, pHistoryArgs->nFrom - 1);
+            hfd = history_get_flags_delta(ctx, pHistoryArgs->nFrom - 1, pHistoryArgs->nTo);
             break;
         default:
             dwError = ERROR_TDNF_INVALID_PARAMETER;
@@ -2133,6 +2184,12 @@ TDNFHistoryResolve(
         pSolvedPkgInfo->pPkgsToReinstall;
 
     pSolvedPkgInfo->ppszPkgsNotResolved = ppszPkgsNotResolved;
+
+    /* if there is no action, maybe there is a flags change */
+    if (!pSolvedPkgInfo->nNeedAction)
+    {
+        pSolvedPkgInfo->nNeedAction = (hfd->count > 0);
+    }
 
     *ppSolvedPkgInfo = pSolvedPkgInfo;
 
@@ -2273,6 +2330,98 @@ error:
     {
         TDNFFreeHistoryInfoItems(pHistoryInfoItems, count);
     }
+    goto cleanup;
+}
+
+uint32_t
+TDNFMark(
+    PTDNF pTdnf,
+    char** ppszPackageNameSpecs,
+    uint32_t dwValue
+    )
+{
+    uint32_t dwError = 0;
+    PSolvQuery pQuery = NULL;
+    PSolvPackageList pPkgList = NULL;
+    struct history_ctx *ctx = NULL;
+    char *pszCmdLine = NULL;
+    char *pszName = NULL;
+
+    if(!pTdnf || !pTdnf->pSack || !ppszPackageNameSpecs)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = SolvCreateQuery(pTdnf->pSack, &pQuery);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFApplyScopeFilter(pQuery, SCOPE_INSTALLED);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = SolvApplyPackageFilter(pQuery, ppszPackageNameSpecs);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = SolvApplyListQuery(pQuery);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = SolvGetQueryResult(pQuery, &pPkgList);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    if (pPkgList->queuePackages.count > 0)
+    {
+        dwError = TDNFJoinArrayToString(&(pTdnf->pArgs->ppszArgv[1]),
+                                        " ",
+                                        pTdnf->pArgs->nArgc,
+                                        &pszCmdLine);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFGetHistoryCtx(pTdnf, &ctx, 1);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        history_add_transaction(ctx, pszCmdLine);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        for (int i = 0; i < pPkgList->queuePackages.count; i++)
+        {
+            int rc;
+
+            dwError = SolvGetPkgNameFromId(pTdnf->pSack,
+                                           pPkgList->queuePackages.elements[i],
+                                           &pszName);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            pr_info("marking %s as %sinstalled\n", pszName, dwValue ? "auto" : "user");
+
+            rc = history_set_auto_flag(ctx, pszName, dwValue);
+            if (rc != 0)
+            {
+                dwError = ERROR_TDNF_HISTORY_ERROR;
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+            TDNF_SAFE_FREE_MEMORY(pszName);
+        }
+    }
+    else
+    {
+        dwError = ERROR_TDNF_NO_MATCH;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszCmdLine);
+    TDNF_SAFE_FREE_MEMORY(pszName);
+    destroy_history_ctx(ctx);
+    if(pQuery)
+    {
+        SolvFreeQuery(pQuery);
+    }
+    if(pPkgList)
+    {
+        SolvFreePackageList(pPkgList);
+    }
+    return dwError;
+error:
     goto cleanup;
 }
 

--- a/client/api.c
+++ b/client/api.c
@@ -178,13 +178,10 @@ error:
 uint32_t
 TDNFAlterCommand(
     PTDNF pTdnf,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedInfo
     )
 {
     uint32_t dwError = 0;
-
-    UNUSED(nAlterType);
 
     if(!pTdnf || !pSolvedInfo)
     {

--- a/client/goal.c
+++ b/client/goal.c
@@ -508,7 +508,8 @@ TDNFGoal(
     nAllowErasing =
         pTdnf->pArgs->nAllowErasing ||
         nAlterType == ALTER_ERASE ||
-        nAlterType == ALTER_AUTOERASE;
+        nAlterType == ALTER_AUTOERASE ||
+        nAlterType == ALTER_AUTOERASEALL;
     if(nAllowErasing)
     {
         TDNFAddUserInstalledToJobs(pTdnf, &queueJobs);
@@ -794,6 +795,7 @@ TDNFAddGoal(
             break;
         case ALTER_ERASE:
         case ALTER_AUTOERASE:
+        case ALTER_AUTOERASEALL:
             dwError = SolvAddPkgEraseJob(pQueueJobs, dwId);
             BAIL_ON_TDNF_ERROR(dwError);
             break;

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -392,6 +392,11 @@ TDNFFilterPackages(
     );
 
 uint32_t
+TDNFGetAutoInstalledOrphans(
+    PTDNF pTdnf,
+    Queue* pQueueGoal);
+
+uint32_t
 TDNFAddPackagesForInstall(
     PSolvSack pSack,
     Queue* pQueueGoal,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -499,7 +499,9 @@ TDNFMarkAutoInstalledSinglePkg(
 uint32_t
 TDNFMarkAutoInstalled(
     PTDNF pTdnf,
-    PTDNF_SOLVED_PKG_INFO ppInfo
+    struct history_ctx *pHistoryCtx,
+    PTDNF_SOLVED_PKG_INFO ppInfo,
+    int nAutoOnly
     );
 
 uint32_t
@@ -900,8 +902,14 @@ TDNFAddNotResolved(
 uint32_t
 TDNFRpmExecTransaction(
     PTDNF pTdnf,
-    PTDNF_SOLVED_PKG_INFO pInfo,
-    TDNF_ALTERTYPE nAlterType
+    PTDNF_SOLVED_PKG_INFO pInfo
+    );
+
+uint32_t
+TDNFRpmExecHistoryTransaction(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedInfo,
+    PTDNF_HISTORY_ARGS pHistoryArgs
     );
 
 void*

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -92,6 +92,11 @@ TDNFPrepareAllPackages(
                        queueGoal);
         BAIL_ON_TDNF_ERROR(dwError);
     }
+    else if (nAlterType == ALTER_AUTOERASEALL)
+    {
+        dwError = TDNFGetAutoInstalledOrphans(pTdnf, queueGoal);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
     dwError = TDNFGetSecuritySeverityOption(
                   pTdnf,
@@ -268,6 +273,40 @@ cleanup:
     if(pInstalledPkgList)
     {
         SolvFreePackageList(pInstalledPkgList);
+    }
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFGetAutoInstalledOrphans(
+    PTDNF pTdnf,
+    Queue* pQueueGoal)
+{
+    uint32_t dwError = 0;
+    PSolvSack pSack = NULL;
+    struct history_ctx *pHistoryCtx = NULL;
+
+    if(!pTdnf || !pTdnf->pSack || !pQueueGoal)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    pSack = pTdnf->pSack;
+
+    dwError = TDNFGetHistoryCtx(pTdnf, &pHistoryCtx, 1);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = SolvGetAutoInstalledOrphans(pSack, pHistoryCtx, pQueueGoal);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+cleanup:
+    if(pHistoryCtx)
+    {
+        destroy_history_ctx(pHistoryCtx);
     }
     return dwError;
 

--- a/history/history.c
+++ b/history/history.c
@@ -882,6 +882,8 @@ int history_restore_auto_flags(struct history_ctx *ctx, int trans_id)
     int rc = 0;
     int i, count;
 
+    check_ptr(ctx);
+
     rc = db_table_exists(ctx->db, "names");
     if (rc == SQLITE_DONE) { /* no table => nothing to restore */
         return 0;
@@ -914,6 +916,8 @@ int history_replay_auto_flags(struct history_ctx *ctx, int from, int to)
 {
     int rc = 0;
     int i, count;
+
+    check_ptr(ctx);
 
     rc = db_table_exists(ctx->db, "names");
     if (rc == SQLITE_DONE) { /* no table => nothing to restore */
@@ -966,6 +970,8 @@ history_get_flags_delta(struct history_ctx *ctx, int from, int to)
     int i, count;
     struct history_flags_delta *hfd = NULL;
 
+    check_ptr(ctx);
+
     rc = db_table_exists(ctx->db, "names");
     if (rc == SQLITE_DONE) { /* no table => nothing to restore */
         return 0;
@@ -976,7 +982,7 @@ history_get_flags_delta(struct history_ctx *ctx, int from, int to)
 
     hfd = (struct history_flags_delta *)calloc(1, sizeof(struct history_flags_delta));
     check_ptr(hfd);
-    
+
     hfd->changed_ids = calloc(count, sizeof(int));
     check_ptr(hfd->changed_ids);
     hfd->values = calloc(count, sizeof(int));
@@ -1054,6 +1060,9 @@ int history_set_ids_from_map(struct history_ctx *ctx,
 {
     int rc = 0;
 
+    check_ptr(ctx);
+    check_ptr(installed_map);
+
     safe_free(ctx->installed_ids);
     ctx->installed_ids =
         get_ids_from_map(installed_map, map_size, &ctx->installed_count);
@@ -1081,6 +1090,8 @@ struct history_delta *history_get_delta(struct history_ctx *ctx, int trans_id)
     struct history_delta *hd =
         (struct history_delta *)calloc(1, sizeof(struct history_delta));
     int *installed_ids = NULL;
+
+    check_ptr(ctx);
 
     check_ptr(hd);
 
@@ -1126,6 +1137,8 @@ struct history_delta *history_get_delta_range(struct history_ctx *ctx,
     struct history_delta *hd =
         (struct history_delta *)calloc(1, sizeof(struct history_delta));
     int *installed_ids0 = NULL, *installed_ids1 = NULL;
+
+    check_ptr(ctx);
 
     check_ptr(hd);
 
@@ -1179,13 +1192,21 @@ void history_free_nevra_map(struct history_nevra_map *hnm)
 
 struct history_nevra_map *history_nevra_map(struct history_ctx *ctx)
 {
+    int rc = 0;
+    check_ptr(ctx);
     return db_nevra_map(ctx->db);
+error:
+    return NULL;
 }
 
 char *history_get_nevra(struct history_nevra_map *hnm, int id)
 {
+    int rc  = 0;
+
+    check_ptr(hnm);
     if (id > 0 && id <= hnm->count)
         return hnm->idmap[id - 1];
+error:
     return NULL;
 }
 
@@ -1195,6 +1216,8 @@ int history_set_state(struct history_ctx *ctx, int trans_id)
     int rc = 0;
     char *installed_map = NULL;
     int map_size = 0;
+
+    check_ptr(ctx);
 
     rc = db_rpms_maxid(ctx->db, &map_size);
     check_rc(rc);
@@ -1222,6 +1245,8 @@ int history_record_state(struct history_ctx *ctx)
     int rc = 0;
     char *err_msg = NULL;
     int trans_id = 0;
+
+    check_ptr(ctx);
 
     /* avoid unfinished transaction record on failure or crash */
     rc = sqlite3_exec(ctx->db, "BEGIN TRANSACTION;", 0, 0, NULL);
@@ -1285,6 +1310,9 @@ int history_get_transactions(struct history_ctx *ctx,
     struct history_transaction *tas = NULL;
     char sql[256];
 
+    check_ptr(ctx);
+    check_ptr(ptas);
+    check_ptr(pcount);
     check_cond(to >= from);
 
     if (from == 0 || to == 0) {
@@ -1365,6 +1393,9 @@ int history_add_transaction(struct history_ctx *ctx, const char *cmdline)
     int trans_id;
     time_t now = time(NULL);
 
+    check_ptr(ctx);
+    check_ptr(cmdline);
+
     rc = db_add_transaction(ctx->db, &trans_id, cmdline, now,
                             /* reuse cookie, we are not changing the rpmdb */
                             ctx->cookie,
@@ -1387,6 +1418,9 @@ int history_update_state(struct history_ctx *ctx, rpmts ts, const char *cmdline)
     int *added_ids = NULL, added_count;
     int *removed_ids = NULL, removed_count;
     char *cookie = NULL;
+
+    check_ptr(ctx);
+    check_ptr(ts);
 
     cookie = rpmdbCookie(rpmtsGetRdb(ts));
     check_ptr(cookie);
@@ -1527,6 +1561,8 @@ struct history_ctx *create_history_ctx(const char *db_filename)
     sqlite3 *db;
     struct history_ctx *ctx = NULL;
     sqlite3_stmt *res = NULL;
+
+    check_ptr(db_filename);
 
     db = init_db(db_filename);
     check_ptr(db);

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -201,7 +201,6 @@ TDNFResolve(
 uint32_t
 TDNFAlterCommand(
     PTDNF pTdnf,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedInfo
     );
 

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -205,6 +205,23 @@ TDNFAlterCommand(
     PTDNF_SOLVED_PKG_INFO pSolvedInfo
     );
 
+/* Similar to TDNFAlterCommand() but for history
+   transactions like rollback, undo and redo
+*/
+uint32_t
+TDNFAlterHistoryCommand(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedInfo,
+    PTDNF_HISTORY_ARGS pHistoryArgs
+    );
+
+uint32_t
+TDNFMark(
+    PTDNF pTdnf,
+    char** ppszPackageNameSpecs,
+    uint32_t dwValue
+    );
+
 //Show a descriptive error message
 //divided into different areas like
 //solv, repo, rpm and generic tdnf errors.

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -298,14 +298,6 @@ TDNFCliMarkCommand(
     );
 
 uint32_t
-TDNFCliAskAndAlter(
-    PTDNF_CLI_CONTEXT pContext,
-    PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_ALTERTYPE nAlterType,
-    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
-);
-
-uint32_t
 TDNFCliAskForAction(
     PTDNF_CMD_ARGS pCmdArgs,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -292,11 +292,28 @@ TDNFCliUpgradeCommand(
     );
 
 uint32_t
+TDNFCliMarkCommand(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_CMD_ARGS pCmdArgs
+    );
+
+uint32_t
 TDNFCliAskAndAlter(
     PTDNF_CLI_CONTEXT pContext,
     PTDNF_CMD_ARGS pCmdArgs,
     TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
+);
+
+uint32_t
+TDNFCliAskForAction(
+    PTDNF_CMD_ARGS pCmdArgs,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
+);
+
+uint32_t
+TDNFCliPrintActionComplete(
+    PTDNF_CMD_ARGS pCmdArgs
 );
 
 uint32_t

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -159,6 +159,18 @@ typedef uint32_t
     PTDNF_HISTORY_ARGS,
     PTDNF_SOLVED_PKG_INFO *);
 
+typedef uint32_t
+(*PFN_TDNF_ALTER_HISTORY)(
+    PTDNF_CLI_CONTEXT,
+    PTDNF_SOLVED_PKG_INFO,
+    PTDNF_HISTORY_ARGS);
+
+typedef uint32_t
+(*PFN_TDNF_MARK_COMMAND)(
+    PTDNF_CLI_CONTEXT pContext,
+    char **ppszPkgNameSpecs,
+    uint32_t nValue);
+
 typedef struct _TDNF_CLI_CONTEXT_
 {
     HTDNF hTdnf;
@@ -182,6 +194,8 @@ typedef struct _TDNF_CLI_CONTEXT_
     PFN_TDNF_UPDATEINFO_SUMMARY   pFnUpdateInfoSummary;
     PFN_TDNF_HISTORY_CMD          pFnHistoryList;
     PFN_TDNF_HISTORY_RESOLVE_CMD  pFnHistoryResolve;
+    PFN_TDNF_ALTER_HISTORY        pFnAlterHistory;
+    PFN_TDNF_MARK_COMMAND         pFnMark;
 }TDNF_CLI_CONTEXT, *PTDNF_CLI_CONTEXT;
 
 #ifdef __cplusplus

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -46,7 +46,6 @@ typedef struct _TDNF_UPDATEINFO_ARGS
 typedef uint32_t
 (*PFN_TDNF_ALTER)(
     PTDNF_CLI_CONTEXT,
-    TDNF_ALTERTYPE,
     PTDNF_SOLVED_PKG_INFO);
 
 typedef uint32_t

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -46,6 +46,7 @@ typedef enum
 typedef enum
 {
     ALTER_AUTOERASE,
+    ALTER_AUTOERASEALL,
     ALTER_DOWNGRADE,
     ALTER_DOWNGRADEALL,
     ALTER_ERASE,

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -382,6 +382,7 @@ typedef struct _TDNF_REPOQUERY_ARGS
     int nExtras;           /* packages that are installed but not available */
     int nInstalled;
     int nUpgrades;
+    int nUserInstalled;
     char *pszFile;         /* packages that own this file */
     char ***pppszWhatKeys;
 

--- a/pytests/tests/test_autoremove.py
+++ b/pytests/tests/test_autoremove.py
@@ -192,3 +192,40 @@ def test_autoremove_conf_false_autoremove(utils):
     assert(not utils.check_package(pkgname))
     # actual test:
     assert(not utils.check_package(pkgname_req))
+
+
+# 'autoremve' without args cleans up all unneeded
+# auto installed pkgs
+def test_autoremove_noargs(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'remove', '--noautoremove', pkgname])
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'autoremove'])
+    assert(not utils.check_package(pkgname))
+
+    # actual test - required pkg should be gone
+    assert(not utils.check_package(pkgname_req))
+
+
+# do not accidentally remove all autoinstaled packages
+# those that are required by userinstalled pkgs should remain
+# and removing them would drag the user installed pkgs with them
+def test_autoremove_noargs2(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname)
+    assert(utils.check_package(pkgname_req))
+
+    utils.run(['tdnf', '-y', 'autoremove'])
+
+    # actual test - user installed pkg should still be there
+    assert(utils.check_package(pkgname))
+    # also check that the required pkg is still there
+    assert(utils.check_package(pkgname_req))

--- a/pytests/tests/test_mark.py
+++ b/pytests/tests/test_mark.py
@@ -1,0 +1,62 @@
+#
+# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import pytest
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgname1 = utils.config["mulversion_pkgname"]
+    pkgname2 = utils.config["sglversion_pkgname"]
+    pkgname3 = utils.config["sglversion2_pkgname"]
+    for pkg in [pkgname1, pkgname2, pkgname3]:
+        utils.erase_package(pkg)
+
+
+# mark autoinstalled package as user installed,
+# should not be removed on autoremove
+def test_mark_install(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+    utils.install_package(pkgname)
+
+    assert(utils.check_package(pkgname_req))
+
+    ret = utils.run(['tdnf', 'mark', 'install', pkgname_req])
+    assert(ret['retval'] == 0)
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test - pkg should still be there:
+    assert(utils.check_package(pkgname_req))
+
+
+# dependency already installed, hence would not be removed
+# on autoremove, but should be if we mark it auto installed:
+def test_mark_remove(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+    utils.install_package(pkgname_req)
+    utils.install_package(pkgname)
+
+    assert(utils.check_package(pkgname_req))
+
+    ret = utils.run(['tdnf', 'mark', 'remove', pkgname_req])
+    assert(ret['retval'] == 0)
+
+    utils.run(['tdnf', '-y', 'autoremove', pkgname])
+
+    assert(not utils.check_package(pkgname))
+    # actual test - pkg should be removed:
+    assert(not utils.check_package(pkgname_req))

--- a/pytests/tests/test_repoquery.py
+++ b/pytests/tests/test_repoquery.py
@@ -215,3 +215,17 @@ def test_two_args(utils):
                      'foo',
                      'bar'])
     assert(ret['retval'] == 902)
+
+
+def test_userinstalled(utils):
+    pkgname = BASE_PKG
+    utils.install_package(pkgname)
+
+    ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
+    assert(pkgname in "\n".join(ret['stdout']))
+
+    ret = utils.run(['tdnf', 'mark', 'remove', pkgname])
+    assert(ret['retval'] == 0)
+
+    ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
+    assert(pkgname not in "\n".join(ret['stdout']))

--- a/python/tdnfpycommands.c
+++ b/python/tdnfpycommands.c
@@ -190,7 +190,7 @@ _TDNFPyAlter(TDNF_ALTERTYPE alterType, PyObject *self, PyObject *args, PyObject 
 
     if (pSolvedInfo && pSolvedInfo->nNeedAction)
     {
-        dwError = TDNFAlterCommand(pTDNF, alterType, pSolvedInfo);
+        dwError = TDNFAlterCommand(pTDNF, pSolvedInfo);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 

--- a/solv/includes.h
+++ b/solv/includes.h
@@ -39,6 +39,7 @@
 #include "../common/defines.h"
 #include "../common/structs.h"
 #include "../common/prototypes.h"
+#include "../history/history.h"
 #include "prototypes.h"
 
 #endif /* __SOLV_INCLUDES_H__ */

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -446,16 +446,10 @@ SolvAddPkgEraseJob(
     );
 
 uint32_t
-SolvAddPkgUserInstalledJob(
-    Queue* pQueueJobs,
-    Id dwId
-    );
-
-uint32_t
 SolvAddUserInstalledToJobs(
     Queue* pQueueJobs,
     Pool *pPool,
-    char **ppszAutoInstalled
+    struct history_ctx *pHistoryCtx
     );
 
 uint32_t
@@ -496,6 +490,11 @@ uint32_t
 SolvApplyFileProvidesFilter(
     PSolvQuery pQuery,
     char *pszFile);
+
+uint32_t
+SolvApplyUserInstalledFilter(
+    PSolvQuery pQuery,
+    struct history_ctx *pHistoryCtx);
 
 // tdnfrepo.c
 uint32_t

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -308,6 +308,19 @@ SolvGetChangeLogFromId(
     PTDNF_PKG_CHANGELOG_ENTRY *ppEntries
     );
 
+uint32_t
+SolvIdIsOrphaned(
+    PSolvSack pSack,
+    Id p,
+    int *pnIsOrphan
+);
+
+uint32_t
+SolvGetAutoInstalledOrphans(
+    PSolvSack pSack,
+    struct history_ctx *pHistoryCtx,
+    Queue *pQueueAutoInstalled);
+
 // tdnfpool.c
 uint32_t
 SolvCreateSack(

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -160,10 +160,8 @@ error:
 }
 
 uint32_t
-TDNFCliAskAndAlter(
-    PTDNF_CLI_CONTEXT pContext,
+TDNFCliAskForAction(
     PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
 )
 {
@@ -171,7 +169,7 @@ TDNFCliAskAndAlter(
     char** ppszPackageArgs = NULL;
     int nSilent = 0;
 
-    if(!pContext || !pCmdArgs || !pSolvedPkgInfo)
+    if(!pCmdArgs || !pSolvedPkgInfo)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_CLI_ERROR(dwError);
@@ -218,41 +216,10 @@ TDNFCliAskAndAlter(
         dwError = TDNFYesOrNo(pCmdArgs, "Is this ok [y/N]: ", &nAnswer);
         BAIL_ON_CLI_ERROR(dwError);
 
-        if(nAnswer)
+        if(!nAnswer)
         {
-            if(!nSilent && pSolvedPkgInfo->nNeedDownload)
-            {
-                pr_info("\nDownloading:\n");
-            }
-
-            dwError = pContext->pFnAlter(
-                          pContext,
-                          nAlterType,
-                          pSolvedPkgInfo);
+            dwError = ERROR_TDNF_OPERATION_ABORTED;
             BAIL_ON_CLI_ERROR(dwError);
-
-            if(!nSilent)
-            {
-                pr_info("\nComplete!\n");
-                if (pCmdArgs->nDownloadOnly)
-                {
-                    if (pCmdArgs->pszDownloadDir != NULL)
-                    {
-                        pr_info("Packages have been downloaded to %s.\n",
-                                pCmdArgs->pszDownloadDir);
-                    } else {
-                        pr_info("Packages have been downloaded to cache.\n");
-                    }
-                }
-            }
-        }
-        else
-        {
-            if (!pCmdArgs->nJsonOutput)
-            {
-                dwError = ERROR_TDNF_OPERATION_ABORTED;
-                BAIL_ON_CLI_ERROR(dwError);
-            }
         }
     }
 
@@ -261,6 +228,86 @@ cleanup:
     return dwError;
 
 error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFCliPrintActionComplete(
+    PTDNF_CMD_ARGS pCmdArgs
+)
+{
+    uint32_t dwError = 0;
+    int nSilent = 0;
+
+    if(!pCmdArgs)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+
+    nSilent = pCmdArgs->nNoOutput;
+
+    if(!nSilent)
+    {
+        pr_info("\nComplete!\n");
+        if (pCmdArgs->nDownloadOnly)
+        {
+            if (pCmdArgs->pszDownloadDir != NULL)
+            {
+                pr_info("Packages have been downloaded to %s.\n",
+                        pCmdArgs->pszDownloadDir);
+            } else {
+                pr_info("Packages have been downloaded to cache.\n");
+            }
+        }
+    }
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFCliAskAndAlter(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_CMD_ARGS pCmdArgs,
+    TDNF_ALTERTYPE nAlterType,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
+)
+{
+    uint32_t dwError = 0;
+    char** ppszPackageArgs = NULL;
+
+    if(!pContext || !pCmdArgs || !pSolvedPkgInfo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+
+    dwError = TDNFCliAskForAction(pCmdArgs, pSolvedPkgInfo);
+    BAIL_ON_CLI_ERROR(dwError);
+
+    dwError = pContext->pFnAlter(
+                pContext,
+                nAlterType,
+                pSolvedPkgInfo);
+    BAIL_ON_CLI_ERROR(dwError);
+
+    if (pCmdArgs->nJsonOutput)
+    {
+        dwError = TDNFCliPrintActionComplete(pCmdArgs);
+        BAIL_ON_CLI_ERROR(dwError);
+    }
+
+cleanup:
+    TDNF_CLI_SAFE_FREE_STRINGARRAY(ppszPackageArgs);
+    return dwError;
+
+error:
+    if (pCmdArgs->nJsonOutput && dwError == ERROR_TDNF_OPERATION_ABORTED)
+    {
+        dwError = 0;
+    }
     goto cleanup;
 }
 

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -130,8 +130,14 @@ TDNFCliAutoEraseCommand(
     )
 {
     uint32_t dwError = 0;
+    int nAlterType = ALTER_AUTOERASE;
 
-    dwError = TDNFCliAlterCommand(pContext, pCmdArgs, ALTER_AUTOERASE);
+    if(pCmdArgs->nCmdCount == 1)
+    {
+        nAlterType = ALTER_AUTOERASEALL;
+    }
+
+    dwError = TDNFCliAlterCommand(pContext, pCmdArgs, nAlterType);
     BAIL_ON_CLI_ERROR(dwError);
 
 cleanup:

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -273,11 +273,11 @@ error:
     goto cleanup;
 }
 
+static
 uint32_t
 TDNFCliAskAndAlter(
     PTDNF_CLI_CONTEXT pContext,
     PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
 )
 {
@@ -295,7 +295,6 @@ TDNFCliAskAndAlter(
 
     dwError = pContext->pFnAlter(
                 pContext,
-                nAlterType,
                 pSolvedPkgInfo);
     BAIL_ON_CLI_ERROR(dwError);
 
@@ -347,7 +346,7 @@ TDNFCliAlterCommand(
                   &pSolvedPkgInfo);
     BAIL_ON_CLI_ERROR(dwError);
 
-    dwError = TDNFCliAskAndAlter(pContext, pCmdArgs, nAlterType, pSolvedPkgInfo);
+    dwError = TDNFCliAskAndAlter(pContext, pCmdArgs, pSolvedPkgInfo);
     BAIL_ON_CLI_ERROR(dwError);
 
 cleanup:

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -79,7 +79,11 @@ static struct option pstOptions[] =
     {"urls",          no_argument, 0, 0},
     // repoquery option
     // repoquery select options
+    {"available",     no_argument, 0, 0},
+    {"extras",        no_argument, 0, 0},
     {"file",          required_argument, 0, 0},
+    {"userinstalled", no_argument, 0, 0},
+    {"upgrades",      no_argument, 0, 0},
     {"whatdepends",   required_argument, 0, 0},
     {"whatprovides",  required_argument, 0, 0},
     {"whatobsoletes", required_argument, 0, 0},
@@ -90,13 +94,11 @@ static struct option pstOptions[] =
     {"whatsupplements", required_argument, 0, 0},
     {"whatenhances",  required_argument, 0, 0},
     // repoquery query options
-    {"available",     no_argument, 0, 0},
     {"changelogs",    no_argument, 0, 0},
     {"conflicts",     no_argument, 0, 0},
     {"depends",       no_argument, 0, 0},
     {"duplicates",    no_argument, 0, 0},
     {"enhances",      no_argument, 0, 0},
-    {"extras",        no_argument, 0, 0},
     {"installed",     no_argument, 0, 0},
     {"list",          no_argument, 0, 0},
     {"obsoletes",     no_argument, 0, 0},
@@ -106,7 +108,6 @@ static struct option pstOptions[] =
     {"requires-pre",  no_argument, 0, 0},
     {"suggests",      no_argument, 0, 0},
     {"supplements",   no_argument, 0, 0},
-    {"upgrades",      no_argument, 0, 0},
     // update-info mode options (also 'list' from above)
     {"info",          no_argument, 0, 0},
     {"summary",       no_argument, 0, 0},
@@ -254,7 +255,7 @@ TDNFCliParseArgs(
     {
         pCmdArgs->nCmdCount = argc - optind;
         dwError = TDNFAllocateMemory(
-                      pCmdArgs->nCmdCount,
+                      pCmdArgs->nCmdCount + 1,
                       sizeof(char*),
                       (void**)&pCmdArgs->ppszCmds);
         BAIL_ON_CLI_ERROR(dwError);

--- a/tools/cli/lib/parsehistoryargs.c
+++ b/tools/cli/lib/parsehistoryargs.c
@@ -100,12 +100,12 @@ TDNFCliParseHistoryArgs(
             pHistoryArgs->nTo = atoi(pSetOpt->pszOptValue);
         }
     }
-    
+
     if (pHistoryArgs->nTo == 0)
     {
         pHistoryArgs->nTo = pHistoryArgs->nFrom;
     }
-    
+
     *ppHistoryArgs = pHistoryArgs;
 cleanup:
     return dwError;

--- a/tools/cli/lib/parserepoqueryargs.c
+++ b/tools/cli/lib/parserepoqueryargs.c
@@ -112,6 +112,10 @@ TDNFCliParseRepoQueryArgs(
         {
             pRepoqueryArgs->nUpgrades = 1;
         }
+        else if (strcasecmp(pSetOpt->pszOptName, "userinstalled") == 0)
+        {
+            pRepoqueryArgs->nUserInstalled = 1;
+        }
         else
         {
             REPOQUERY_DEP_KEY depKey;

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -39,6 +39,7 @@ static TDNF_CLI_CMD_MAP arCmdMap[] =
     {"install",            TDNFCliInstallCommand, true},
     {"list",               TDNFCliListCommand, false},
     {"makecache",          TDNFCliMakeCacheCommand, true},
+    {"mark",               TDNFCliMarkCommand, false},
     {"provides",           TDNFCliProvidesCommand, false},
     {"whatprovides",       TDNFCliProvidesCommand, false},
     {"reinstall",          TDNFCliReinstallCommand, true},
@@ -102,6 +103,8 @@ int main(int argc, char **argv)
         _context.pFnUpdateInfoSummary = TDNFCliInvokeUpdateInfoSummary;
         _context.pFnHistoryList = TDNFCliInvokeHistoryList;
         _context.pFnHistoryResolve = TDNFCliInvokeHistoryResolve;
+        _context.pFnAlterHistory = TDNFCliInvokeAlterHistory;
+        _context.pFnMark = TDNFCliInvokeMark;
 
         pszCmd = pCmdArgs->ppszCmds[0];
 
@@ -226,7 +229,7 @@ TDNFCliPrintError(
             CHECK_JD_RC(jd_map_start(jd));
             CHECK_JD_RC(jd_map_add_int(jd, "Error", dwErrorCode));
             CHECK_JD_RC(jd_map_add_string(jd, "ErrorMessage", pszError));
-            
+
             pr_json(jd->buf);
         }
     }
@@ -363,6 +366,16 @@ TDNFCliInvokeAlter(
     )
 {
     return TDNFAlterCommand(pContext->hTdnf, nAlterType, pSolvedPkgInfo);
+}
+
+uint32_t
+TDNFCliInvokeAlterHistory(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    PTDNF_HISTORY_ARGS pHistoryArgs
+    )
+{
+    return TDNFAlterHistoryCommand(pContext->hTdnf, pSolvedPkgInfo, pHistoryArgs);
 }
 
 uint32_t
@@ -509,4 +522,14 @@ TDNFCliInvokeHistoryResolve(
         pContext->hTdnf,
         pHistoryArgs,
         ppSolvedPkgInfo);
+}
+
+uint32_t
+TDNFCliInvokeMark(
+    PTDNF_CLI_CONTEXT pContext,
+    char **ppszPkgNameSpecs,
+    uint32_t nValue
+    )
+{
+    return TDNFMark(pContext->hTdnf, ppszPkgNameSpecs, nValue);
 }

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -361,11 +361,10 @@ TDNFCliInvokeCount(
 uint32_t
 TDNFCliInvokeAlter(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
     )
 {
-    return TDNFAlterCommand(pContext->hTdnf, nAlterType, pSolvedPkgInfo);
+    return TDNFAlterCommand(pContext->hTdnf, pSolvedPkgInfo);
 }
 
 uint32_t

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -25,7 +25,6 @@
 uint32_t
 TDNFCliInvokeAlter(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_ALTERTYPE nAlterType,
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo
     );
 

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -134,6 +134,13 @@ TDNFCliInvokeHistoryResolve(
 );
 
 uint32_t
+TDNFCliInvokeAlterHistory(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    PTDNF_HISTORY_ARGS pHistoryArgs
+    );
+
+uint32_t
 TDNFCliUpdateInfoInfo(
     PTDNF_UPDATEINFO pInfo
     );
@@ -391,4 +398,11 @@ TDNFCliUpdateInfoSummary(
 void
 TDNFFreeListArgs(
     PTDNF_LIST_ARGS pListArgs
+    );
+
+uint32_t
+TDNFCliInvokeMark(
+    PTDNF_CLI_CONTEXT pContext,
+    char **ppszPkgNameSpecs,
+    uint32_t nValue
     );


### PR DESCRIPTION
PR https://github.com/vmware/tdnf/pull/314 will break the status of the autoremove flags for package. For example, a rollback will not restore the flags. This change moves tracking of the flag from the flat file `/var/lib/tdnf/autoinstalled `to the db, and tracks it for transactions.

This  also adds the `mark` command to mark a packages as "autoinstalled".

And it adds the `--userinstalled` option to the `repoquery` command to list all user installed packages.

And it implements the `autoremove` command without args to uninstall all autoinstalled packages. Closes #319 .

The command `tdnf mark remove foo` will mark a package as automatically installed, and `tdnf mark install foo` will reset that flag. The flag setting will be part of transactions, so can be rolled back or undone/redone with the `history` commands.

The syntax is the same as for the dnf command, see https://dnf.readthedocs.io/en/latest/command_ref.html#mark-command-label , only we do not have the `group` label.