### PR TITLE
python: Fix linking to built libraries

### DIFF
--- a/pytests/CMakeLists.txt
+++ b/pytests/CMakeLists.txt
@@ -14,7 +14,7 @@ configure_file(
 )
 
 add_custom_target(check
-    COMMAND pytest
+    COMMAND ${CMAKE_COMMAND} -E env LD_LIBRARY_PATH="${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" pytest
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "Running tests.."
 )

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -10,11 +10,7 @@ from setuptools import setup
 from distutils.core import Extension
 
 cflags = [
-    '-I@PYTDNF_INC_DIR@'
-]
-
-link_args = [
-    '-Wl,-rpath=@PYTDNF_LIB_DIR@'
+    '-I@PYTDNF_INC_DIR@',
 ]
 
 pytdnf_sources = [
@@ -29,8 +25,7 @@ tdnfmodule = Extension('tdnf._tdnf',
                        libraries=['tdnf'],
                        library_dirs=['${PYTDNF_LIB_DIR}'],
                        sources=pytdnf_sources,
-                       extra_compile_args=cflags,
-                       extra_link_args=link_args)
+                       extra_compile_args=cflags)
 
 setup(name='@PYTDNF_PACKAGE_NAME@',
        version='@PYTDNF_VERSION@',


### PR DESCRIPTION
We incorrectly use RPATH here when we actually want to link
to the libraries we produced earlier in the build.

Usage of RPATH also causes package builds in Fedora to fail,
since RPATHs are forbidden.