### PR TITLE
use a unique path for cache data

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -438,31 +438,31 @@ TDNFClean(
         if (nCleanType & CLEANTYPE_METADATA)
         {
             pr_info(" metadata");
-            dwError = TDNFRepoRemoveCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRepoRemoveCache(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         if (nCleanType & CLEANTYPE_DBCACHE)
         {
             pr_info(" dbcache");
-            dwError = TDNFRemoveSolvCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRemoveSolvCache(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         if (nCleanType & CLEANTYPE_PACKAGES)
         {
             pr_info(" packages");
-            dwError = TDNFRemoveRpmCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRemoveRpmCache(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         if (nCleanType & CLEANTYPE_KEYS)
         {
             pr_info(" keys");
-            dwError = TDNFRemoveKeysCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRemoveKeysCache(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         if (nCleanType & CLEANTYPE_EXPIRE_CACHE)
         {
             pr_info(" expire-cache");
-            dwError = TDNFRemoveLastRefreshMarker(pTdnf, pRepo->pszId);
+            dwError = TDNFRemoveLastRefreshMarker(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         pr_info("\n");

--- a/client/api.c
+++ b/client/api.c
@@ -468,6 +468,20 @@ TDNFClean(
 
         /* remove the top level repo cache dir if it's not empty */
         dwError = TDNFRepoRemoveCacheDir(pTdnf, pRepo);
+        if (dwError == ERROR_TDNF_SYSTEM_BASE + ENOTEMPTY)
+        {
+            /* if we did a 'clean all' the directory should be empty now. If
+               not we either missed something or someone other than us
+               put a file there, so warn about it, but don't bail out.
+               If we did clean just one part it's not expected to be empty
+               unless the other parts were already cleaned.
+            */
+            if (nCleanType == CLEANTYPE_ALL)
+            {
+                pr_err("Cache directory for %s not removed because it's not empty.\n", pRepo->pszId);
+            }
+            dwError = 0;
+        }
         BAIL_ON_TDNF_ERROR(dwError);
         
         pr_info("\n");

--- a/client/api.c
+++ b/client/api.c
@@ -465,6 +465,11 @@ TDNFClean(
             dwError = TDNFRemoveLastRefreshMarker(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }
+
+        /* remove the top level repo cache dir if it's not empty */
+        dwError = TDNFRepoRemoveCacheDir(pTdnf, pRepo);
+        BAIL_ON_TDNF_ERROR(dwError);
+        
         pr_info("\n");
     }
 cleanup:

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -564,6 +564,7 @@ TDNFFetchRemoteGPGKey(
     char* pszRealTopKeyCacheDir = NULL;
     char* pszDownloadCacheDir = NULL;
     char* pszKeyLocation = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
 
     if(!pTdnf || IsNullOrEmptyString(pszRepoName || IsNullOrEmptyString(pszUrlGPGKey)))
     {
@@ -578,12 +579,12 @@ TDNFFetchRemoteGPGKey(
     }
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFJoinPath(
-                  &pszTopKeyCacheDir,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoName,
-                  "keys",
-                  NULL);
+    dwError = TDNFFindRepoById(pTdnf, pszRepoName, &pRepo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               "keys", NULL,
+                               &pszTopKeyCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFNormalizePath(pszTopKeyCacheDir,

--- a/client/init.c
+++ b/client/init.c
@@ -281,11 +281,9 @@ TDNFRefreshSack(
            unless requested to ignore. lMetadataExpire < 0 means never expire. */
         if(pRepo->lMetadataExpire >= 0 && !pTdnf->pArgs->nCacheOnly)
         {
-            dwError = TDNFJoinPath(
-                          &pszRepoCacheDir,
-                          pTdnf->pConf->pszCacheDir,
-                          pRepo->pszId,
-                          NULL);
+            dwError = TDNFGetCachePath(pTdnf, pRepo,
+                                       NULL, NULL,
+                                       &pszRepoCacheDir);
             BAIL_ON_TDNF_ERROR(dwError);
 
             dwError = TDNFShouldSyncMetadata(

--- a/client/init.c
+++ b/client/init.c
@@ -313,14 +313,14 @@ TDNFRefreshSack(
                 goto cleanup;
             }
 
-            dwError = TDNFRepoRemoveCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRepoRemoveCache(pTdnf, pRepo);
             if (dwError == ERROR_TDNF_FILE_NOT_FOUND)
             {
                 dwError = 0;//Ignore non existent folders
             }
             BAIL_ON_TDNF_ERROR(dwError);
 
-            dwError = TDNFRemoveSolvCache(pTdnf, pRepo->pszId);
+            dwError = TDNFRemoveSolvCache(pTdnf, pRepo);
             if (dwError == ERROR_TDNF_FILE_NOT_FOUND)
             {
                 dwError = 0;//Ignore non existent folders

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -167,6 +167,12 @@ TDNFRepoGetRpmCacheDir(
     );
 
 uint32_t
+TDNFRepoRemoveCacheDir(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    );
+
+uint32_t
 TDNFRepoRemoveCache(
     PTDNF pTdnf,
     PTDNF_REPO_DATA pRepo

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -162,26 +162,26 @@ TDNFRepoGetUserPass(
 uint32_t
 TDNFRepoGetRpmCacheDir(
     PTDNF pTdnf,
-    const char* pszRepo,
+    PTDNF_REPO_DATA pRepo,
     char** ppszRpmCacheDir
     );
 
 uint32_t
 TDNFRepoRemoveCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
 TDNFRemoveRpmCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
 TDNFRemoveLastRefreshMarker(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
@@ -192,13 +192,13 @@ TDNFRemoveTmpRepodata(
 uint32_t
 TDNFRemoveSolvCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
 TDNFRemoveKeysCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     );
 
 uint32_t
@@ -676,6 +676,15 @@ TDNFGetSkipDigestOption(
     PTDNF pTdnf,
     uint32_t *pdwSkipDigest
     );
+
+uint32_t
+TDNFGetCachePath(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo,
+    const char *pszSubDir,
+    const char *pszFileName,
+    char **ppszPath
+);
 
 uint32_t
 TDNFGetRepoById(

--- a/client/repo.c
+++ b/client/repo.c
@@ -32,22 +32,22 @@ TDNFInitRepo(
     char* pszRepoDataDir = NULL;
     char* pszRepoCacheDir = NULL;
     PTDNF_REPO_METADATA pRepoMD = NULL;
-    PTDNF_CONF pConf = NULL;
     Repo* pRepo = NULL;
     Pool* pPool = NULL;
     int nUseMetaDataCache = 0;
     PSOLV_REPO_INFO_INTERNAL pSolvRepoInfo = NULL;
 
-    if (!pTdnf || !pTdnf->pConf || !pRepoData || !pSack || !pSack->pPool)
+    if (!pTdnf || !pRepoData || !pSack || !pSack->pPool)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    pConf = pTdnf->pConf;
     pPool = pSack->pPool;
 
-    dwError = TDNFGetCachePath(pTdnf, pRepoData, NULL, NULL, &pszRepoCacheDir);
+    dwError = TDNFGetCachePath(pTdnf, pRepoData,
+                               NULL, NULL,
+                               &pszRepoCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFJoinPath(
@@ -77,6 +77,7 @@ TDNFInitRepo(
         BAIL_ON_TDNF_ERROR(dwError);
     }
     pSolvRepoInfo->pRepo = pRepo;
+    pSolvRepoInfo->pszRepoCacheDir = pszRepoCacheDir;
     pRepo->appdata = pSolvRepoInfo;
 
     dwError = SolvCalculateCookieForFile(pRepoMD->pszRepoMD, pSolvRepoInfo->cookie);

--- a/client/repo.c
+++ b/client/repo.c
@@ -47,11 +47,7 @@ TDNFInitRepo(
     pConf = pTdnf->pConf;
     pPool = pSack->pPool;
 
-    dwError = TDNFJoinPath(
-                  &pszRepoCacheDir,
-                  pConf->pszCacheDir,
-                  pRepoData->pszId,
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepoData, NULL, NULL, &pszRepoCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFJoinPath(

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -679,7 +679,6 @@ TDNFRepoListFinalize(
                                                   &pRepo->pszCacheName);
             }
             BAIL_ON_TDNF_ERROR(dwError);
-            printf("pszCacheName = %s\n", pRepo->pszCacheName);
         }
     }
 cleanup:
@@ -803,6 +802,7 @@ TDNFFreeReposInternal(
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszUser);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszPass);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszCacheName);
         pRepos = pRepo->pNext;
         TDNF_SAFE_FREE_MEMORY(pRepo);
     }

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -645,42 +645,38 @@ TDNFRepoListFinalize(
     }
 
     /* Now that the overrides are applied, replace config vars
-       for the repos that are enabled. */
+       for all repos. */
     for(pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
     {
-//        if(pRepo->nEnabled)
-        if (1)
+        if(pRepo->pszName)
         {
-            if(pRepo->pszName)
-            {
-                dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszName);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
-            if(pRepo->pszBaseUrl)
-            {
-                dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszBaseUrl);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
-            if(pRepo->pszMetaLink)
-            {
-                dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMetaLink);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
-
-            if (pRepo->pszMetaLink)
-            {
-                dwError = SolvCreateRepoCacheName(pRepo->pszId,
-                                                  pRepo->pszMetaLink,
-                                                  &pRepo->pszCacheName);
-            }
-            else if (pRepo->pszBaseUrl)
-            {
-                dwError = SolvCreateRepoCacheName(pRepo->pszId,
-                                                  pRepo->pszBaseUrl,
-                                                  &pRepo->pszCacheName);
-            }
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszName);
             BAIL_ON_TDNF_ERROR(dwError);
         }
+        if(pRepo->pszBaseUrl)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszBaseUrl);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+        if(pRepo->pszMetaLink)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMetaLink);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+
+        if (pRepo->pszMetaLink)
+        {
+            dwError = SolvCreateRepoCacheName(pRepo->pszId,
+                                              pRepo->pszMetaLink,
+                                              &pRepo->pszCacheName);
+        }
+        else if (pRepo->pszBaseUrl)
+        {
+            dwError = SolvCreateRepoCacheName(pRepo->pszId,
+                                              pRepo->pszBaseUrl,
+                                              &pRepo->pszCacheName);
+        }
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 cleanup:
     return dwError;

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -648,7 +648,8 @@ TDNFRepoListFinalize(
        for the repos that are enabled. */
     for(pRepo = pTdnf->pRepos; pRepo; pRepo = pRepo->pNext)
     {
-        if(pRepo->nEnabled)
+//        if(pRepo->nEnabled)
+        if (1)
         {
             if(pRepo->pszName)
             {

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -665,6 +665,21 @@ TDNFRepoListFinalize(
                 dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMetaLink);
                 BAIL_ON_TDNF_ERROR(dwError);
             }
+
+            if (pRepo->pszMetaLink)
+            {
+                dwError = SolvCreateRepoCacheName(pRepo->pszId,
+                                                  pRepo->pszMetaLink,
+                                                  &pRepo->pszCacheName);
+            }
+            else if (pRepo->pszBaseUrl)
+            {
+                dwError = SolvCreateRepoCacheName(pRepo->pszId,
+                                                  pRepo->pszBaseUrl,
+                                                  &pRepo->pszCacheName);
+            }
+            BAIL_ON_TDNF_ERROR(dwError);
+            printf("pszCacheName = %s\n", pRepo->pszCacheName);
         }
     }
 cleanup:

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -226,6 +226,44 @@ error:
     goto cleanup;
 }
 
+/* remove the repo top level cache dir */
+uint32_t
+TDNFRepoRemoveCacheDir(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    )
+{
+    uint32_t dwError = 0;
+    char* pszRepoCacheDir = NULL;
+
+    if(!pTdnf || !pRepo)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               NULL, NULL,
+                               &pszRepoCacheDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    if (rmdir(pszRepoCacheDir) != 0)
+    {
+        /* ignore ENOTEMPTY, let's keep the dir if it's not empty */
+        if (errno != ENOENT && errno != ENOTEMPTY)
+        {
+            BAIL_ON_TDNF_ERROR(errno);
+        }
+    }
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszRepoCacheDir);
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
 uint32_t
 TDNFRepoRemoveCache(
     PTDNF pTdnf,

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -247,13 +247,10 @@ TDNFRepoRemoveCacheDir(
                                &pszRepoCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if (rmdir(pszRepoCacheDir) != 0)
+    if (rmdir(pszRepoCacheDir) != 0 && errno != ENOENT)
     {
-        /* ignore ENOTEMPTY, let's keep the dir if it's not empty */
-        if (errno != ENOENT && errno != ENOTEMPTY)
-        {
-            BAIL_ON_TDNF_ERROR(errno);
-        }
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
 
 cleanup:

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -42,24 +42,24 @@ error:
 uint32_t
 TDNFRepoSetBaseUrl(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA pszRepo,
+    PTDNF_REPO_DATA pRepo,
     const char *pszBaseUrlFile
     )
 {
     uint32_t dwError = 0;
     char *pszBaseUrl = NULL;
 
-    if (!pTdnf || !pszRepo || IsNullOrEmptyString(pszBaseUrlFile))
+    if (!pTdnf || !pRepo || IsNullOrEmptyString(pszBaseUrlFile))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    TDNF_SAFE_FREE_MEMORY(pszRepo->pszBaseUrl);
+    TDNF_SAFE_FREE_MEMORY(pRepo->pszBaseUrl);
     dwError = TDNFFileReadAllText(pszBaseUrlFile, &pszBaseUrl, NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    pszRepo->pszBaseUrl = pszBaseUrl;
+    pRepo->pszBaseUrl = pszBaseUrl;
 
 cleanup:
     return dwError;
@@ -180,14 +180,14 @@ error:
 uint32_t
 TDNFRepoGetRpmCacheDir(
     PTDNF pTdnf,
-    const char* pszRepoId,
+    PTDNF_REPO_DATA pRepo,
     char** ppszRpmCacheDir
     )
 {
     uint32_t dwError = 0;
     char* pszRpmCacheDir = NULL;
 
-    if(!pTdnf || IsNullOrEmptyString(pszRepoId) || !ppszRpmCacheDir)
+    if(!pTdnf || !pRepo || !ppszRpmCacheDir)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -199,12 +199,9 @@ TDNFRepoGetRpmCacheDir(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFJoinPath(
-                  &pszRpmCacheDir,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoId,
-                  TDNF_RPM_CACHE_DIR_NAME,
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               TDNF_RPM_CACHE_DIR_NAME, NULL,
+                               &pszRpmCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     if(access(pszRpmCacheDir, F_OK))
@@ -232,24 +229,21 @@ error:
 uint32_t
 TDNFRepoRemoveCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     )
 {
     uint32_t dwError = 0;
     char* pszRepoCacheDir = NULL;
 
-    if(!pTdnf || !pTdnf->pConf || IsNullOrEmptyString(pszRepoId))
+    if(!pTdnf || !pRepo || !pTdnf->pConf)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFJoinPath(
-                  &pszRepoCacheDir,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoId,
-                  TDNF_REPODATA_DIR_NAME,
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               TDNF_REPODATA_DIR_NAME, NULL,
+                               &pszRepoCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFRecursivelyRemoveDir(pszRepoCacheDir);
@@ -270,19 +264,19 @@ error:
 uint32_t
 TDNFRemoveRpmCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     )
 {
     uint32_t dwError = 0;
     char* pszRpmCacheDir = NULL;
 
-    if (!pTdnf || !pTdnf->pConf || IsNullOrEmptyString(pszRepoId))
+    if (!pTdnf || !pRepo || !pTdnf->pConf)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFRepoGetRpmCacheDir(pTdnf, pszRepoId, &pszRpmCacheDir);
+    dwError = TDNFRepoGetRpmCacheDir(pTdnf, pRepo, &pszRpmCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     if (!IsNullOrEmptyString(pszRpmCacheDir))
@@ -330,24 +324,21 @@ error:
 uint32_t
 TDNFRemoveLastRefreshMarker(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     )
 {
     uint32_t dwError = 0;
     char* pszLastRefreshMarker = NULL;
 
-    if(!pTdnf || !pTdnf->pConf || IsNullOrEmptyString(pszRepoId))
+    if(!pTdnf || !pRepo || !pTdnf->pConf)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFJoinPath(
-                  &pszLastRefreshMarker,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoId,
-                  TDNF_REPO_METADATA_MARKER,
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               TDNF_REPO_METADATA_MARKER, NULL,
+                               &pszLastRefreshMarker);
     BAIL_ON_TDNF_ERROR(dwError);
     if (pszLastRefreshMarker)
     {
@@ -367,24 +358,21 @@ error:
 uint32_t
 TDNFRemoveSolvCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     )
 {
     uint32_t dwError = 0;
     char* pszSolvCacheDir = NULL;
 
-    if(!pTdnf || !pTdnf->pConf || IsNullOrEmptyString(pszRepoId))
+    if(!pTdnf || !pRepo || !pTdnf->pConf)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFJoinPath(
-                  &pszSolvCacheDir,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoId,
-                  TDNF_SOLVCACHE_DIR_NAME,
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               TDNF_SOLVCACHE_DIR_NAME, NULL,
+                               &pszSolvCacheDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFRecursivelyRemoveDir(pszSolvCacheDir);
@@ -404,24 +392,21 @@ error:
 uint32_t
 TDNFRemoveKeysCache(
     PTDNF pTdnf,
-    const char* pszRepoId
+    PTDNF_REPO_DATA pRepo
     )
 {
     uint32_t dwError = 0;
     char* pszKeysDir = NULL;
 
-    if(!pTdnf || !pTdnf->pConf || IsNullOrEmptyString(pszRepoId))
+    if(!pTdnf || !pRepo || !pTdnf->pConf)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFJoinPath(
-                  &pszKeysDir,
-                  pTdnf->pConf->pszCacheDir,
-                  pszRepoId,
-                  "keys",
-                  NULL);
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               "keys", NULL,
+                               &pszKeysDir);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFRecursivelyRemoveDir(pszKeysDir);
@@ -606,6 +591,38 @@ TDNFRepoApplySSLSettings(
             BAIL_ON_TDNF_ERROR(dwError);
         }
     }
+
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}
+
+uint32_t
+TDNFGetCachePath(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo,
+    const char *pszSubDir,
+    const char *pszFileName,
+    char **ppszPath
+)
+{
+    uint32_t dwError = 0;
+
+    if(!pTdnf || !pRepo || !ppszPath)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFJoinPath(
+                  ppszPath,
+                  pTdnf->pConf->pszCacheDir,
+                  pRepo->pszId,
+                  pszSubDir,
+                  pszFileName,
+                  NULL);
+    BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
 
 cleanup:
     return dwError;

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -615,10 +615,17 @@ TDNFGetCachePath(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if (!pRepo->pszCacheName)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+        pr_err("pRepo->pszCacheName not set\n");
+    }
+
     dwError = TDNFJoinPath(
                   ppszPath,
                   pTdnf->pConf->pszCacheDir,
-                  pRepo->pszId,
+                  pRepo->pszCacheName ? pRepo->pszCacheName : pRepo->pszId,
                   pszSubDir,
                   pszFileName,
                   NULL);

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -615,13 +615,6 @@ TDNFGetCachePath(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if (!pRepo->pszCacheName)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-        pr_err("pRepo->pszCacheName not set\n");
-    }
-
     dwError = TDNFJoinPath(
                   ppszPath,
                   pTdnf->pConf->pszCacheDir,

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -275,6 +275,7 @@ typedef struct _TDNF_REPO_DATA
     int nSkipMDFileLists;
     int nSkipMDUpdateInfo;
     int nSkipMDOther;
+    char *pszCacheName;
 
     struct _TDNF_REPO_DATA* pNext;
 }TDNF_REPO_DATA, *PTDNF_REPO_DATA;

--- a/pytests/tests/test_cache.py
+++ b/pytests/tests/test_cache.py
@@ -7,6 +7,7 @@
 #
 
 import os
+import fnmatch
 import pytest
 
 
@@ -42,6 +43,14 @@ def check_package_in_cache(utils, pkgname):
     if ret['stdout']:
         return True
     return False
+
+
+def find_cache_dir(utils, reponame):
+    cache_dir = utils.tdnf_config.get('main', 'cachedir')
+    for f in os.listdir(cache_dir):
+        if fnmatch.fnmatch(f, '{}-*'.format(reponame)):
+            return os.path.join(cache_dir, f)
+    return None
 
 
 def test_install_without_cache(utils):
@@ -86,8 +95,9 @@ def test_install_with_keepcache_false(utils):
 
 
 def test_disable_repo_make_cache(utils):
-    cache_dir = utils.tdnf_config.get('main', 'cachedir')
-    lastrefresh = os.path.join(cache_dir, 'photon-test/lastrefresh')
+    cache_dir = find_cache_dir(utils, 'photon-test')
+    assert(cache_dir is not None)
+    lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '--disablerepo=*', 'makecache'])
     after = os.path.getmtime(lastrefresh)
@@ -95,8 +105,9 @@ def test_disable_repo_make_cache(utils):
 
 
 def test_enable_repo_make_cache(utils):
-    cache_dir = utils.tdnf_config.get('main', 'cachedir')
-    lastrefresh = os.path.join(cache_dir, 'photon-test/lastrefresh')
+    cache_dir = find_cache_dir(utils, 'photon-test')
+    assert(cache_dir is not None)
+    lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '--disablerepo=*', '--enablerepo=photon-test', 'makecache'])
     after = os.path.getmtime(lastrefresh)
@@ -105,8 +116,9 @@ def test_enable_repo_make_cache(utils):
 
 # -v (verbose) prints progress data
 def test_enable_repo_make_cache_verbose(utils):
-    cache_dir = utils.tdnf_config.get('main', 'cachedir')
-    lastrefresh = os.path.join(cache_dir, 'photon-test/lastrefresh')
+    cache_dir = find_cache_dir(utils, 'photon-test')
+    assert(cache_dir is not None)
+    lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '-v', '--disablerepo=*', '--enablerepo=photon-test', 'makecache'])
     after = os.path.getmtime(lastrefresh)

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -9,6 +9,7 @@
 import os
 import shutil
 import pytest
+import fnmatch
 
 INSTALLROOT = '/root/installroot'
 REPOFILENAME = 'photon-test.repo'
@@ -76,6 +77,14 @@ def erase_package(utils, pkgname, installroot=INSTALLROOT, pkgversion=None):
     assert(not check_package(utils, pkgname))
 
 
+def find_cache_dir(reponame):
+    cache_dir = os.path.join(INSTALLROOT, 'var/cache/tdnf')
+    for f in os.listdir(cache_dir):
+        if fnmatch.fnmatch(f, '{}-*'.format(reponame)):
+            return os.path.join(cache_dir, f)
+    return None
+
+
 def test_install(utils):
     install_root(utils)
     pkgname = utils.config["mulversion_pkgname"]
@@ -98,7 +107,7 @@ def test_makecache(utils):
                      '--installroot', INSTALLROOT,
                      '--releasever=4.0'], noconfig=True)
     assert(ret['retval'] == 0)
-    assert(os.path.isdir(os.path.join(INSTALLROOT, 'var/cache/tdnf', 'photon-test')))
+    assert(find_cache_dir('photon-test') is not None)
 
     shutil.rmtree(INSTALLROOT)
 

--- a/pytests/tests/test_skip_md.py
+++ b/pytests/tests/test_skip_md.py
@@ -10,7 +10,7 @@
 import os
 import pytest
 import glob
-
+import fnmatch
 
 REPOFILENAME = "photon-skip.repo"
 REPOID = "photon-skip"
@@ -61,6 +61,14 @@ def get_cache_dir(utils):
     return '/var/cache/tdnf/'
 
 
+def find_cache_dir(utils, reponame):
+    cache_dir = utils.tdnf_config.get('main', 'cachedir')
+    for f in os.listdir(cache_dir):
+        if fnmatch.fnmatch(f, '{}-*'.format(reponame)):
+            return os.path.join(cache_dir, f)
+    return None
+
+
 # enable/disable md part, expect/do not expect download of the associated file
 def check_skip_md_part(utils, mdpart, skipped):
     repoconf = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
@@ -68,7 +76,7 @@ def check_skip_md_part(utils, mdpart, skipped):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'clean', 'all'])
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
 
-    md_dir = os.path.join(get_cache_dir(utils), REPOID, 'repodata')
+    md_dir = os.path.join(find_cache_dir(utils, REPOID), 'repodata')
     assert((len(glob.glob('{}/*{}*'.format(md_dir, mdpart))) == 0) == skipped)
 
 

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -46,6 +46,7 @@ typedef struct _SOLV_REPO_INFO_INTERNAL_
     Repo*         pRepo;
     unsigned char cookie[SOLV_COOKIE_LEN];
     int           nCookieSet;
+    char          *pszRepoCacheDir;
 }SOLV_REPO_INFO_INTERNAL, *PSOLV_REPO_INFO_INTERNAL;
 
 extern Id allDepKeyIds[];

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -571,6 +571,13 @@ SolvCalculateCookieForFile(
     );
 
 uint32_t
+SolvCreateRepoCacheName(
+    const char *pszName,
+    const char *pszUrl,
+    char **ppszCacheName
+    );
+
+uint32_t
 SolvGetMetaDataCachePath(
     PSOLV_REPO_INFO_INTERNAL pSolvRepoInfo,
     PSolvSack pSack,

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -392,9 +392,8 @@ SolvCreateRepoCacheName(
     uint32_t dwError = 0;
     Chksum *pChkSum = NULL;
     unsigned char pCookie[SOLV_COOKIE_LEN] = {0};
-    char pszCookie[SOLV_COOKIE_LEN*2+1];
+    char pszCookie[9] = {0};
     char *pszCacheName;
-    int i;
 
     if (!pszName || !pszUrl || !ppszCacheName)
     {
@@ -411,10 +410,8 @@ SolvCreateRepoCacheName(
     solv_chksum_add(pChkSum, pszUrl, strlen(pszUrl));
     solv_chksum_free(pChkSum, pCookie);
 
-    for (i = 0; i < SOLV_COOKIE_LEN; i++)
-    {
-        snprintf(&pszCookie[2*i], 3, "%.2x", pCookie[i]);
-    }
+    snprintf(pszCookie, sizeof(pszCookie), "%.2x%.2x%.2x%.2x",
+             pCookie[0], pCookie[1], pCookie[2], pCookie[3]);
 
     dwError = TDNFAllocateStringPrintf(&pszCacheName, "%s-%s", pszName, pszCookie);
     BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -278,6 +278,7 @@ SolvReadInstalledRpms(
     Repo *pRepo = NULL;
     FILE *pCacheFile = NULL;
     int  dwFlags = 0;
+
     if(!pPool || !ppRepo)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
@@ -295,6 +296,7 @@ SolvReadInstalledRpms(
     {
         /* coverity[toctou] */
         pCacheFile = fopen(pszCacheFileName, "r");
+
         if(!pCacheFile)
         {
             dwError = errno;
@@ -378,7 +380,7 @@ error:
 }
 
 /* Create a name for the repo cache path based on repo name and
-   a a hash of the url.
+   a hash of the url.
 */
 uint32_t
 SolvCreateRepoCacheName(
@@ -447,9 +449,8 @@ SolvGetMetaDataCachePath(
     {
         dwError = TDNFAllocateStringPrintf(
                       &pszCachePath,
-                      "%s/%s/%s/%s.solv",
-                      pSack->pszCacheDir,
-                      pRepo->name,
+                      "%s/%s/%s.solv",
+                      pSolvRepoInfo->pszRepoCacheDir,
                       TDNF_SOLVCACHE_DIR_NAME,
                       pRepo->name);
         BAIL_ON_TDNF_ERROR(dwError);
@@ -615,12 +616,10 @@ SolvCreateMetaDataCache(
     pRepo = pSolvRepoInfo->pRepo;
     dwError = TDNFJoinPath(
                   &pszSolvCacheDir,
-                  pSack->pszCacheDir,
-                  pRepo->name,
+                  pSolvRepoInfo->pszRepoCacheDir,
                   TDNF_SOLVCACHE_DIR_NAME,
                   NULL);
     BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
-
     if (access(pszSolvCacheDir, W_OK | X_OK))
     {
         if(errno != ENOENT)


### PR DESCRIPTION
Fixes issue #253 . Wit this change, `tdnf` uses a unique name for the top level cache directory, derived from a `sha256` hash of the `baseurl` or `metalink` URL, after expansion of variables (like `$releasever`). This ensures different paths if `$releasever` is set using the `--releasever` option.

Example from the original issue report:

```
root [ /build/bld-ph4 ]# ./bin/tdnf makecache
Refreshing metadata for: 'VMware Photon Linux 4.0 (aarch64) Updates'
Refreshing metadata for: 'VMware Photon Linux 4.0 (aarch64)'
Refreshing metadata for: 'VMware Photon Extras 4.0 (aarch64)'
Metadata cache created.                    123 100%
root [ /build/bld-ph4 ]# ./bin/tdnf --releasever=3.0 install lsof
Refreshing metadata for: 'VMware Photon Linux 3.0 (aarch64) Updates'
Refreshing metadata for: 'VMware Photon Linux 3.0 (aarch64)'
Refreshing metadata for: 'VMware Photon Extras 3.0 (aarch64)'
photon-extras                              123 100%
Installing:
libtirpc                                            aarch64                   1.1.4-1.ph3                        photon-release               180.60k 184935
lsof                                                aarch64                   4.91-1.ph3                         photon-release               195.94k 200642

Total installed size: 376.54k 385577
Is this ok [y/N]: N
```
From the above, two different sets of cache directories were created:
```
# ls /var/cache/tdnf/
photon-extras-03310507f9e69f4ffd6371f07359c05de4d14c47b8ec056958a35cf2691430a5   photon-release-c58bea6dd9ed4dcf138eff5168526c61eb7a2cebe84d7292a6c97bc0c1d9a41a
photon-extras-89385989dce942383163eebfddbc353146801fa3f62b0dbfa11a1c6ca86a5811   photon-updates-ba5e6bf96d92bf6b703fccd7b1816b7ac57e83d7abcdb631ab2208dc4032af32
photon-release-2d2a0e933fae8240c8f9d53bc467764813771d913d32f7b80a03a415b2fb60f7  photon-updates-bec13383a1df049249f68a4ffff75eec7304d8464739a758831dd1956e1fdde0
```
This behavior is also similar to dnf.

Additionally, `tdnf clean all` will remove the top level repo cache dir as well.
