### PR TITLE
Fix missing error when repo build script setup-repo.sh fails.

### DIFF
--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -101,7 +101,12 @@ class TestUtils(object):
             self.config.update(cli_args)
         self.config['distribution'] = os.environ.get('DIST', 'photon')
         script = os.path.join(self.config['test_path'], 'repo/setup-repo.sh')
-        self.run(['sh', script, self.config['repo_path']])
+        ret = self.run(['sh', script, self.config['repo_path']])
+        if ret['retval']:
+            pytest.exit("An error occured while running {}, stdout: \n{}".format(
+                script,
+                "\n".join(ret['stdout'])
+            ))
         self.tdnf_config = configparser.ConfigParser()
         self.tdnf_config.read(os.path.join(self.config['repo_path'],
                                            'tdnf.conf'))


### PR DESCRIPTION
Adds error-checking to the script `pytests/repo/setup-repo.sh` as well as a `pytest.exit()` call when the script fails to run. Currently, no error is printed and the tests run regardless of failing to build the test repository. 

Added as a separate PR as per https://github.com/vmware/tdnf/pull/321#issuecomment-1179221201.