### PR TITLE
Fix coverity issues

### DIFF
--- a/ci/coverity.sh
+++ b/ci/coverity.sh
@@ -16,6 +16,14 @@ CC=cc
 
 cov-configure --config ${COV_CONFIG} --compiler ${CC} --comptype gcc --template
 cov-build --dir ${COV_DIR} --config ${COV_CONFIG} make
+
+# gcc >= 10.0 workaround, see https://www.mail-archive.com/gcc@gcc.gnu.org/msg93814.html
+if grep -qr 'version>0' . --include=*.xml ; then
+    for f in $(grep -lr 'version>0' . --include=*.xml) ; do sed -i 's/version>0/version>10/' $f; done
+    make clean
+    cov-build --dir ${COV_DIR} --config ${COV_CONFIG} make
+fi
+
 cov-analyze --dir ${COV_DIR} --config ${COV_CONFIG} --all
 
 mkdir html

--- a/client/api.c
+++ b/client/api.c
@@ -1080,6 +1080,7 @@ _rm_rpms(
         else
         {
             /* marker file can be removed now */
+            /* coverity[toctou] */
             if(remove(pszKeepFile) < 0)
             {
                 pr_crit("unable to remove %s: %s\n", pszKeepFile, strerror(errno));
@@ -1234,7 +1235,7 @@ TDNFRepoSync(
             if (!pReposyncArgs->nNoRepoPath)
             {
                 dwError = TDNFJoinPath(&pszDir,
-                                       strcmp(pszRootPath, "/") ? pszRootPath : "",
+                                       pszRootPath && strcmp(pszRootPath, "/") ? pszRootPath : "",
                                        pPkgInfo->pszRepoName,
                                        NULL);
                 BAIL_ON_TDNF_ERROR(dwError);
@@ -1321,7 +1322,7 @@ TDNFRepoSync(
 
             /* no need to check nNoRepoPath since we wouldn't get here */
             dwError = TDNFJoinPath(&pszRepoDir,
-                                   strcmp(pszRootPath, "/") ? pszRootPath : "",
+                                   pszRootPath && strcmp(pszRootPath, "/") ? pszRootPath : "",
                                    pRepo->pszId,
                                    NULL);
             BAIL_ON_TDNF_ERROR(dwError);
@@ -1356,7 +1357,7 @@ TDNFRepoSync(
                                 pReposyncArgs->pszMetaDataPath : pszRootPath;
 
                 dwError = TDNFJoinPath(&pszRepoDir,
-                                       strcmp(pszBasePath, "/") ? pszBasePath : "",
+                                       pszBasePath && strcmp(pszBasePath, "/") ? pszBasePath : "",
                                        pRepo->pszId,
                                        NULL);
                 BAIL_ON_TDNF_ERROR(dwError);
@@ -1981,7 +1982,7 @@ TDNFHistoryResolve(
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo = NULL;
     struct history_ctx *ctx = NULL;
     struct history_delta *hd = NULL;
-    struct history_flags_delta *hfd;
+    struct history_flags_delta *hfd = NULL;
     struct history_nevra_map *hnm = NULL;
     rpmts ts = NULL;
     Queue qInstall = {0};
@@ -2193,6 +2194,7 @@ TDNFHistoryResolve(
 cleanup:
     history_free_nevra_map(hnm);
     history_free_delta(hd);
+    history_free_flags_delta(hfd);
     destroy_history_ctx(ctx);
     queue_free(&queueGoal);
     queue_free(&qInstall);

--- a/client/repo.c
+++ b/client/repo.c
@@ -839,7 +839,7 @@ TDNFGetRepoMD(
 
                 //check if the repomd file downloaded using metalink have the same checksum
                 //as mentioned in the metalink file.
-                dwError = TDNFCheckRepoMDFileHashFromMetalink(pszTmpRepoMDFile , ml_ctx);
+                dwError = TDNFCheckRepoMDFileHashFromMetalink(pszTmpRepoMDFile, ml_ctx);
                 BAIL_ON_TDNF_ERROR(dwError);
 
                 dwError = TDNFRepoSetBaseUrl(pTdnf, pRepoData, pszTempBaseUrlFile);
@@ -1527,6 +1527,9 @@ cleanup:
     dataiterator_free(&di);
     return dwError;
 error:
+    TDNF_SAFE_FREE_MEMORY(pszPartUrl);
+    TDNF_SAFE_FREE_MEMORY(pszPartPath);
+
     goto cleanup;
 }
 

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -55,7 +55,8 @@ TDNFLoadRepoData(
     {
         if(strcmp(pSetOpt->pszOptName, "repofrompath") == 0)
         {
-            TDNFSplitStringToArray(pSetOpt->pszOptValue, ",", &ppszUrlIdTuple);
+            dwError = TDNFSplitStringToArray(pSetOpt->pszOptValue, ",", &ppszUrlIdTuple);
+            BAIL_ON_TDNF_ERROR(dwError);
             if ((ppszUrlIdTuple[0] == NULL) || ppszUrlIdTuple[1] == NULL)
             {
                 dwError = ERROR_TDNF_INVALID_PARAMETER;

--- a/common/utils.c
+++ b/common/utils.c
@@ -824,10 +824,10 @@ TDNFJoinPath(char **ppszPath, ...)
 
         TDNF_SAFE_FREE_MEMORY(pszNodeCopy);
     }
-    va_end(ap);
 
     *ppszPath = pszResult;
 cleanup:
+    va_end(ap);
     return dwError;
 error:
     TDNF_SAFE_FREE_MEMORY(pszResult);

--- a/history/history.h
+++ b/history/history.h
@@ -89,7 +89,7 @@ int history_get_auto_flag(struct history_ctx *ctx, const char *name, int *pvalue
 int history_restore_auto_flags(struct history_ctx *ctx, int trans_id);
 int history_replay_auto_flags(struct history_ctx *ctx, int from, int to);
 
-void free_history_flags_delta(struct history_flags_delta * hfd);
+void history_free_flags_delta(struct history_flags_delta * hfd);
 struct history_flags_delta *
 history_get_flags_delta(struct history_ctx *ctx, int from, int to);
 

--- a/jsondump/jsondump.c
+++ b/jsondump/jsondump.c
@@ -46,8 +46,10 @@ char *_alloc_vsprintf(const char *fmt, va_list ap)
 
     size++;             /* For '\0' */
     p = (char *)calloc(1, size);
-    if (p == NULL)
+    if (p == NULL) {
+        va_end(aq);
         return NULL;
+    }
 
     size = vsnprintf(p, size, fmt, aq);
     va_end(aq);

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1917,6 +1917,10 @@ SolvGetNevraFromId(
     {
         *ppszEVR = pszEVR;
     }
+    else
+    {
+        TDNF_SAFE_FREE_MEMORY(pszEVR);
+    }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszEpoch);
     return dwError;
@@ -2212,9 +2216,18 @@ cleanup:
     return dwError;
 
 error:
-    *ppszName = NULL;
-    *ppszArch = NULL;
-    *ppszEVR = NULL;
+    if (ppszName)
+    {
+        *ppszName = NULL;
+    }
+    if (ppszArch)
+    {
+        *ppszArch = NULL;
+    }
+    if (ppszEVR)
+    {
+        *ppszEVR = NULL;
+    }
     TDNF_SAFE_FREE_MEMORY(pszName);
     TDNF_SAFE_FREE_MEMORY(pszArch);
     TDNF_SAFE_FREE_MEMORY(pszEVR);
@@ -2283,6 +2296,8 @@ cleanup:
     return dwError;
 
 error:
+    /* Coverity false positive, low impact if any */
+    /* coverity[overwrite_var] */
     for (pEntry = pEntries; pEntry; pEntry = pEntryNext)
     {
         pEntryNext = pEntry->pNext;

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -393,7 +393,7 @@ SolvCreateRepoCacheName(
     Chksum *pChkSum = NULL;
     unsigned char pCookie[SOLV_COOKIE_LEN] = {0};
     char pszCookie[9] = {0};
-    char *pszCacheName;
+    char *pszCacheName = NULL;
 
     if (!pszName || !pszUrl || !ppszCacheName)
     {

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -629,7 +629,7 @@ TDNFCliRepoSyncCommand(
     )
 {
     uint32_t dwError = 0;
-    PTDNF_REPOSYNC_ARGS pReposyncArgs;
+    PTDNF_REPOSYNC_ARGS pReposyncArgs = NULL;
 
     if(!pContext || !pContext->hTdnf || !pCmdArgs || !pContext->pFnRepoSync)
     {
@@ -761,7 +761,7 @@ TDNFCliRepoQueryCommand(
 
                     if (strftime(szTime, 20, "%a %b %d %Y", localtime(&pEntry->timeTime)))
                     {
-                        jd_map_add_string(jd_entry, "Time", szTime);
+                        CHECK_JD_RC(jd_map_add_string(jd_entry, "Time", szTime));
                     }
                     CHECK_JD_RC(jd_map_add_string(jd_entry, "Author", pEntry->pszAuthor));
                     CHECK_JD_RC(jd_map_add_string(jd_entry, "Text", pEntry->pszText));

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -309,7 +309,7 @@ cleanup:
     return dwError;
 
 error:
-    if (pCmdArgs->nJsonOutput && dwError == ERROR_TDNF_OPERATION_ABORTED)
+    if (pCmdArgs && pCmdArgs->nJsonOutput && dwError == ERROR_TDNF_OPERATION_ABORTED)
     {
         dwError = 0;
     }
@@ -371,12 +371,13 @@ JDPkgList(
     uint32_t dwError = 0;
     PTDNF_PKG_INFO pPkgInfo;
     struct json_dump *jd_list = jd_create(0);
+    struct json_dump *jd_pkg = NULL;
     CHECK_JD_NULL(jd_list);
 
     jd_list_start(jd_list);
     for(pPkgInfo = pPkgInfos; pPkgInfo; pPkgInfo = pPkgInfo->pNext)
     {
-        struct json_dump *jd_pkg = jd_create(0);
+        jd_pkg = jd_create(0);
         CHECK_JD_NULL(jd_pkg);
 
         CHECK_JD_RC(jd_map_start(jd_pkg));
@@ -393,6 +394,7 @@ JDPkgList(
 cleanup:
     return dwError;
 error:
+    JD_SAFE_DESTROY(jd_pkg);
     JD_SAFE_DESTROY(jd_list);
     goto cleanup;
 }

--- a/tools/cli/lib/parsehistoryargs.c
+++ b/tools/cli/lib/parsehistoryargs.c
@@ -108,6 +108,7 @@ TDNFCliParseHistoryArgs(
 
     *ppHistoryArgs = pHistoryArgs;
 cleanup:
+    TDNF_SAFE_FREE_MEMORY(ppszRange);
     return dwError;
 error:
     if (pHistoryArgs)

--- a/tools/cli/lib/parserepoqueryargs.c
+++ b/tools/cli/lib/parserepoqueryargs.c
@@ -172,7 +172,10 @@ TDNFCliParseRepoQueryArgs(
 cleanup:
     return dwError;
 error:
-    *ppRepoqueryArgs = NULL;
+    if (ppRepoqueryArgs)
+    {
+        *ppRepoqueryArgs = NULL;
+    }
     TDNFCliFreeRepoQueryArgs(pRepoqueryArgs);
     goto cleanup;
 }

--- a/tools/cli/lib/parsereposyncargs.c
+++ b/tools/cli/lib/parsereposyncargs.c
@@ -49,7 +49,7 @@ TDNFCliParseRepoSyncArgs(
         {
             if (pReposyncArgs->ppszArchs == NULL)
             {
-                TDNFAllocateMemory(TDNF_REPOSYNC_MAXARCHS+1, sizeof(char *),
+                dwError = TDNFAllocateMemory(TDNF_REPOSYNC_MAXARCHS+1, sizeof(char *),
                     (void **)&pReposyncArgs->ppszArchs);
                 BAIL_ON_CLI_ERROR(dwError);
             }

--- a/tools/cli/lib/updateinfocmd.c
+++ b/tools/cli/lib/updateinfocmd.c
@@ -125,7 +125,7 @@ TDNFCliUpdateInfoSummary(
         jd_map_start(jd);
         for(i = UPDATE_UNKNOWN; i <= UPDATE_ENHANCEMENT; ++i)
         {
-            jd_map_add_int(jd, TDNFGetUpdateInfoType(pSummary[i].nType), pSummary[i].nCount);
+            CHECK_JD_RC(jd_map_add_int(jd, TDNFGetUpdateInfoType(pSummary[i].nType), pSummary[i].nCount));
         }
         pr_json(jd->buf);
         JD_SAFE_DESTROY(jd);

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -262,19 +262,25 @@ TDNFCliShowVersion(
     PTDNF_CMD_ARGS pCmdArgs
     )
 {
+    uint32_t dwError = 0;
+    struct json_dump *jd = NULL;
+
     if (pCmdArgs->nJsonOutput)
     {
-        struct json_dump *jd = jd_create(0);
+        jd = jd_create(0);
         jd_map_start(jd);
-        jd_map_add_string(jd, "Name", TDNFGetPackageName());
-        jd_map_add_string(jd, "Version", TDNFGetVersion());
+        CHECK_JD_NULL(jd);
+        CHECK_JD_RC(jd_map_add_string(jd, "Name", TDNFGetPackageName()));
+        CHECK_JD_RC(jd_map_add_string(jd, "Version", TDNFGetVersion()));
         pr_json(jd->buf);
-        jd_destroy(jd);
     }
     else
     {
         pr_info("%s: %s\n", TDNFGetPackageName(), TDNFGetVersion());
     }
+error:
+    JD_SAFE_DESTROY(jd);
+    return;
 }
 
 uint32_t


### PR DESCRIPTION
Fixing most issues found by coverity.

Also working around a coverity bug triggered by gcc >= 10.0 - the version isn't parsed correctly. 

Remaining issues:
* 5 instances of `PARSE_ERROR` in `stdlib.h` (we have no control over)
* 7 instances of `PW.BRANCH_PAST_INITIALIZATION` that have no impact
* 2 instances of `PW.INCLUDE_RECURSION` in `libxml` headrers, again not under our control


