### PR TITLE
add clean options and refactor

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -410,7 +410,7 @@ TDNFCheckUpdates(
 uint32_t
 TDNFClean(
     PTDNF pTdnf,
-    TDNF_CLEANTYPE nCleanType
+    uint32_t nCleanType
     )
 {
     uint32_t dwError = 0;
@@ -435,31 +435,31 @@ TDNFClean(
             continue;
         }
         pr_info("cleaning %s:", pRepo->pszId);
-        if (nCleanType == CLEANTYPE_METADATA || nCleanType == CLEANTYPE_ALL)
+        if (nCleanType & CLEANTYPE_METADATA)
         {
             pr_info(" metadata");
             dwError = TDNFRepoRemoveCache(pTdnf, pRepo->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
         }
-        if (nCleanType == CLEANTYPE_DBCACHE || nCleanType == CLEANTYPE_ALL)
+        if (nCleanType & CLEANTYPE_DBCACHE)
         {
             pr_info(" dbcache");
             dwError = TDNFRemoveSolvCache(pTdnf, pRepo->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
         }
-        if (nCleanType == CLEANTYPE_PACKAGES || nCleanType == CLEANTYPE_ALL)
+        if (nCleanType & CLEANTYPE_PACKAGES)
         {
             pr_info(" packages");
             dwError = TDNFRemoveRpmCache(pTdnf, pRepo->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
         }
-        if (nCleanType == CLEANTYPE_KEYS || nCleanType == CLEANTYPE_ALL)
+        if (nCleanType & CLEANTYPE_KEYS)
         {
             pr_info(" keys");
             dwError = TDNFRemoveKeysCache(pTdnf, pRepo->pszId);
             BAIL_ON_TDNF_ERROR(dwError);
         }
-        if (nCleanType == CLEANTYPE_EXPIRE_CACHE || nCleanType == CLEANTYPE_ALL)
+        if (nCleanType & CLEANTYPE_EXPIRE_CACHE)
         {
             pr_info(" expire-cache");
             dwError = TDNFRemoveLastRefreshMarker(pTdnf, pRepo->pszId);

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -351,7 +351,7 @@ TDNFRemoveLastRefreshMarker(
     BAIL_ON_TDNF_ERROR(dwError);
     if (pszLastRefreshMarker)
     {
-        if(unlink(pszLastRefreshMarker))
+        if(unlink(pszLastRefreshMarker) && errno != ENOENT)
         {
            dwError = errno;
            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);

--- a/common/utils.c
+++ b/common/utils.c
@@ -408,18 +408,6 @@ TDNFFreeRepos(
     }
 }
 
-void
-TDNFFreeCleanInfo(
-    PTDNF_CLEAN_INFO pCleanInfo
-    )
-{
-    if(pCleanInfo)
-    {
-        TDNF_SAFE_FREE_STRINGARRAY(pCleanInfo->ppszReposUsed);
-        TDNFFreeMemory(pCleanInfo);
-    }
-}
-
 uint32_t
 TDNFYesOrNo(
     PTDNF_CMD_ARGS pArgs,

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -51,8 +51,7 @@ TDNFCheckUpdates(
 uint32_t
 TDNFClean(
     PTDNF pTdnf,
-    TDNF_CLEANTYPE nCleanType,
-    PTDNF_CLEAN_INFO* ppCleanInfo
+    TDNF_CLEANTYPE nCleanType
     );
 
 //show list of packages filtered by scope, name
@@ -204,11 +203,6 @@ TDNFGetErrorString(
 void
 TDNFCloseHandle(
     PTDNF pTdnf
-    );
-
-void
-TDNFFreeCleanInfo(
-    PTDNF_CLEAN_INFO pCleanInfo
     );
 
 void

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -51,7 +51,7 @@ TDNFCheckUpdates(
 uint32_t
 TDNFClean(
     PTDNF pTdnf,
-    TDNF_CLEANTYPE nCleanType
+    uint32_t nCleanType
     );
 
 //show list of packages filtered by scope, name

--- a/include/tdnfcli.h
+++ b/include/tdnfcli.h
@@ -51,13 +51,13 @@ TDNFCliFreeListArgs(
 uint32_t
 TDNFCliParseCleanType(
     const char* pszCleanType,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     );
 
 uint32_t
 TDNFCliParseCleanArgs(
     PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     );
 
 uint32_t

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -69,7 +69,7 @@ typedef uint32_t
 typedef uint32_t
 (*PFN_TDNF_CLEAN)(
     PTDNF_CLI_CONTEXT,
-    TDNF_CLEANTYPE
+    uint32_t
     );
 
 typedef uint32_t

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -69,8 +69,7 @@ typedef uint32_t
 typedef uint32_t
 (*PFN_TDNF_CLEAN)(
     PTDNF_CLI_CONTEXT,
-    TDNF_CLEANTYPE,
-    PTDNF_CLEAN_INFO *
+    TDNF_CLEANTYPE
     );
 
 typedef uint32_t

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -108,18 +108,15 @@ typedef enum
     UPDATE_ENHANCEMENT
 }TDNF_UPDATEINFO_TYPE;
 
-//Clean command type
-typedef enum
-{
-    CLEANTYPE_NONE = -1,
-    CLEANTYPE_PACKAGES,
-    CLEANTYPE_METADATA,
-    CLEANTYPE_DBCACHE,
-    CLEANTYPE_PLUGINS,
-    CLEANTYPE_EXPIRE_CACHE,
-    CLEANTYPE_KEYS,
-    CLEANTYPE_ALL
-}TDNF_CLEANTYPE;
+#define CLEANTYPE_NONE         0x00
+#define CLEANTYPE_PACKAGES     0x01
+#define CLEANTYPE_METADATA     0x02
+#define CLEANTYPE_DBCACHE      0x04
+#define CLEANTYPE_PLUGINS      0x08
+#define CLEANTYPE_EXPIRE_CACHE 0x10
+#define CLEANTYPE_KEYS         0x20
+#define CLEANTYPE_ALL          0xff
+
 
 //RepoList command filter
 typedef enum

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -117,7 +117,7 @@ typedef enum
     CLEANTYPE_DBCACHE,
     CLEANTYPE_PLUGINS,
     CLEANTYPE_EXPIRE_CACHE,
-    CLEANTYPE_RPMDB,
+    CLEANTYPE_KEYS,
     CLEANTYPE_ALL
 }TDNF_CLEANTYPE;
 
@@ -281,16 +281,6 @@ typedef struct _TDNF_REPO_DATA
 
     struct _TDNF_REPO_DATA* pNext;
 }TDNF_REPO_DATA, *PTDNF_REPO_DATA;
-
-typedef struct _TDNF_CLEAN_INFO
-{
-    int nCleanAll;
-    char** ppszReposUsed;
-    int nRpmDbFilesRemoved;
-    int nMetadataFilesRemoved;
-    int nDbCacheFilesRemoved;
-    int nPackageFilesRemoved;
-}TDNF_CLEAN_INFO, *PTDNF_CLEAN_INFO;
 
 typedef struct _TDNF_ERROR_DESC
 {

--- a/pytests/tests/test_clean.py
+++ b/pytests/tests/test_clean.py
@@ -31,22 +31,22 @@ def test_clean_invalid_arg(utils):
 
 def test_clean_packages(utils):
     ret = utils.run(['tdnf', 'clean', 'packages'])
-    assert(ret['retval'] == 1016)
+    assert(ret['retval'] == 0)
 
 
 def test_clean_dbcache(utils):
     ret = utils.run(['tdnf', 'clean', 'dbcache'])
-    assert(ret['retval'] == 1016)
+    assert(ret['retval'] == 0)
 
 
 def test_clean_metadata(utils):
     ret = utils.run(['tdnf', 'clean', 'metadata'])
-    assert(ret['retval'] == 1016)
+    assert(ret['retval'] == 0)
 
 
 def test_clean_expire_cache(utils):
     ret = utils.run(['tdnf', 'clean', 'expire-cache'])
-    assert(ret['retval'] == 1016)
+    assert(ret['retval'] == 0)
 
 
 def test_clean_plugins(utils):

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -56,8 +56,6 @@ TDNFCliCleanCommand(
 {
     uint32_t dwError = 0;
     TDNF_CLEANTYPE nCleanType = CLEANTYPE_NONE;
-    PTDNF_CLEAN_INFO pTDNFCleanInfo = NULL;
-    char** ppszReposUsed = NULL;
 
     if(!pContext || !pContext->hTdnf || !pContext->pFnClean)
     {
@@ -68,30 +66,12 @@ TDNFCliCleanCommand(
     dwError = TDNFCliParseCleanArgs(pCmdArgs, &nCleanType);
     BAIL_ON_CLI_ERROR(dwError);
 
-    dwError = pContext->pFnClean(pContext, nCleanType, &pTDNFCleanInfo);
+    dwError = pContext->pFnClean(pContext, nCleanType);
     BAIL_ON_CLI_ERROR(dwError);
 
-    //Print clean info
-    pr_info("Cleaning repos:");
-    ppszReposUsed = pTDNFCleanInfo->ppszReposUsed;
-    while(*ppszReposUsed)
-    {
-        pr_info(" %s", *ppszReposUsed);
-        ++ppszReposUsed;
-    }
-
-    pr_info("\n");
-
-    if(pTDNFCleanInfo->nCleanAll)
-    {
-        pr_info("Cleaning up everything\n");
-    }
+    pr_info("Done.\n");
 
 cleanup:
-    if(pTDNFCleanInfo)
-    {
-        TDNFFreeCleanInfo(pTDNFCleanInfo);
-    }
     return dwError;
 
 error:

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -55,7 +55,7 @@ TDNFCliCleanCommand(
     )
 {
     uint32_t dwError = 0;
-    TDNF_CLEANTYPE nCleanType = CLEANTYPE_NONE;
+    uint32_t nCleanType = CLEANTYPE_NONE;
 
     if(!pContext || !pContext->hTdnf || !pContext->pFnClean)
     {

--- a/tools/cli/lib/parsecleanargs.c
+++ b/tools/cli/lib/parsecleanargs.c
@@ -24,11 +24,11 @@
 uint32_t
 TDNFCliParseCleanArgs(
     PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     )
 {
     uint32_t dwError = 0;
-    TDNF_CLEANTYPE nCleanType = CLEANTYPE_NONE;
+    uint32_t nCleanType = CLEANTYPE_NONE;
 
     if(!pCmdArgs)
     {
@@ -64,12 +64,12 @@ error:
 uint32_t
 TDNFCliParseCleanType(
     const char* pszCleanType,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     )
 {
     uint32_t dwError = 0;
     int nIndex = 0;
-    TDNF_CLEANTYPE nCleanType = CLEANTYPE_ALL;
+    uint32_t nCleanType = CLEANTYPE_ALL;
     struct stTemp
     {
         char* pszTypeName;

--- a/tools/cli/lib/parsecleanargs.c
+++ b/tools/cli/lib/parsecleanargs.c
@@ -81,6 +81,7 @@ TDNFCliParseCleanType(
         {"metadata",      CLEANTYPE_METADATA},
         {"dbcache",       CLEANTYPE_DBCACHE},
         {"plugins",       CLEANTYPE_PLUGINS},
+        {"keys",          CLEANTYPE_KEYS},
         {"expire-cache",  CLEANTYPE_EXPIRE_CACHE},
         {"all",           CLEANTYPE_ALL},
     };

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -337,7 +337,7 @@ TDNFCliInvokeCheckUpdate(
 uint32_t
 TDNFCliInvokeClean(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_CLEANTYPE nCleanType
+    uint32_t nCleanType
     )
 {
     return TDNFClean(pContext->hTdnf, nCleanType);

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -337,11 +337,10 @@ TDNFCliInvokeCheckUpdate(
 uint32_t
 TDNFCliInvokeClean(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_CLEANTYPE nCleanType,
-    PTDNF_CLEAN_INFO *ppTDNFCleanInfo
+    TDNF_CLEANTYPE nCleanType
     )
 {
-    return TDNFClean(pContext->hTdnf, nCleanType, ppTDNFCleanInfo);
+    return TDNFClean(pContext->hTdnf, nCleanType);
 }
 
 uint32_t

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -51,8 +51,7 @@ TDNFCliInvokeCheckUpdate(
 uint32_t
 TDNFCliInvokeClean(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_CLEANTYPE nCleanType,
-    PTDNF_CLEAN_INFO *ppTDNFCleanInfo
+    TDNF_CLEANTYPE nCleanType
     );
 
 uint32_t

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -51,7 +51,7 @@ TDNFCliInvokeCheckUpdate(
 uint32_t
 TDNFCliInvokeClean(
     PTDNF_CLI_CONTEXT pContext,
-    TDNF_CLEANTYPE nCleanType
+    uint32_t nCleanType
     );
 
 uint32_t
@@ -284,13 +284,13 @@ TDNFCliParseArgs(
 uint32_t
 ParseCleanType(
     const char* pszCleanType,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     );
 
 uint32_t
 TDNFCliParseCleanArgs(
     PTDNF_CMD_ARGS pCmdArgs,
-    TDNF_CLEANTYPE* pnCleanType
+    uint32_t* pnCleanType
     );
 
 //parselistargs.c


### PR DESCRIPTION
Addresses issue #209 . This adds the options `metadata, dbcache, packages, keys and expire-cache` to the `clean` command. Example output:
```
# ./bin/tdnf clean all
cleaning photon: metadata dbcache packages keys expire-cache
cleaning photon-debuginfo: metadata dbcache packages keys expire-cache
cleaning photon-iso: metadata dbcache packages keys expire-cache
cleaning photon-updates: metadata dbcache packages keys expire-cache
cleaning photon-extras: metadata dbcache packages keys expire-cache
cleaning photon-release: metadata dbcache packages keys expire-cache
Done.
```
This will clean all repos, including the disabled repositories. This is the same behavior as the `dnf clean` command. The `keys` option however is unique to `tdnf`.