### PR TITLE
Correctly mark internal libraries to be built as static libraries

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-add_library(${LIB_TDNF_COMMON}
+add_library(${LIB_TDNF_COMMON} STATIC
     configreader.c
     memory.c
     setopt.c

--- a/history/CMakeLists.txt
+++ b/history/CMakeLists.txt
@@ -6,6 +6,6 @@
 # of the License are located in the COPYING file of this distribution.
 #
 
-add_library(${LIB_TDNF_HISTORY}
+add_library(${LIB_TDNF_HISTORY} STATIC
     history.c
 )

--- a/jsondump/CMakeLists.txt
+++ b/jsondump/CMakeLists.txt
@@ -12,7 +12,7 @@ add_executable(${TDNF_JSON_BIN}
     test.c
 )
 
-add_library(${LIB_TDNF_JSONDUMP}
+add_library(${LIB_TDNF_JSONDUMP} STATIC
     jsondump.c
 )
 

--- a/solv/CMakeLists.txt
+++ b/solv/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 include_directories(${CMAKE_SOURCE_DIR}/include)
 
-add_library(${LIB_TDNF_SOLV}
+add_library(${LIB_TDNF_SOLV} STATIC
     tdnfpackage.c
     tdnfpool.c
     tdnfquery.c


### PR DESCRIPTION
We were relying on CMake having a particular default preferred
behavior, but this causes problems when building tdnf RPMs on
Fedora, where CMake's default behavior is to produce shared libraries.

Explicitly set up these internal libraries as static libraries to
resolve the issue.