### PR TITLE
fix flake8 errors for assert()

### DIFF
--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -172,7 +172,7 @@ class TestUtils(object):
         else:
             pkg = pkgname
         self.run(['tdnf', 'erase', '-y', pkg])
-        assert(not self.check_package(pkgname))
+        assert not self.check_package(pkgname)
 
     def install_package(utils, pkgname, pkgversion=None):
         if pkgversion:
@@ -180,7 +180,7 @@ class TestUtils(object):
         else:
             pkg = pkgname
         utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
-        assert(utils.check_package(pkgname))
+        assert utils.check_package(pkgname)
 
     def _requests_get(self, url, verify):
         try:

--- a/pytests/tests/test_assumeno.py
+++ b/pytests/tests/test_assumeno.py
@@ -27,12 +27,12 @@ def teardown_test(utils):
 def test_assumeno_install(utils):
     pkgname = utils.config['sglversion_pkgname']
     utils.run(['tdnf', '--assumeno', 'install', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 def test_assumeno_erase(utils):
     pkgname = utils.config['sglversion_pkgname']
     utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
     utils.run(['tdnf', '--assumeno', 'erase', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_autoremove.py
+++ b/pytests/tests/test_autoremove.py
@@ -52,13 +52,13 @@ def test_autoremove(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
     utils.install_package(pkgname)
 
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)
 
 
 # When the required package is installed first, removing the
@@ -69,14 +69,14 @@ def test_autoremove_req_is_user_installed(utils):
     utils.install_package(pkgname_req)
     utils.install_package(pkgname)
 
-    assert(utils.check_package(pkgname_req))
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname_req)
+    assert utils.check_package(pkgname)
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
 
 # When the required package has been installed as a dependency
@@ -88,14 +88,14 @@ def test_autoremove_req_is_user_installed2(utils):
     utils.install_package(pkgname)
     utils.install_package(pkgname_req)
 
-    assert(utils.check_package(pkgname))
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname)
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
 
 # leaf1 pulls in a dependency. leaf2 has the same dependency.
@@ -110,15 +110,15 @@ def test_autoremove2(utils):
     utils.install_package(pkgname2)
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
     # actual test:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname2])
 
     # actual test:
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)
 
 
 # like autoremove, but in config file
@@ -130,13 +130,13 @@ def test_autoremove_conf_true(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', '-c', conffile, 'remove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)
 
 
 # autoremove disabled in config file
@@ -148,13 +148,13 @@ def test_autoremove_conf_false(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', '-c', conffile, 'remove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
 
 # autoremove enabled in config file, but --noautoremove in cmd line
@@ -166,13 +166,13 @@ def test_autoremove_conf_noautoremove(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', '-c', conffile, '--noautoremove', 'remove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
 
 # autoremove disabled in config file, 'autoremove' should still
@@ -185,13 +185,13 @@ def test_autoremove_conf_false_autoremove(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', '-c', conffile, 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test:
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)
 
 
 # 'autoremve' without args cleans up all unneeded
@@ -201,16 +201,16 @@ def test_autoremove_noargs(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'remove', '--noautoremove', pkgname])
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'autoremove'])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
     # actual test - required pkg should be gone
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)
 
 
 # do not accidentally remove all autoinstaled packages
@@ -221,11 +221,11 @@ def test_autoremove_noargs2(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
 
     utils.install_package(pkgname)
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     utils.run(['tdnf', '-y', 'autoremove'])
 
     # actual test - user installed pkg should still be there
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
     # also check that the required pkg is still there
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)

--- a/pytests/tests/test_cache.py
+++ b/pytests/tests/test_cache.py
@@ -93,7 +93,7 @@ def test_install_without_cache(utils):
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
 
-    assert(not check_package_in_cache(utils, pkgname))
+    assert not check_package_in_cache(utils, pkgname)
 
 
 def test_install_with_cache(utils):
@@ -106,7 +106,7 @@ def test_install_with_cache(utils):
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
 
-    assert(check_package_in_cache(utils, pkgname))
+    assert check_package_in_cache(utils, pkgname)
 
 
 def test_install_with_keepcache_false(utils):
@@ -121,38 +121,38 @@ def test_install_with_keepcache_false(utils):
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
 
-    assert(not check_package_in_cache(utils, pkgname))
+    assert not check_package_in_cache(utils, pkgname)
 
 
 def test_disable_repo_make_cache(utils):
     cache_dir = find_cache_dir(utils, 'photon-test')
-    assert(cache_dir is not None)
+    assert cache_dir is not None
     lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '--disablerepo=*', 'makecache'])
     after = os.path.getmtime(lastrefresh)
-    assert(before == after)
+    assert before == after
 
 
 def test_enable_repo_make_cache(utils):
     cache_dir = find_cache_dir(utils, 'photon-test')
-    assert(cache_dir is not None)
+    assert cache_dir is not None
     lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '--disablerepo=*', '--enablerepo=photon-test', 'makecache'])
     after = os.path.getmtime(lastrefresh)
-    assert(before < after)
+    assert before < after
 
 
 # -v (verbose) prints progress data
 def test_enable_repo_make_cache_verbose(utils):
     cache_dir = find_cache_dir(utils, 'photon-test')
-    assert(cache_dir is not None)
+    assert cache_dir is not None
     lastrefresh = os.path.join(cache_dir, 'lastrefresh')
     before = os.path.getmtime(lastrefresh)
     utils.run(['tdnf', '-v', '--disablerepo=*', '--enablerepo=photon-test', 'makecache'])
     after = os.path.getmtime(lastrefresh)
-    assert(before < after)
+    assert before < after
 
 
 def test_download_vs_cache_size_single_package(utils):
@@ -167,7 +167,7 @@ def test_download_vs_cache_size_single_package(utils):
     down_bytes = utils.download_size_to_bytes(ret['stdout'])
     cached_rpm_bytes = sum(utils.get_cached_package_sizes(cache_dir).values())
 
-    assert(utils.floats_approx_equal(down_bytes, cached_rpm_bytes))
+    assert utils.floats_approx_equal(down_bytes, cached_rpm_bytes)
 
 
 def test_download_vs_cache_size_multiple_packages(utils):
@@ -189,7 +189,7 @@ def test_download_vs_cache_size_multiple_packages(utils):
     down_bytes = utils.download_size_to_bytes(ret['stdout'])
     cached_rpm_bytes = sum(utils.get_cached_package_sizes(cache_dir).values())
 
-    assert(utils.floats_approx_equal(down_bytes, cached_rpm_bytes))
+    assert utils.floats_approx_equal(down_bytes, cached_rpm_bytes)
 
 
 @pytest.mark.skipif(try_mount_small_cache() != 0, reason="Failed to mount small cache directory.")
@@ -209,4 +209,4 @@ def test_cache_directory_out_of_disk_space(utils):
     switch_cache_path(utils, utils.tdnf_config.get('main', 'cachedir'))
     clean_cache(utils)
     clean_small_cache(utils)
-    assert(ret['retval'] == 1036)
+    assert ret['retval'] == 1036

--- a/pytests/tests/test_cfgreader.py
+++ b/pytests/tests/test_cfgreader.py
@@ -50,22 +50,22 @@ def teardown_test(utils):
     os.remove(NEW_REPO_FN)
     os.rename(ORIG_REPO_FN + '.bak', ORIG_REPO_FN)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_makecache(utils):
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     for i in ret['stdout']:
         if 'Metadata cache created' in i:
             return
-    assert(False)
+    assert False
 
 
 def test_repolist(utils):
     ret = utils.run(['tdnf', 'repolist'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     for i in ret['stdout']:
         if 'cfg-test' in i and 'enabled' in i and 'Test Repo' in i:
             return
-    assert(False)
+    assert False

--- a/pytests/tests/test_check_local.py
+++ b/pytests/tests/test_check_local.py
@@ -27,18 +27,18 @@ def teardown_test(utils):
 
 def test_check_local_no_args(utils):
     ret = utils.run(['tdnf', 'check-local'])
-    assert(ret['retval'] == 906)
+    assert ret['retval'] == 906
 
 
 def test_check_local_with_invalid_dir(utils):
     ret = utils.run(['tdnf', 'check-local', '/home/invalid_dir'])
-    assert(ret['retval'] == 1602)
+    assert ret['retval'] == 1602
 
 
 def test_check_local_empty_directory(utils):
     temp_dir = tempfile.TemporaryDirectory()
     ret = utils.run(['tdnf', 'check-local', temp_dir.name])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_check_local_with_local_rpm(utils):
@@ -48,4 +48,4 @@ def test_check_local_with_local_rpm(utils):
         shutil.copyfile(src, dest)
 
         ret = utils.run(['tdnf', 'check-local', tmpdir])
-        assert(ret['retval'] == 0)
+        assert ret['retval'] == 0

--- a/pytests/tests/test_check_skip.py
+++ b/pytests/tests/test_check_skip.py
@@ -13,7 +13,7 @@ def run_cmd(utils, opt, retval):
     cmd = ['tdnf', 'check']
     cmd.extend(opt)
     ret = utils.run(cmd)
-    assert(ret['retval'] == retval)
+    assert ret['retval'] == retval
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/pytests/tests/test_check_update.py
+++ b/pytests/tests/test_check_update.py
@@ -23,27 +23,27 @@ def teardown_test(utils):
 
 def test_check_update_no_arg(utils):
     ret = utils.run(['tdnf', 'check-update'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_check_update_invalid_args(utils):
     ret = utils.run(['tdnf', 'check-update', 'abcd', '1234'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_check_update_multi_version_package(utils):
     package = utils.config["mulversion_pkgname"] + '-' + utils.config["mulversion_lower"]
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', package])
-    assert(utils.check_package(utils.config["mulversion_pkgname"]))
+    assert utils.check_package(utils.config["mulversion_pkgname"])
 
     ret = utils.run(['tdnf', 'check-update', utils.config["mulversion_pkgname"]])
-    assert(len(ret['stdout']) > 0)
+    assert len(ret['stdout']) > 0
 
 
 def test_check_update_single_version_package(utils):
     package = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', package])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'check-update', package])
-    assert(len(ret['stdout']) == 0)
+    assert len(ret['stdout']) == 0

--- a/pytests/tests/test_clean.py
+++ b/pytests/tests/test_clean.py
@@ -21,50 +21,50 @@ def teardown_test(utils):
 
 def test_clean_no_args(utils):
     ret = utils.run(['tdnf', 'clean'])
-    assert(ret['retval'] == 903)
+    assert ret['retval'] == 903
 
 
 def test_clean_invalid_arg(utils):
     ret = utils.run(['tdnf', 'clean', 'abcde'])
-    assert(ret['retval'] == 901)
+    assert ret['retval'] == 901
 
 
 def test_clean_packages(utils):
     ret = utils.run(['tdnf', 'clean', 'packages'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_dbcache(utils):
     ret = utils.run(['tdnf', 'clean', 'dbcache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_metadata(utils):
     ret = utils.run(['tdnf', 'clean', 'metadata'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_expire_cache(utils):
     ret = utils.run(['tdnf', 'clean', 'expire-cache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_plugins(utils):
     ret = utils.run(['tdnf', 'clean', 'plugins'])
-    assert(ret['retval'] == 1016)
+    assert ret['retval'] == 1016
 
 
 def test_clean_all(utils):
     utils.run(['tdnf', 'makecache'])
     ret = utils.run(['tdnf', 'clean', 'all'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_all_clean_already(utils):
     utils.run(['tdnf', 'makecache'])
     utils.run(['tdnf', 'clean', 'all'])
     ret = utils.run(['tdnf', 'clean', 'all'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_clean_install_and_clean(utils):
@@ -74,4 +74,4 @@ def test_clean_install_and_clean(utils):
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
 
     ret = utils.run(['tdnf', 'clean', 'all'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_config.py
+++ b/pytests/tests/test_config.py
@@ -33,21 +33,21 @@ def teardown_test(utils):
 def test_config_invalid(utils):
     spkg = utils.config['sglversion_pkgname']
     ret = utils.run(['tdnf', '--config', '/tmp/myrepo/test123.conf', 'list', spkg])
-    assert(ret['retval'] == 1602)
+    assert ret['retval'] == 1602
 
 
 def test_config_list(utils):
     spkg = utils.config['sglversion_pkgname']
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', '--config', '/tmp/myrepo/mytdnf.conf', 'list', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_config_list_with_disable_repos(utils):
     spkg = utils.config['sglversion_pkgname']
     ret = utils.run(['tdnf', '--disablerepo=*', '--config', '/tmp/myrepo/mytdnf.conf', 'list', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     for line in ret['stdout']:
         if not line or '@System' in line:
@@ -59,4 +59,4 @@ def test_config_invaid_repodir(utils):
     spkg = utils.config['sglversion_pkgname']
     utils.run(['sed', '-i', 's#repodir=/tmp/myrepo#repodir=/etc/invalid#g', '/tmp/myrepo/mytdnf.conf'])
     ret = utils.run(['tdnf', '--config', '/tmp/myrepo/mytdnf.conf', 'list', spkg])
-    assert(ret['retval'] == 1005)
+    assert ret['retval'] == 1005

--- a/pytests/tests/test_conflict.py
+++ b/pytests/tests/test_conflict.py
@@ -26,17 +26,17 @@ def teardown_test(utils):
 def test_install_conflict_file(utils):
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg0])
     print(ret)
-    assert(utils.check_package(pkg0))
+    assert utils.check_package(pkg0)
 
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg1])
     print(ret)
-    assert(ret['retval'] == 1525)
-    assert(not utils.check_package(pkg1))
+    assert ret['retval'] == 1525
+    assert not utils.check_package(pkg1)
 
 
 def test_install_conflict_file_atonce(utils):
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg0, pkg1])
     print(ret)
-    assert(ret['retval'] == 1525)
-    assert(not utils.check_package(pkg0))
-    assert(not utils.check_package(pkg1))
+    assert ret['retval'] == 1525
+    assert not utils.check_package(pkg0)
+    assert not utils.check_package(pkg1)

--- a/pytests/tests/test_count.py
+++ b/pytests/tests/test_count.py
@@ -21,10 +21,10 @@ def teardown_test(utils):
 
 def test_count(utils):
     ret = utils.run(['tdnf', 'count'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 # memcheck
 def test_count_memcheck(utils):
     ret = utils.run_memcheck(['tdnf', 'count'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_downgrade.py
+++ b/pytests/tests/test_downgrade.py
@@ -22,41 +22,41 @@ def teardown_test(utils):
 
 def test_downgrade_no_arg(utils):
     ret = utils.run(['tdnf', 'downgrade'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_downgrade_install(utils):
     mpkg = utils.config['mulversion_pkgname']
     ret = utils.run(['tdnf', 'install', '-y', mpkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'downgrade', '-y', mpkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_downgrade_with_lower_version(utils):
     mpkg = utils.config['mulversion_pkgname']
     mpkg_lower = utils.config['mulversion_lower']
     ret = utils.run(['tdnf', 'install', '-y', mpkg + '-' + mpkg_lower])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'downgrade', '-y', mpkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_downgrade_with_higher_version(utils):
     mpkg = utils.config['mulversion_pkgname']
     ret = utils.run(['tdnf', 'install', '-y', mpkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     mpkg_lower = utils.config['mulversion_lower']
     ret = utils.run(['tdnf', 'downgrade', '-y', mpkg + '-' + mpkg_lower])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_downgrade_with_invalid_version(utils):
     mpkg = utils.config['mulversion_pkgname']
     ret = utils.run(['tdnf', 'downgrade', '-y', mpkg + '-123.123.123'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_downgrade_invalid_pkg_name(utils):
     ret = utils.run(['tdnf', 'downgrade', '-y', 'invalid_pkg_name'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011

--- a/pytests/tests/test_downloadonly.py
+++ b/pytests/tests/test_downloadonly.py
@@ -36,9 +36,9 @@ def check_package_in_cache(utils, pkgname):
 def test_install_download_only(utils):
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', '--downloadonly', pkgname])
-    assert(ret['retval'] == 0)
-    assert(not utils.check_package(pkgname))
-    assert(check_package_in_cache(utils, pkgname))
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+    assert check_package_in_cache(utils, pkgname)
 
 
 # download only to cache dir - must succeed but not install, file must
@@ -48,14 +48,14 @@ def test_install_download_only_to_directory(utils):
     os.makedirs(DOWNLOADDIR, exist_ok=True)
     ret = utils.run(['tdnf', 'install', '-y', '--downloadonly', '--downloaddir', DOWNLOADDIR, pkgname])
     print(ret)
-    assert(ret['retval'] == 0)
-    assert(not utils.check_package(pkgname))
-    assert(len(glob.glob('{}/{}*.rpm'.format(DOWNLOADDIR, pkgname))) > 0)
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+    assert len(glob.glob('{}/{}*.rpm'.format(DOWNLOADDIR, pkgname))) > 0
 
 
 # --downloaddir option without --downloadonly should fail
 def test_install_downloaddir_no_downloadonly(utils):
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', '--downloaddir', DOWNLOADDIR, pkgname])
-    assert(ret['retval'] != 0)
-    assert(not utils.check_package(pkgname))
+    assert ret['retval'] != 0
+    assert not utils.check_package(pkgname)

--- a/pytests/tests/test_erase.py
+++ b/pytests/tests/test_erase.py
@@ -21,12 +21,12 @@ def teardown_test(utils):
 
 def test_erase_no_arg(utils):
     ret = utils.run(['tdnf', 'erase'])
-    assert(ret['retval'] == 1001)
+    assert ret['retval'] == 1001
 
 
 def test_erase_invalid_package(utils):
     ret = utils.run(['tdnf', 'erase', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_erase_package_with_version_suffix(utils):
@@ -35,7 +35,7 @@ def test_erase_package_with_version_suffix(utils):
     utils.install_package(pkgname, pkgversion)
 
     utils.run(['tdnf', 'erase', '-y', pkgname + '-' + pkgversion])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 def test_erase_package_without_version_suffix(utils):
@@ -43,7 +43,7 @@ def test_erase_package_without_version_suffix(utils):
     utils.install_package(pkgname)
 
     utils.run(['tdnf', 'erase', '-y', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 def test_erase_memcheck(utils):
@@ -51,4 +51,4 @@ def test_erase_memcheck(utils):
     utils.install_package(pkgname)
 
     utils.run_memcheck(['tdnf', 'erase', '-y', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)

--- a/pytests/tests/test_excludes.py
+++ b/pytests/tests/test_excludes.py
@@ -28,7 +28,7 @@ def test_install_package_with_version_suffix(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '--exclude=', pkgname, '-y', '--nogpgcheck', pkgname + '-' + pkgversion])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 # basic test (negative test)
@@ -37,7 +37,7 @@ def test_install_package_without_version_suffix(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '--exclude=', pkgname, '-y', '--nogpgcheck', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 # excluded dependency (negative test)
@@ -48,7 +48,7 @@ def test_install_package_with_excluded_dependency(utils):
     utils.erase_package(pkgname_required)
 
     utils.run(['tdnf', 'install', '--exclude=', pkgname_required, '-y', '--nogpgcheck', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
 
 
 # an update should skip an excluded package (negative test)
@@ -65,11 +65,11 @@ def test_update_package(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname + '-' + pkgversion1])
-    assert(utils.check_package(pkgname, pkgversion1))
+    assert utils.check_package(pkgname, pkgversion1)
 
     utils.run(['tdnf', 'update', '--exclude=', pkgname, '-y', '--nogpgcheck', pkgname + '-' + pkgversion2])
-    assert(not utils.check_package(pkgname, pkgversion2))
-    assert(utils.check_package(pkgname, pkgversion1))
+    assert not utils.check_package(pkgname, pkgversion2)
+    assert utils.check_package(pkgname, pkgversion1)
 
 
 # removing an excluded package should fail (dnf behavior) (negative test)
@@ -78,4 +78,4 @@ def test_remove_package(utils):
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
     utils.run(['tdnf', 'remove', '--exclude=', pkgname, '-y', '--nogpgcheck', pkgname])
     # package should still be there
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_expired_cache.py
+++ b/pytests/tests/test_expired_cache.py
@@ -50,7 +50,7 @@ def test_cached_expired(utils):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
     time.sleep(expire + 2)
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'list'])
-    assert("Refreshing metadata" in "\n".join(ret['stdout']))
+    assert "Refreshing metadata" in "\n".join(ret['stdout'])
 
 
 def test_cached_not_expired(utils):
@@ -61,7 +61,7 @@ def test_cached_not_expired(utils):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
     time.sleep(5)
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'list'])
-    assert("Refreshing metadata" not in "\n".join(ret['stdout']))
+    assert "Refreshing metadata" not in "\n".join(ret['stdout'])
 
 
 def test_cached_never_expired(utils):
@@ -72,7 +72,7 @@ def test_cached_never_expired(utils):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
     time.sleep(5)
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'list'])
-    assert("Refreshing metadata" not in "\n".join(ret['stdout']))
+    assert "Refreshing metadata" not in "\n".join(ret['stdout'])
 
 
 def test_cached_expired_cacheonly(utils):
@@ -83,7 +83,7 @@ def test_cached_expired_cacheonly(utils):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
     time.sleep(expire + 2)
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), '-C', 'list'])
-    assert("Refreshing metadata" not in "\n".join(ret['stdout']))
+    assert "Refreshing metadata" not in "\n".join(ret['stdout'])
 
 
 # test for issue #302 - refresh marker was reset for any command
@@ -97,4 +97,4 @@ def test_cached_expired_no_reset(utils):
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'list'])
     time.sleep(expire / 2 + 2)
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'list'])
-    assert("Refreshing metadata" in "\n".join(ret['stdout']))
+    assert "Refreshing metadata" in "\n".join(ret['stdout'])

--- a/pytests/tests/test_granular_perms.py
+++ b/pytests/tests/test_granular_perms.py
@@ -29,15 +29,15 @@ def run_bash_cmd(cmd, rc, bash_cmd=False):
     print('stdout:', out, '\nstderr:', err)
 
     if bash_cmd:
-        assert(rc == (not not proc.returncode))
+        assert rc == (not not proc.returncode)
         return
 
     if not rc:
-        assert('You have to be root' not in err)
+        assert 'You have to be root' not in err
     else:
-        assert('You have to be root' in err)
+        assert 'You have to be root' in err
 
-    assert(rc == (not not proc.returncode))
+    assert rc == (not not proc.returncode)
     return [out, err]
 
 

--- a/pytests/tests/test_history.py
+++ b/pytests/tests/test_history.py
@@ -31,23 +31,23 @@ def test_history_list(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
     ret = utils.run(['tdnf', 'history'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     # 'install' must be in history output
-    assert('install' in '\n'.join(ret['stdout']))
+    assert 'install' in '\n'.join(ret['stdout'])
 
     ret = utils.run(['tdnf', 'history', '--info'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     # pkgname must be in history info output
-    assert(pkgname in '\n'.join(ret['stdout']))
+    assert pkgname in '\n'.join(ret['stdout'])
 
     utils.erase_package(pkgname)
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     ret = utils.run(['tdnf', 'history'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     # 'erase' must be in history output
-    assert('erase' in '\n'.join(ret['stdout']))
+    assert 'erase' in '\n'.join(ret['stdout'])
 
     ret = utils.run(['tdnf', 'history'])
     last = ret['stdout'][-1].split()[0]
@@ -68,10 +68,10 @@ def test_history_rollback(utils):
     baseline = ret['stdout'][-1].split()[0]
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
     utils.run(['tdnf', 'history', '-y', 'rollback', '--to', baseline])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_history_undo(utils):
@@ -87,12 +87,12 @@ def test_history_undo(utils):
 
     for pkg in [pkgname1, pkgname2, pkgname3]:
         utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
-        assert(utils.check_package(pkg))
+        assert utils.check_package(pkg)
 
     # should undo install of pkgname2
     utils.run(['tdnf', 'history', '-y', 'undo', '--from', str(int(baseline) + 2)])
-    assert(ret['retval'] == 0)
-    assert(not utils.check_package(pkgname2))
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname2)
 
 
 def test_history_undo_multiple(utils):
@@ -108,13 +108,13 @@ def test_history_undo_multiple(utils):
 
     for pkg in [pkgname1, pkgname2, pkgname3]:
         utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
-        assert(utils.check_package(pkg))
+        assert utils.check_package(pkg)
 
     utils.run(['tdnf', 'history', '-y', 'undo', '--from', str(int(baseline) + 1), '--to', str(int(baseline) + 3)])
-    assert(ret['retval'] == 0)
-    assert(not utils.check_package(pkgname1))
-    assert(not utils.check_package(pkgname2))
-    assert(not utils.check_package(pkgname3))
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname1)
+    assert not utils.check_package(pkgname2)
+    assert not utils.check_package(pkgname3)
 
 
 def test_history_redo(utils):
@@ -130,15 +130,15 @@ def test_history_redo(utils):
 
     for pkg in [pkgname1, pkgname2, pkgname2]:
         utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
-        assert(utils.check_package(pkg))
+        assert utils.check_package(pkg)
 
     utils.erase_package(pkgname2)
-    assert(not utils.check_package(pkgname2))
+    assert not utils.check_package(pkgname2)
 
     # should redo install of pkgname2
     utils.run(['tdnf', 'history', '-y', 'redo', '--from', str(int(baseline) + 2)])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname2))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname2)
 
 
 def test_history_mark(utils):
@@ -146,16 +146,16 @@ def test_history_mark(utils):
     utils.install_package(pkgname)
 
     ret = utils.run(['tdnf', 'mark', 'remove', pkgname])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'history'])
     trans_id = ret['stdout'][-1].split()[0]
 
     utils.run(['tdnf', 'history', '-y', 'undo', trans_id])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
-    assert(pkgname in "\n".join(ret['stdout']))
+    assert pkgname in "\n".join(ret['stdout'])
 
 
 # redo may pull additional deps if they were already installed
@@ -175,15 +175,15 @@ def test_history_redo_and_autoinstall(utils):
     utils.erase_package(pkgname_req)
 
     utils.run(['tdnf', 'history', '-y', 'redo', trans_id])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname_req])
-    assert(pkgname_req not in "\n".join(ret['stdout']))
+    assert pkgname_req not in "\n".join(ret['stdout'])
 
 
 def test_history_memcheck(utils):
     ret = utils.run_memcheck(['tdnf', 'history'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run_memcheck(['tdnf', 'history', '--info'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_install.py
+++ b/pytests/tests/test_install.py
@@ -22,12 +22,12 @@ def teardown_test(utils):
 
 def test_install_no_arg(utils):
     ret = utils.run(['tdnf', 'install'])
-    assert(ret['retval'] == 1001)
+    assert ret['retval'] == 1001
 
 
 def test_install_invalid_arg(utils):
     ret = utils.run(['tdnf', 'install', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_install_package_with_version_suffix(utils):
@@ -36,7 +36,7 @@ def test_install_package_with_version_suffix(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname + '-' + pkgversion])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_install_package_without_version_suffix(utils):
@@ -44,7 +44,7 @@ def test_install_package_without_version_suffix(utils):
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 # -v (verbose) prints progress data
@@ -52,7 +52,7 @@ def test_install_package_verbose(utils):
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
     utils.run(['tdnf', 'install', '-y', '-v', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_dummy_requires(utils):
@@ -66,4 +66,4 @@ def xxx_test_install_memcheck(utils):
     utils.erase_package(pkgname)
 
     utils.run_memcheck(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -74,7 +74,7 @@ def erase_package(utils, pkgname, installroot=INSTALLROOT, pkgversion=None):
                '--installroot', installroot,
                '--releasever=4.0',
                'erase', '-y', pkg])
-    assert(not check_package(utils, pkgname))
+    assert not check_package(utils, pkgname)
 
 
 def find_cache_dir(reponame):
@@ -94,8 +94,8 @@ def test_install(utils):
                      '-y', '--nogpgcheck',
                      '--installroot', INSTALLROOT,
                      '--releasever=4.0', pkgname], noconfig=True)
-    assert(ret['retval'] == 0)
-    assert(check_package(utils, pkgname))
+    assert ret['retval'] == 0
+    assert check_package(utils, pkgname)
 
     shutil.rmtree(INSTALLROOT)
 
@@ -106,8 +106,8 @@ def test_makecache(utils):
                      '-y', '--nogpgcheck',
                      '--installroot', INSTALLROOT,
                      '--releasever=4.0'], noconfig=True)
-    assert(ret['retval'] == 0)
-    assert(find_cache_dir('photon-test') is not None)
+    assert ret['retval'] == 0
+    assert find_cache_dir('photon-test') is not None
 
     shutil.rmtree(INSTALLROOT)
 
@@ -124,6 +124,6 @@ def test_setopt_reposdir_with_installroot(utils):
                      '--releasever=4.0',
                      '--setopt=reposdir={}'.format(REPODIR),
                      'repolist'])
-    assert(REPONAME in "\n".join(ret['stdout']))
+    assert REPONAME in "\n".join(ret['stdout'])
 
     shutil.rmtree(INSTALLROOT)

--- a/pytests/tests/test_json.py
+++ b/pytests/tests/test_json.py
@@ -34,7 +34,7 @@ def test_list(utils):
         if info['Name'] == "glibc":
             glibc_found = True
             break
-    assert(glibc_found)
+    assert glibc_found
 
 
 def test_list_tdnfj(utils):
@@ -47,7 +47,7 @@ def test_list_tdnfj(utils):
         if info['Name'] == "glibc":
             glibc_found = True
             break
-    assert(glibc_found)
+    assert glibc_found
 
 
 def test_info(utils):
@@ -59,7 +59,7 @@ def test_info(utils):
         if info['Name'] == "glibc":
             glibc_found = True
             break
-    assert(glibc_found)
+    assert glibc_found
 
 
 def test_install(utils):
@@ -68,7 +68,7 @@ def test_install(utils):
     ret = utils.run(['tdnf',
                      '-j', '-y', '--nogpgcheck',
                      'install', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
     install_info = json.loads("\n".join(ret['stdout']))
 
     pkg_found = False
@@ -77,7 +77,7 @@ def test_install(utils):
         if p['Name'] == pkgname:
             pkg_found = True
             break
-    assert(pkg_found)
+    assert pkg_found
 
 
 def test_erase(utils):
@@ -86,7 +86,7 @@ def test_erase(utils):
     ret = utils.run(['tdnf',
                      '-j', '-y', '--nogpgcheck',
                      'erase', pkgname])
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     install_info = json.loads("\n".join(ret['stdout']))
 
     pkg_found = False
@@ -95,13 +95,13 @@ def test_erase(utils):
         if p['Name'] == pkgname:
             pkg_found = True
             break
-    assert(pkg_found)
+    assert pkg_found
 
 
 def test_check_update(utils):
     ret = utils.run(['tdnf', '-j', 'check-update'])
     d = json.loads("\n".join(ret['stdout']))
-    assert(type(d) == list)
+    assert type(d) == list
 
 
 def test_repolist(utils):
@@ -112,42 +112,42 @@ def test_repolist(utils):
     for repo in repolist:
         if repo['Repo'] == 'photon-test':
             repo_found = True
-            assert(repo['Enabled'])
+            assert repo['Enabled']
             break
-    assert(repo_found)
+    assert repo_found
 
 
 def test_repoquery(utils):
     ret = utils.run(['tdnf', '-j', 'repoquery'])
     d = json.loads("\n".join(ret['stdout']))
-    assert(type(d) == list)
+    assert type(d) == list
 
 
 def test_updateinfo(utils):
     ret = utils.run(['tdnf', '-j', 'updateinfo'])
     d = json.loads("\n".join(ret['stdout']))
-    assert(type(d) == dict)
+    assert type(d) == dict
 
 
 def test_updateinfo_info(utils):
     ret = utils.run(['tdnf', '-j', 'updateinfo', '--info'])
     d = json.loads("\n".join(ret['stdout']))
-    assert(type(d) == list)
+    assert type(d) == list
 
 
 def test_history_info(utils):
     ret = utils.run(['tdnf', '-j', 'history', '--info'])
     d = json.loads("\n".join(ret['stdout']))
-    assert(type(d) == list)
+    assert type(d) == list
 
 
 def test_jsondump(utils):
     cmd = os.path.join(utils.config['build_dir'], 'bin/jsondumptest')
     ret = utils.run([cmd])
-    assert("FAIL" not in "\n".join(ret['stdout']))
+    assert "FAIL" not in "\n".join(ret['stdout'])
 
 
 def test_jsondump_memcheck(utils):
     cmd = os.path.join(utils.config['build_dir'], 'bin/jsondumptest')
     ret = utils.run_memcheck([cmd])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_list.py
+++ b/pytests/tests/test_list.py
@@ -23,30 +23,30 @@ def teardown_test(utils):
 
 def helper_test_list_sub_cmd(utils, sub_cmd):
     ret = utils.run(['tdnf', 'list', sub_cmd])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'list', sub_cmd, utils.config["sglversion_pkgname"]])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'list', sub_cmd, 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_list_top(utils):
     spkg = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'list'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'list', utils.config["sglversion_pkgname"]])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'list', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_list_sub_cmd(utils):
     spkg = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     helper_test_list_sub_cmd(utils, 'all')
     helper_test_list_sub_cmd(utils, 'installed')
@@ -59,7 +59,7 @@ def test_list_sub_cmd(utils):
 def test_list_options(utils):
     spkg = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     helper_test_list_sub_cmd(utils, '--all')
     helper_test_list_sub_cmd(utils, '--installed')
@@ -75,16 +75,16 @@ def test_list_notinstalled(utils):
     spkg = utils.config["sglversion_pkgname"]
 
     ret = utils.run(['tdnf', 'list', 'upgrades'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', mpkg + '-' + mpkg_version])
     ret = utils.run(['tdnf', 'list', 'upgrades', mpkg])
-    assert(len(ret['stdout']) == 1)
+    assert len(ret['stdout']) == 1
 
     for cmd in ['updates', 'upgrades', 'downgrades', '--updates', '--upgrades', '--downgrades']:
         ret = utils.run(['tdnf', 'list', cmd, 'invalid_package'])
-        assert(ret['retval'] == 1011)
+        assert ret['retval'] == 1011
 
         # spkg is not installed, expect error
         ret = utils.run(['tdnf', 'list', cmd, spkg])
-        assert(ret['retval'] == 1011)
+        assert ret['retval'] == 1011

--- a/pytests/tests/test_lock.py
+++ b/pytests/tests/test_lock.py
@@ -49,7 +49,7 @@ def run_tdnf_blocking_cmd(utils, pkgname):
         out = out.decode().strip().split('\n')
         err = err.decode().strip().split('\n')
         print('\n\n\n', out, err)
-        assert('Installing:' in out)
+        assert 'Installing:' in out
     except Exception:
         global t1_failed
         t1_failed = True
@@ -62,8 +62,8 @@ def run_tdnf_search_cmd(utils, pkgname):
     t2_started = True
     ret = utils.run(cmd)  # this gets blocked till install finishes
     try:
-        assert(expected_str in ret['stdout'])
-        assert('tdnf-test-one : basic install test file.' in ret['stdout'])
+        assert expected_str in ret['stdout']
+        assert 'tdnf-test-one : basic install test file.' in ret['stdout']
     except Exception:
         global t2_failed
         t2_failed = True
@@ -77,8 +77,8 @@ def run_tdnf_info_cmd(utils, pkgname):
     ret = utils.run(cmd)  # this gets blocked till install finishes
     print(ret['stdout'])
     try:
-        assert(expected_str in ret['stdout'])
-        assert('Name          : tdnf-test-one' in ret['stdout'])
+        assert expected_str in ret['stdout']
+        assert 'Name          : tdnf-test-one' in ret['stdout']
     except Exception:
         global t3_failed
         t3_failed = True
@@ -110,4 +110,4 @@ def test_lock_basic(utils):
     t2.join()
     t3.join()
 
-    assert(not t1_failed and not t2_failed and not t3_failed)
+    assert not t1_failed and not t2_failed and not t3_failed

--- a/pytests/tests/test_locks.py
+++ b/pytests/tests/test_locks.py
@@ -52,11 +52,11 @@ def test_locks_conf_erase(utils):
     utils.install_package(pkgname)
 
     # sanity check
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
     # test - uninstalling should fail
     utils.run(['tdnf', '-y', '--nogpgcheck', 'remove', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_locks_conf_update(utils):
@@ -65,8 +65,8 @@ def test_locks_conf_update(utils):
     set_locks_file(utils, pkgname)
 
     utils.install_package(pkgname, pkgversion=version_low)
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
     # test - update should fail
     utils.run(['tdnf', '-y', '--nogpgcheck', 'update', pkgname])
-    assert(utils.check_package(pkgname, version=version_low))
+    assert utils.check_package(pkgname, version=version_low)

--- a/pytests/tests/test_mark.py
+++ b/pytests/tests/test_mark.py
@@ -30,16 +30,16 @@ def test_mark_install(utils):
     pkgname_req = 'tdnf-test-cleanreq-required'
     utils.install_package(pkgname)
 
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     ret = utils.run(['tdnf', 'mark', 'install', pkgname_req])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test - pkg should still be there:
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
 
 # dependency already installed, hence would not be removed
@@ -50,13 +50,13 @@ def test_mark_remove(utils):
     utils.install_package(pkgname_req)
     utils.install_package(pkgname)
 
-    assert(utils.check_package(pkgname_req))
+    assert utils.check_package(pkgname_req)
 
     ret = utils.run(['tdnf', 'mark', 'remove', pkgname_req])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     utils.run(['tdnf', '-y', 'autoremove', pkgname])
 
-    assert(not utils.check_package(pkgname))
+    assert not utils.check_package(pkgname)
     # actual test - pkg should be removed:
-    assert(not utils.check_package(pkgname_req))
+    assert not utils.check_package(pkgname_req)

--- a/pytests/tests/test_metalink.py
+++ b/pytests/tests/test_metalink.py
@@ -136,12 +136,12 @@ def test_with_metalink_and_url(utils):
     set_sha512(utils, False)
     set_md5(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 # comment out baseurl
@@ -153,12 +153,12 @@ def test_metalink_without_baseurl(utils):
     set_sha1(utils, False)
     set_md5(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 # comment out metalink
@@ -171,12 +171,12 @@ def test_url_without_metalink(utils):
     set_sha1(utils, False)
     set_md5(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 # comment out both metalink and baseurl
@@ -189,7 +189,7 @@ def test_without_url_and_metalink(utils):
     set_md5(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
     print(ret['stderr'][0])
-    assert(ret['stderr'][0].startswith('Error: Cannot find a valid base URL for repo'))
+    assert ret['stderr'][0].startswith('Error: Cannot find a valid base URL for repo')
 
 
 def test_md5_digest(utils):
@@ -200,12 +200,12 @@ def test_md5_digest(utils):
     set_sha256(utils, False)
     set_sha512(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_sha1_digest(utils):
@@ -216,11 +216,11 @@ def test_sha1_digest(utils):
     set_sha256(utils, False)
     set_sha512(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_sha256_digest(utils):
@@ -231,12 +231,12 @@ def test_sha256_digest(utils):
     set_sha256(utils, True)
     set_sha512(utils, False)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_sha512_digest(utils):
@@ -247,12 +247,12 @@ def test_sha512_digest(utils):
     set_sha256(utils, False)
     set_sha512(utils, True)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_invalid_md5_digest(utils):
@@ -264,10 +264,10 @@ def test_invalid_md5_digest(utils):
     set_sha512(utils, False)
     set_invalid_md5(utils)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['stderr'][0].startswith('Error: Validating metalink'))
+    assert ret['stderr'][0].startswith('Error: Validating metalink')
     cache_dir = utils.tdnf_config.get('main', 'cachedir')
     tmp_dir = os.path.join(cache_dir, 'photon-test/tmp')
-    assert(not os.path.isdir(tmp_dir))
+    assert not os.path.isdir(tmp_dir)
 
 
 def test_invalid_sha1_digest(utils):
@@ -279,10 +279,10 @@ def test_invalid_sha1_digest(utils):
     set_sha512(utils, False)
     set_invalid_sha1(utils)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['stderr'][0].startswith('Error: Validating metalink'))
+    assert ret['stderr'][0].startswith('Error: Validating metalink')
     cache_dir = utils.tdnf_config.get('main', 'cachedir')
     tmp_dir = os.path.join(cache_dir, 'photon-test/tmp')
-    assert(not os.path.isdir(tmp_dir))
+    assert not os.path.isdir(tmp_dir)
 
 
 def test_invalid_sha256_digest(utils):
@@ -294,10 +294,10 @@ def test_invalid_sha256_digest(utils):
     set_sha512(utils, False)
     set_invalid_sha256(utils)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['stderr'][0].startswith('Error: Validating metalink'))
+    assert ret['stderr'][0].startswith('Error: Validating metalink')
     cache_dir = utils.tdnf_config.get('main', 'cachedir')
     tmp_dir = os.path.join(cache_dir, 'photon-test/tmp')
-    assert(not os.path.isdir(tmp_dir))
+    assert not os.path.isdir(tmp_dir)
 
 
 def test_invalid_sha256_valid_sha1(utils):
@@ -310,12 +310,12 @@ def test_invalid_sha256_valid_sha1(utils):
     set_invalid_sha256_length(utils)
     set_sha1(utils, True)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_invalid_sha512_valid_sha1(utils):
@@ -328,12 +328,12 @@ def test_invalid_sha512_valid_sha1(utils):
     set_invalid_sha512_length(utils)
     set_sha1(utils, True)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 def test_invalid_sha1_valid_md5(utils):
@@ -346,9 +346,9 @@ def test_invalid_sha1_valid_md5(utils):
     set_invalid_sha1_length(utils)
     set_md5(utils, True)
     ret = utils.run(['tdnf', 'makecache'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_minversions.py
+++ b/pytests/tests/test_minversions.py
@@ -64,8 +64,8 @@ def test_minversions_conf(utils):
     set_minversions_conf(utils, "{}={}".format(pkgname, utils.config["mulversion_higher"]))
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
-    assert(ret['retval'] == 1301)
-    assert('disabled' in "\n".join(ret['stderr']))
+    assert ret['retval'] == 1301
+    assert 'disabled' in "\n".join(ret['stderr'])
 
 
 def test_minversions_conf_multiple(utils):
@@ -73,8 +73,8 @@ def test_minversions_conf_multiple(utils):
     set_minversions_conf(utils, "bogus=1.2.3 {}={}".format(pkgname, utils.config["mulversion_higher"]))
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
-    assert(ret['retval'] == 1301)
-    assert('disabled' in "\n".join(ret['stderr']))
+    assert ret['retval'] == 1301
+    assert 'disabled' in "\n".join(ret['stderr'])
 
 
 def test_minversions_file(utils):
@@ -82,8 +82,8 @@ def test_minversions_file(utils):
     set_minversions_file(utils, "{}={}".format(pkgname, utils.config["mulversion_higher"]))
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
-    assert(ret['retval'] == 1301)
-    assert('disabled' in "\n".join(ret['stderr']))
+    assert ret['retval'] == 1301
+    assert 'disabled' in "\n".join(ret['stderr'])
 
 
 def test_minversions_file_multiple(utils):
@@ -91,4 +91,4 @@ def test_minversions_file_multiple(utils):
     set_minversions_file(utils, "bogus=1.2.3\n{}={}".format(pkgname, utils.config["mulversion_higher"]))
     utils.install_package(pkgname)
     ret = utils.run(['tdnf', '-y', '--nogpgcheck', 'downgrade', pkgname])
-    assert(ret['retval'] == 1301)
+    assert ret['retval'] == 1301

--- a/pytests/tests/test_noscripts.py
+++ b/pytests/tests/test_noscripts.py
@@ -24,11 +24,11 @@ def teardown_test(utils):
 def test_install_normal(utils):
     pkgname = 'tdnf-bad-pre'
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(ret['retval'] == 1525)
+    assert ret['retval'] == 1525
 
 
 def test_install_noscripts(utils):
     pkgname = 'tdnf-bad-pre'
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck',
                      '--setopt=tsflags=noscripts', pkgname])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_pluginconf.py
+++ b/pytests/tests/test_pluginconf.py
@@ -50,9 +50,9 @@ def test_plugin_conf(utils):
     enable_plugins(utils)
     ret = utils.run(['tdnf', 'repolist'])
     # should attempt a plugin load
-    assert(ret['stderr'][0].startswith('Error loading plugin'))  # nosec
+    assert ret['stderr'][0].startswith('Error loading plugin')  # nosec
     # plugin load failure should not affect command result
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # even when config file has plugins=1, --noplugins
@@ -61,9 +61,9 @@ def test_plugin_conf_override_no_plugins(utils):
     set_plugin_flag_in_conf(utils, '1')
     ret = utils.run(['tdnf', 'repolist', '--noplugins'])
     # expect no standard error lines - this corresponds to plugin load
-    assert(len(ret['stderr']) == 0)  # nosec
+    assert len(ret['stderr']) == 0  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # if plugins=0 in config, no plugins should be loaded.
@@ -71,9 +71,9 @@ def test_plugin_conf_disable_plugins_in_conf(utils):
     set_plugin_flag_in_conf(utils, '0')
     ret = utils.run(['tdnf', 'repolist'])
     # expect no standard error lines
-    assert(len(ret['stderr']) == 0)  # nosec
+    assert len(ret['stderr']) == 0  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # if all plugins are deactivated using wildcard,
@@ -82,9 +82,9 @@ def test_plugin_command_line_disable_with_glob(utils):
     set_plugin_flag_in_conf(utils, '1')
     ret = utils.run(['tdnf', 'repolist', '--disableplugin=*'])
     # expect no standard error lines - this corresponds to plugin load
-    assert(len(ret['stderr']) == 0)  # nosec
+    assert len(ret['stderr']) == 0  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # enable all plugins by command line glob
@@ -93,9 +93,9 @@ def test_plugin_command_line_enable_with_glob(utils):
     set_plugin_flag_in_conf(utils, '1')
     ret = utils.run(['tdnf', 'repolist', '--enableplugin=*'])
     # stderr should have an attempted load
-    assert(ret['stderr'][0].startswith('Error loading plugin'))  # nosec
+    assert ret['stderr'][0].startswith('Error loading plugin')  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # enable a specific plugin
@@ -104,9 +104,9 @@ def test_plugin_command_line_enable_single(utils):
     set_plugin_flag_in_conf(utils, '1')
     ret = utils.run(['tdnf', 'repolist', '--disableplugin=*', '--enableplugin=test_plugin'])
     # stderr should have an attempted load
-    assert(ret['stderr'][0].startswith('Error loading plugin'))  # nosec
+    assert ret['stderr'][0].startswith('Error loading plugin')  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # deactivate individual plugin via plugin config
@@ -116,9 +116,9 @@ def test_plugin_disable_via_plugin_config(utils):
     set_plugin_config_enabled_flag(utils, '0')
     ret = utils.run(['tdnf', 'repolist'])
     # stderr should not have an attempted load
-    assert(len(ret['stderr']) == 0)  # nosec
+    assert len(ret['stderr']) == 0  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # deactivate individual plugin via plugin config
@@ -128,6 +128,6 @@ def test_plugin_enable_disabled_plugin_via_cmdline_override(utils):
     set_plugin_config_enabled_flag(utils, '0')
     ret = utils.run(['tdnf', 'repolist', '--enableplugin=test_plugin'])
     # stderr should have an attempted load
-    assert(ret['stderr'][0].startswith('Error loading plugin'))  # nosec
+    assert ret['stderr'][0].startswith('Error loading plugin')  # nosec
     # command should pass
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec

--- a/pytests/tests/test_pretrans.py
+++ b/pytests/tests/test_pretrans.py
@@ -30,24 +30,24 @@ def remove_dummy_pretrans_dependency(utils):
 def test_install_pretrans_lessthan_fail(utils):
     remove_dummy_pretrans_dependency(utils)
     ret = utils.run(['tdnf', 'install', '-y', 'tdnf-test-pretrans-one'])
-    assert(ret['stderr'][0].startswith('Detected rpm pre-transaction dependency'))
-    assert(ret['retval'] == 1515)
+    assert ret['stderr'][0].startswith('Detected rpm pre-transaction dependency')
+    assert ret['retval'] == 1515
 
 
 def test_install_pretrans_greaterthan_fail(utils):
     remove_dummy_pretrans_dependency(utils)
     ret = utils.run(['tdnf', 'install', '-y', 'tdnf-test-pretrans-two'])
-    assert(ret['stderr'][0].startswith('Detected rpm pre-transaction dependency'))
-    assert(ret['retval'] == 1515)
+    assert ret['stderr'][0].startswith('Detected rpm pre-transaction dependency')
+    assert ret['retval'] == 1515
 
 
 def test_install_pretrans_lessthan_success(utils):
     install_dummy_pretrans_dependency(utils)
     ret = utils.run(['tdnf', 'install', '-y', 'tdnf-test-pretrans-one'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_install_pretrans_greaterthan_success(utils):
     install_dummy_pretrans_dependency(utils)
     ret = utils.run(['tdnf', 'install', '-y', 'tdnf-test-pretrans-two'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_provides.py
+++ b/pytests/tests/test_provides.py
@@ -21,14 +21,14 @@ def teardown_test(utils):
 
 def test_provides_no_arg(utils):
     ret = utils.run(['tdnf', 'provides'])
-    assert(ret['retval'] == 907)
+    assert ret['retval'] == 907
 
 
 def test_provides_valid_pkg_name(utils):
     ret = utils.run(['tdnf', 'provides', 'tdnf'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_provides_invalid_pkg_name(utils):
     ret = utils.run(['tdnf', 'provides', 'invalid_pkg_name'])
-    assert(ret['stderr'][0] == 'No data available')
+    assert ret['stderr'][0] == 'No data available'

--- a/pytests/tests/test_repo_missing_metadata.py
+++ b/pytests/tests/test_repo_missing_metadata.py
@@ -38,19 +38,19 @@ def test_repo_no_filelists(utils):
                      '--download-metadata',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
-    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
+    assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
 
     for file in ['filelists', 'filelists_db']:
         ret = utils.run(['modifyrepo', '--remove', file, os.path.join(synced_dir, 'repodata')])
-        assert(ret['retval'] == 0)
+        assert ret['retval'] == 0
 
     ret = utils.run(['tdnf',
                      '--repofrompath=synced-repo,{}'.format(synced_dir),
                      '--repo=synced-repo',
                      'makecache'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_repofrompath.py
+++ b/pytests/tests/test_repofrompath.py
@@ -42,18 +42,18 @@ def test_repofrompath_created_repo(utils):
                      '--download-metadata',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
-    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
+    assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
 
     ret = utils.run(['tdnf',
                      '--repofrompath=synced-repo,{}'.format(synced_dir),
                      '--repo=synced-repo',
                      'makecache'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
@@ -63,5 +63,5 @@ def test_repofrompath_created_repo(utils):
                      '--repo=synced-repo',
                      'install', pkgname],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_repogpgcheck.py
+++ b/pytests/tests/test_repogpgcheck.py
@@ -64,9 +64,9 @@ def test_tdnfrepogpgcheck_plugin_load(utils):
     enable_plugins(utils)
     ret = utils.run(['tdnf', 'repolist'])
     # we should load the plugin
-    assert(ret['stdout'][0].startswith('Loaded plugin: tdnfrepogpgcheck'))  # nosec
+    assert ret['stdout'][0].startswith('Loaded plugin: tdnfrepogpgcheck')  # nosec
     # we should also pass the repolist command
-    assert(ret['retval'] == 0)  # nosec
+    assert ret['retval'] == 0  # nosec
 
 
 # make sure libtdnfrepogpgcheck.so is used to validate repo signature
@@ -74,5 +74,5 @@ def test_tdnfrepogpgcheck_plugin_validatesignature(utils):
     set_repo_flag_repo_gpgcheck(utils, "1")
     ret = utils.run(['tdnf', 'repolist', '--refresh'])
     # we should load the plugin
-    assert(ret['stdout'][0].startswith('Loaded plugin: tdnfrepogpgcheck'))  # nosec
-    assert(ret['retval'] == 0)
+    assert ret['stdout'][0].startswith('Loaded plugin: tdnfrepogpgcheck')  # nosec
+    assert ret['retval'] == 0

--- a/pytests/tests/test_repoid.py
+++ b/pytests/tests/test_repoid.py
@@ -41,8 +41,8 @@ def test_repoid(utils):
                      '--setopt=reposdir={}'.format(REPODIR),
                      '--repoid={}'.format(REPONAME),
                      'repolist'])
-    assert(ret['retval'] == 0)
-    assert(REPONAME in "\n".join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert REPONAME in "\n".join(ret['stdout'])
 
 
 # reposync a repo and install from it
@@ -55,11 +55,11 @@ def test_repoid_created_repo(utils):
                      '--download-metadata',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
-    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
+    assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
 
     filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
     baseurl = "file://{}".format(synced_dir)
@@ -70,7 +70,7 @@ def test_repoid_created_repo(utils):
                      '--repo=synced-repo',
                      'makecache'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
@@ -79,5 +79,5 @@ def test_repoid_created_repo(utils):
                      '--repo=synced-repo',
                      'install', pkgname],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_repolist.py
+++ b/pytests/tests/test_repolist.py
@@ -21,30 +21,30 @@ def teardown_test(utils):
 
 def test_repolist(utils):
     ret = utils.run(['tdnf', 'repolist'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_repolist_all(utils):
     ret = utils.run(['tdnf', 'repolist', 'all'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_repolist_enabled(utils):
     ret = utils.run(['tdnf', 'repolist', 'enabled'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_repolist_disabled(utils):
     ret = utils.run(['tdnf', 'repolist', 'disabled'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_repolist_invalid(utils):
     ret = utils.run(['tdnf', 'repolist', 'invalid_repo'])
-    assert(ret['retval'] == 901)
+    assert ret['retval'] == 901
 
 
 # memcheck
 def test_repolist_memcheck(utils):
     ret = utils.run_memcheck(['tdnf', 'repolist'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_repoquery.py
+++ b/pytests/tests/test_repoquery.py
@@ -28,10 +28,10 @@ def test_whatdepends(utils):
                      'repoquery',
                      '--whatdepends',
                      BASE_PKG])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     for d in ['enhances', 'recommends', 'requires', 'suggests', 'supplements']:
-        assert('tdnf-repoquery-{}'.format(d) in '\n'.join(ret['stdout']))
+        assert 'tdnf-repoquery-{}'.format(d) in '\n'.join(ret['stdout'])
 
 
 # repoquery should list the package that has a specific
@@ -46,8 +46,8 @@ def test_what_alldeps(utils):
                          '--what{}'.format(dep),
                          BASE_PKG
                          ])
-        assert(ret['retval'] == 0)
-        assert('tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout']))
+        assert ret['retval'] == 0
+        assert 'tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout'])
 
 
 # repoquery should list the package that requires BASE_PKG
@@ -60,8 +60,8 @@ def test_what_2(utils):
                      '--whatrequires',
                      "{},{}".format('doesnotexist', BASE_PKG)
                      ])
-    assert(ret['retval'] == 0)
-    assert('tdnf-repoquery-requires' in '\n'.join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert 'tdnf-repoquery-requires' in '\n'.join(ret['stdout'])
 
 
 # packages should have specified relation to BASE_PKG
@@ -75,8 +75,8 @@ def test_alldeps(utils):
                          '--{}'.format(dep),
                          'tdnf-repoquery-{}'.format(dep)
                          ])
-        assert(ret['retval'] == 0)
-        assert(BASE_PKG in '\n'.join(ret['stdout']))
+        assert ret['retval'] == 0
+        assert BASE_PKG in '\n'.join(ret['stdout'])
 
 
 # all these packages depend on BASE_PKG
@@ -86,8 +86,8 @@ def test_depends(utils):
                          'repoquery',
                          '--depends',
                          'tdnf-repoquery-{}'.format(dep)])
-        assert(ret['retval'] == 0)
-        assert(BASE_PKG in '\n'.join(ret['stdout']))
+        assert ret['retval'] == 0
+        assert BASE_PKG in '\n'.join(ret['stdout'])
 
 
 # each package has a file with its name
@@ -101,8 +101,8 @@ def test_list(utils):
                          '--list',
                          'tdnf-repoquery-{}'.format(dep)
                          ])
-        assert(ret['retval'] == 0)
-        assert('/usr/lib/repoquery/tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout']))
+        assert ret['retval'] == 0
+        assert '/usr/lib/repoquery/tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout'])
 
 
 # like test_list(), but the other way around
@@ -116,39 +116,39 @@ def test_file(utils):
                          '--file',
                          '/usr/lib/repoquery/tdnf-repoquery-{}'.format(dep)
                          ])
-        assert(ret['retval'] == 0)
-        assert('tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout']))
+        assert ret['retval'] == 0
+        assert 'tdnf-repoquery-{}'.format(dep) in '\n'.join(ret['stdout'])
 
 
 def test_available(utils):
     ret = utils.run(['tdnf',
                      'repoquery',
                      '--available'])
-    assert(ret['retval'] == 0)
-    assert(BASE_PKG in '\n'.join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert BASE_PKG in '\n'.join(ret['stdout'])
 
 
 def test_installed(utils):
     ret = utils.run(['tdnf',
                      'install', '-y', '--nogpgcheck',
                      BASE_PKG])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf',
                      'repoquery',
                      '--installed'])
-    assert(ret['retval'] == 0)
-    assert(BASE_PKG in '\n'.join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert BASE_PKG in '\n'.join(ret['stdout'])
 
 
 def test_extras(utils):
     ret = utils.run(['tdnf',
                      'repoquery',
                      '--extras'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     # we are using just the 'photon-test repo,
     # so any real system package is 'extra'
-    assert('glibc' in '\n'.join(ret['stdout']))
+    assert 'glibc' in '\n'.join(ret['stdout'])
 
 
 def test_upgrades(utils):
@@ -158,13 +158,13 @@ def test_upgrades(utils):
     ret = utils.run(['tdnf',
                      'install', '-y', '--nogpgcheck',
                      pkg_low])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf',
                      'repoquery',
                      '--upgrades'])
-    assert(ret['retval'] == 0)
-    assert(pkg_high in '\n'.join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert pkg_high in '\n'.join(ret['stdout'])
 
 
 def test_changelog(utils):
@@ -172,13 +172,13 @@ def test_changelog(utils):
                      'repoquery',
                      '--changelogs',
                      'tdnf-repoquery-changelog'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     # tests changelog text, author and date
     output = '\n'.join(ret['stdout'])
-    assert("needle in a haystack" in output)
-    assert("John Doe" in output)
-    assert("Wed Jan 01 2020" in output)
+    assert "needle in a haystack" in output
+    assert "John Doe" in output
+    assert "Wed Jan 01 2020" in output
 
 
 def test_source(utils):
@@ -190,11 +190,11 @@ def test_source(utils):
                      'repoquery',
                      '--source',
                      pkgname])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     output = '\n'.join(ret['stdout'])
-    assert(pkgname in output)
-    assert('src' in output)
-    assert('x86_64' not in output)
+    assert pkgname in output
+    assert 'src' in output
+    assert 'x86_64' not in output
 
 
 # each package has a file with its name
@@ -205,7 +205,7 @@ def test_list1(utils):
                               '--list',
                               'tdnf-repoquery-{}'.format(dep)
                               ])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 # fail with ore than one pkg spec
@@ -214,7 +214,7 @@ def test_two_args(utils):
                      'repoquery',
                      'foo',
                      'bar'])
-    assert(ret['retval'] == 902)
+    assert ret['retval'] == 902
 
 
 def test_userinstalled(utils):
@@ -222,10 +222,10 @@ def test_userinstalled(utils):
     utils.install_package(pkgname)
 
     ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
-    assert(pkgname in "\n".join(ret['stdout']))
+    assert pkgname in "\n".join(ret['stdout'])
 
     ret = utils.run(['tdnf', 'mark', 'remove', pkgname])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
-    assert(pkgname not in "\n".join(ret['stdout']))
+    assert pkgname not in "\n".join(ret['stdout'])

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -53,10 +53,10 @@ def check_synced_repo(utils, reponame, synced_dir):
                     os.listdir(local_dir)))
 
     # make sure we aren't confused which directory to check
-    assert(len(local_rpms) > 0)
+    assert len(local_rpms) > 0
 
     for rpm in local_rpms:
-        assert(os.path.isfile(os.path.join(synced_dir, 'RPMS', ARCH, rpm)))
+        assert os.path.isfile(os.path.join(synced_dir, 'RPMS', ARCH, rpm))
 
 
 # reposync with no options - sync to local directory
@@ -69,9 +69,9 @@ def test_reposync(utils):
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
@@ -83,13 +83,13 @@ def test_reposync_download_path(utils):
     reponame = TESTREPO
     downloaddir = DOWNLOADDIR
     utils.makedirs(downloaddir)
-    assert(os.path.isdir(downloaddir))
+    assert os.path.isdir(downloaddir)
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-path={}'.format(downloaddir),
                      'reposync'])
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(os.path.join(downloaddir, reponame)))
+    assert ret['retval'] == 0
+    assert os.path.isdir(os.path.join(downloaddir, reponame))
 
     check_synced_repo(utils, reponame, os.path.join(downloaddir, reponame))
 
@@ -100,13 +100,13 @@ def test_reposync_download_path_slash(utils):
     reponame = TESTREPO
     downloaddir = DOWNLOADDIR + '/'
     utils.makedirs(downloaddir)
-    assert(os.path.isdir(downloaddir))
+    assert os.path.isdir(downloaddir)
 
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-path={}'.format(downloaddir),
                      'reposync'])
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(os.path.join(downloaddir, reponame)))
+    assert ret['retval'] == 0
+    assert os.path.isdir(os.path.join(downloaddir, reponame))
 
     check_synced_repo(utils, reponame, os.path.join(downloaddir, reponame))
 
@@ -119,8 +119,8 @@ def test_reposync_download_path_root(utils):
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--download-path={}'.format(downloaddir),
                      'reposync'])
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(os.path.join(downloaddir, reponame)))
+    assert ret['retval'] == 0
+    assert os.path.isdir(os.path.join(downloaddir, reponame))
 
     check_synced_repo(utils, reponame, os.path.join(downloaddir, reponame))
 
@@ -133,8 +133,8 @@ def test_reposync_workdir_root(utils):
     ret = utils.run(['tdnf', '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(os.path.join(workdir, reponame)))
+    assert ret['retval'] == 0
+    assert os.path.isdir(os.path.join(workdir, reponame))
 
     check_synced_repo(utils, reponame, os.path.join(workdir, reponame))
 
@@ -148,8 +148,8 @@ def test_reposync_download_path_norepopath(utils):
                      '--download-path={}'.format(downloaddir),
                      '--norepopath',
                      'reposync'])
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(downloaddir))
+    assert ret['retval'] == 0
+    assert os.path.isdir(downloaddir)
 
     check_synced_repo(utils, reponame, downloaddir)
 
@@ -164,7 +164,7 @@ def test_reposync_download_path_norepopath_delete(utils):
                      '--norepopath',
                      '--delete',
                      'reposync'])
-    assert(ret['retval'] == 1622)
+    assert ret['retval'] == 1622
 
 
 # reposync excluding the repo name and multiple repos is incompatible
@@ -174,7 +174,7 @@ def xxxtest_reposync_download_path_norepopath_multiple_repos(utils):
                      '--download-path={}'.format(downloaddir),
                      '--norepopath',
                      'reposync'])
-    assert(ret['retval'] == 1622)
+    assert ret['retval'] == 1622
 
 
 # reposync with metadata
@@ -187,11 +187,11 @@ def test_reposync_metadata(utils):
                      '--download-metadata',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
-    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
+    assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
 
     check_synced_repo(utils, reponame, synced_dir)
 
@@ -211,10 +211,10 @@ def test_reposync_metadata_path(utils):
                      '--metadata-path={}'.format(mdatadir),
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isfile(os.path.join(mdatadir, reponame, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isfile(os.path.join(mdatadir, reponame, 'repodata', 'repomd.xml'))
 
     check_synced_repo(utils, reponame, synced_dir)
 
@@ -234,20 +234,20 @@ def test_reposync_delete(utils):
     with open(faked_rpm, 'w') as f:
         f.write('fake package')
 
-    assert(os.path.isfile(faked_rpm))
+    assert os.path.isfile(faked_rpm)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      '--delete',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(synced_dir))
+    assert ret['retval'] == 0
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
     # file should be gone
-    assert(not os.path.isfile(faked_rpm))
+    assert not os.path.isfile(faked_rpm)
 
     shutil.rmtree(synced_dir)
 
@@ -265,19 +265,19 @@ def test_reposync_no_delete(utils):
     with open(faked_rpm, 'w') as f:
         f.write('fake package')
 
-    assert(os.path.isfile(faked_rpm))
+    assert os.path.isfile(faked_rpm)
 
     ret = utils.run(['tdnf',
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(synced_dir))
+    assert ret['retval'] == 0
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
     # file should still be there
-    assert(os.path.isfile(faked_rpm))
+    assert os.path.isfile(faked_rpm)
 
     shutil.rmtree(synced_dir)
 
@@ -293,9 +293,9 @@ def test_reposync_gpgcheck(utils):
                      '--gpgcheck',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
@@ -313,9 +313,9 @@ def test_reposync_urls(utils):
                      '--urls',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(not os.path.isdir(synced_dir))
+    assert not os.path.isdir(synced_dir)
 
 
 # reposync a repo and install from it
@@ -328,11 +328,11 @@ def test_reposync_create_repo(utils):
                      '--download-metadata',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
-    assert(os.path.isdir(os.path.join(synced_dir, 'repodata')))
-    assert(os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml')))
+    assert os.path.isdir(synced_dir)
+    assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
+    assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
 
     check_synced_repo(utils, reponame, synced_dir)
 
@@ -345,7 +345,7 @@ def test_reposync_create_repo(utils):
                      '--disablerepo=*', '--enablerepo=synced-repo',
                      'makecache'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     pkgname = utils.config["mulversion_pkgname"]
     utils.erase_package(pkgname)
@@ -354,7 +354,7 @@ def test_reposync_create_repo(utils):
                      '--disablerepo=*', '--enablerepo=synced-repo',
                      'install', pkgname],
                     cwd=workdir)
-    assert(utils.check_package(pkgname))
+    assert utils.check_package(pkgname)
 
 
 # reposync with arch option should not sync other archs
@@ -372,12 +372,12 @@ def test_reposync_arch(utils):
                      '--arch', ARCH,
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(synced_dir))
+    assert ret['retval'] == 0
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
-    assert(not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch')))
+    assert not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch'))
     shutil.rmtree(synced_dir)
 
 
@@ -399,12 +399,12 @@ def test_reposync_arch_others(utils):
                      '--arch', ARCH,
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
-    assert(os.path.isdir(synced_dir))
+    assert ret['retval'] == 0
+    assert os.path.isdir(synced_dir)
 
     check_synced_repo(utils, reponame, synced_dir)
 
-    assert(not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch')))
+    assert not os.path.isdir(os.path.join(synced_dir, 'RPMS', 'noarch'))
     shutil.rmtree(synced_dir)
 
 
@@ -419,16 +419,16 @@ def test_reposync_newest(utils):
                      '--newest-only',
                      'reposync'],
                     cwd=workdir)
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     synced_dir = os.path.join(workdir, reponame)
-    assert(os.path.isdir(synced_dir))
+    assert os.path.isdir(synced_dir)
 
     mulversion_pkgname_found = False
     for f in os.listdir(os.path.join(synced_dir, 'RPMS', ARCH)):
         if f.startswith(utils.config['mulversion_pkgname']):
-            assert(not utils.config['mulversion_lower'] in f)
+            assert not utils.config['mulversion_lower'] in f
             mulversion_pkgname_found = True
 
-    assert(mulversion_pkgname_found)
+    assert mulversion_pkgname_found
 
     shutil.rmtree(synced_dir)

--- a/pytests/tests/test_rpm_cmdline.py
+++ b/pytests/tests/test_rpm_cmdline.py
@@ -58,8 +58,8 @@ def test_install_as_file(utils):
     pkgname = utils.config["sglversion_pkgname"]
     path = get_pkg_file_path(utils, pkgname)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install ../path/to/pkg.rpm" (relative path)
@@ -76,8 +76,8 @@ def test_install_as_file_relpath1(utils):
     cwd = os.getcwd()
     os.chdir(tmpdir)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', relpath])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
     os.chdir(cwd)
     shutil.rmtree(tmpdir)
 
@@ -87,8 +87,8 @@ def test_install_as_file_with_doubledots(utils):
     pkgname = utils.config["sglversion_pkgname"]
     path = get_pkg_file_path_with_doubledots(utils, pkgname)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install pkg.rpm"
@@ -96,8 +96,8 @@ def test_install_as_file_relpath2(utils):
     pkgname = utils.config["sglversion_pkgname"]
     path = os.path.relpath(get_pkg_file_path(utils, pkgname))
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install file:///path/to/pkg.rpm"
@@ -106,8 +106,8 @@ def test_install_as_file_uri(utils):
     path = get_pkg_file_path(utils, pkgname)
     uri = 'file://{}'.format(path)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', uri])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install http://server.com/path/to/pkg.rpm"
@@ -115,8 +115,8 @@ def test_install_remote(utils):
     pkgname = utils.config["sglversion_pkgname"]
     uri = get_pkg_remote_url(utils, pkgname)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', uri])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install http://server.com/otherpath/../path/to/pkg.rpm"
@@ -124,8 +124,8 @@ def test_install_remote_with_doubledots(utils):
     pkgname = utils.config["sglversion_pkgname"]
     uri = get_pkg_remote_url_with_doubledots(utils, pkgname)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', uri])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test something like "tdnf install http://server.com/path/to/pkg.rpm",
@@ -133,7 +133,7 @@ def test_install_remote_with_doubledots(utils):
 def test_install_remote_notfound(utils):
     uri = 'http://localhost:8080/doesnotexist.rpm'
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', uri])
-    assert(ret['retval'] == 1622)
+    assert ret['retval'] == 1622
 
 
 # test something like "tdnf install /path/to/pkg.rpm otherpkg"
@@ -142,9 +142,9 @@ def test_install_as_mixed(utils):
     pkgname2 = utils.config["sglversion2_pkgname"]
     path = get_pkg_file_path(utils, pkgname)
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path, pkgname2])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
-    assert(utils.check_package(pkgname2))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+    assert utils.check_package(pkgname2)
 
 
 # test installing a package that has the same name as a file
@@ -154,8 +154,8 @@ def test_install_same_as_filname(utils):
     pkgname = utils.config["sglversion_pkgname"]
     utils.run(['touch', pkgname])
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # test "tdnf reinstall /path/to/pkg.rpm". See PR #300.
@@ -165,12 +165,12 @@ def test_reinstall_as_file(utils):
 
     # prepare by installing package
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
     # actual test
     ret = utils.run(['tdnf', 'reinstall', '-y', '--nogpgcheck', path])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
-    assert("Nothing to do" not in "\n".join(ret['stderr']))
-    assert("Reinstalling" in "\n".join(ret['stdout']))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+    assert "Nothing to do" not in "\n".join(ret['stderr'])
+    assert "Reinstalling" in "\n".join(ret['stdout'])

--- a/pytests/tests/test_search.py
+++ b/pytests/tests/test_search.py
@@ -21,19 +21,19 @@ def teardown_test(utils):
 
 def test_search_no_arg(utils):
     ret = utils.run(['tdnf', 'search'])
-    assert(ret['retval'] == 1599)
+    assert ret['retval'] == 1599
 
 
 def test_search_invalid_arg(utils):
     ret = utils.run(['tdnf', 'search', 'invalid_arg'])
-    assert(ret['retval'] == 1599)
+    assert ret['retval'] == 1599
 
 
 def test_search_single(utils):
     ret = utils.run(['tdnf', 'search', 'tdnf'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
 
 def test_search_multiple(utils):
     ret = utils.run(['tdnf', 'search', 'tdnf', 'wget', 'gzip'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_setopt_reposdir.py
+++ b/pytests/tests/test_setopt_reposdir.py
@@ -32,4 +32,4 @@ def test_setopt_reposdir(utils):
                           "http://foo.bar.com/packages",
                           REPONAME)
     ret = utils.run(['tdnf', '--setopt=reposdir={}'.format(REPODIR), 'repolist'])
-    assert(REPONAME in "\n".join(ret['stdout']))
+    assert REPONAME in "\n".join(ret['stdout'])

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -52,8 +52,8 @@ def test_install_skipsignature(utils):
     set_repo_key(utils, DEFAULT_KEY)
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', '--skipsignature', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # import key prior to install, expect success
@@ -64,8 +64,8 @@ def test_install_with_key(utils):
     utils.run(['rpm', '--import', keypath])
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # import local, correct key during install from repo config, expect success
@@ -75,8 +75,8 @@ def test_install_local_key(utils):
     set_repo_key(utils, 'file://{}'.format(keypath))
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # import remote, correct key during install from repo config, expect success
@@ -85,8 +85,8 @@ def test_install_remote_key(utils):
     set_repo_key(utils, 'http://localhost:8080/photon-test/keys/pubkey.asc')
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # -v (verbose) prints progress data
@@ -95,8 +95,8 @@ def test_install_remote_key_verbose(utils):
     set_repo_key(utils, 'http://localhost:8080/photon-test/keys/pubkey.asc')
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-v', '-y', pkgname])
-    assert(ret['retval'] == 0)
-    assert(utils.check_package(pkgname))
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # import remote key with url containing a directory traversal, expect fail
@@ -105,7 +105,7 @@ def test_install_remote_key_no_traversal(utils):
     set_repo_key(utils, 'http://localhost:8080/../photon-test/keys/pubkey.asc')
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] != 0)
+    assert ret['retval'] != 0
 
 
 # import remote key with url containing a directory traversal, expect fail
@@ -114,7 +114,7 @@ def test_install_remote_key_no_traversal2(utils):
     set_repo_key(utils, 'http://localhost:8080/photon-test/keys/../../../pubkey.asc')
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] != 0)
+    assert ret['retval'] != 0
 
 
 # test with gpgcheck enabled but no key entry, expect fail
@@ -123,8 +123,8 @@ def test_install_nokey(utils):
     set_repo_key(utils, None)
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] == 1523)
-    assert(not utils.check_package(pkgname))
+    assert ret['retval'] == 1523
+    assert not utils.check_package(pkgname)
 
 
 # 'wrong' key in repo config, expect fail
@@ -133,5 +133,5 @@ def test_install_nokey1(utils):
     set_repo_key(utils, DEFAULT_KEY)
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
-    assert(ret['retval'] == 1514)
-    assert(not utils.check_package(pkgname))
+    assert ret['retval'] == 1514
+    assert not utils.check_package(pkgname)

--- a/pytests/tests/test_skip_md.py
+++ b/pytests/tests/test_skip_md.py
@@ -77,7 +77,7 @@ def check_skip_md_part(utils, mdpart, skipped):
     utils.run(['tdnf', '--repoid={}'.format(REPOID), 'makecache'])
 
     md_dir = os.path.join(find_cache_dir(utils, REPOID), 'repodata')
-    assert((len(glob.glob('{}/*{}*'.format(md_dir, mdpart))) == 0) == skipped)
+    assert (len(glob.glob('{}/*{}*'.format(md_dir, mdpart))) == 0) == skipped
 
 
 def test_skip_md_parts(utils):
@@ -96,12 +96,12 @@ def test_install_conflict_file(utils):
 
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'install', '-y', '--nogpgcheck', pkg0])
     print(ret)
-    assert(utils.check_package(pkg0))
+    assert utils.check_package(pkg0)
 
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'install', '-y', '--nogpgcheck', pkg1])
     print(ret)
-    assert(ret['retval'] == 1525)
-    assert(not utils.check_package(pkg1))
+    assert ret['retval'] == 1525
+    assert not utils.check_package(pkg1)
 
 
 def test_install_conflict_file_atonce(utils):
@@ -110,6 +110,6 @@ def test_install_conflict_file_atonce(utils):
 
     ret = utils.run(['tdnf', '--repoid={}'.format(REPOID), 'install', '-y', '--nogpgcheck', pkg0, pkg1])
     print(ret)
-    assert(ret['retval'] == 1525)
-    assert(not utils.check_package(pkg0))
-    assert(not utils.check_package(pkg1))
+    assert ret['retval'] == 1525
+    assert not utils.check_package(pkg0)
+    assert not utils.check_package(pkg1)

--- a/pytests/tests/test_tdnf_automatic.py
+++ b/pytests/tests/test_tdnf_automatic.py
@@ -99,7 +99,7 @@ def prepare_and_run_test_cmd(utils, opt, retval, retstr=''):
     if '-c' not in opt and '--config' not in opt:
         tmp += ['-c', tmp_auto_conf]
     ret = run_test_cmd(utils, tmp + opt)
-    assert(ret['retval'] == retval)
+    assert ret['retval'] == retval
 
     if not retstr:
         return 0
@@ -112,7 +112,7 @@ def prepare_and_run_test_cmd(utils, opt, retval, retstr=''):
             found = True
             break
 
-    assert(found)
+    assert found
 
 
 def test_tdnf_automatic_show_help(utils):
@@ -205,7 +205,7 @@ def test_emit_to_file(utils):
     set_base_conf_and_store(tmp_auto_conf)
     prepare_and_run_test_cmd(utils, [], 0)
     with open(emit_file) as f:
-        assert('System upto date' in f.read())
+        assert 'System upto date' in f.read()
 
     prepare_and_run_test_cmd(utils, [], 0)
     glob.glob(emit_file + '*.bak')
@@ -225,7 +225,7 @@ def test_tdnf_automatic_show_updates(utils):
     set_base_conf_and_store(tmp_auto_conf)
     prepare_and_run_test_cmd(utils, [], 0, 'The following updates are available on')
     with open(emit_file) as f:
-        assert(pkgname in f.read())
+        assert pkgname in f.read()
 
 
 def test_tdnf_automatic_apply_updates(utils):
@@ -242,7 +242,7 @@ def test_tdnf_automatic_apply_updates(utils):
     set_base_conf_and_store(tmp_auto_conf)
     prepare_and_run_test_cmd(utils, [], 0, 'The following updates are applied on')
     with open(emit_file) as f:
-        assert(pkgname in f.read())
+        assert pkgname in f.read()
 
 
 def test_tdnf_automatic_same_show_apply_updates(utils):
@@ -257,12 +257,12 @@ def test_tdnf_automatic_same_show_apply_updates(utils):
     ini_set('commands', 'apply_updates', 'yes')
     set_base_conf_and_store(tmp_auto_conf)
     prepare_and_run_test_cmd(utils, [], 0, 'The following updates are available on')
-    assert(not os.path.isfile(emit_file))
+    assert not os.path.isfile(emit_file)
     ini_set('commands', 'show_updates', 'no')
     ini_set('commands', 'apply_updates', 'no')
     set_base_conf_and_store(tmp_auto_conf)
     prepare_and_run_test_cmd(utils, [], 0, 'The following updates are available on')
-    assert(not os.path.isfile(emit_file))
+    assert not os.path.isfile(emit_file)
 
 
 def test_tdnf_automatic_hostname(utils):
@@ -279,4 +279,4 @@ def test_tdnf_automatic_hostname(utils):
         set_base_conf_and_store(tmp_auto_conf)
         prepare_and_run_test_cmd(utils, [], 0, 'The following updates are available on - ' + i)
         with open(emit_file) as f:
-            assert(i in f.read())
+            assert i in f.read()

--- a/pytests/tests/test_tdnf_python.py
+++ b/pytests/tests/test_tdnf_python.py
@@ -42,8 +42,8 @@ def setup_test(utils):
 def teardown_test(utils):
     utils.run(['tdnf', 'erase', '-y', sglpkgname])
     utils.run(['tdnf', 'erase', '-y', mulpkgname])
-    assert(not utils.check_package(sglpkgname))
-    assert(not utils.check_package(mulpkgname))
+    assert not utils.check_package(sglpkgname)
+    assert not utils.check_package(mulpkgname)
 
 
 def tdnf_py_erase(pkgs, quiet=False, refresh=False, cfg=None):
@@ -94,77 +94,77 @@ def test_tdnf_python_install_single(utils):
     pkgs = [sglpkgname]
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
+    assert not utils.check_package(sglpkgname)
     tdnf_py_install(pkgs=pkgs)
-    assert(utils.check_package(sglpkgname))
+    assert utils.check_package(sglpkgname)
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
+    assert not utils.check_package(sglpkgname)
     tdnf_py_install(pkgs=pkgs, refresh=True)
-    assert(utils.check_package(sglpkgname))
+    assert utils.check_package(sglpkgname)
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
+    assert not utils.check_package(sglpkgname)
     tdnf_py_install(pkgs=pkgs, refresh=True, quiet=True)
-    assert(utils.check_package(sglpkgname))
+    assert utils.check_package(sglpkgname)
 
 
 def test_tdnf_python_install_multiple(utils):
     pkgs = [sglpkgname, mulpkgname]
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
-    assert(not utils.check_package(mulpkgname))
+    assert not utils.check_package(sglpkgname)
+    assert not utils.check_package(mulpkgname)
     tdnf_py_install(pkgs=pkgs)
-    assert(utils.check_package(sglpkgname))
-    assert(utils.check_package(mulpkgname))
+    assert utils.check_package(sglpkgname)
+    assert utils.check_package(mulpkgname)
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
-    assert(not utils.check_package(mulpkgname))
+    assert not utils.check_package(sglpkgname)
+    assert not utils.check_package(mulpkgname)
     tdnf_py_install(pkgs=pkgs, refresh=True)
-    assert(utils.check_package(sglpkgname))
-    assert(utils.check_package(mulpkgname))
+    assert utils.check_package(sglpkgname)
+    assert utils.check_package(mulpkgname)
 
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
-    assert(not utils.check_package(mulpkgname))
+    assert not utils.check_package(sglpkgname)
+    assert not utils.check_package(mulpkgname)
     tdnf_py_install(pkgs=pkgs, refresh=True, quiet=True)
-    assert(utils.check_package(sglpkgname))
-    assert(utils.check_package(mulpkgname))
+    assert utils.check_package(sglpkgname)
+    assert utils.check_package(mulpkgname)
 
 
 def test_tdnf_python_erase_single(utils):
     pkgs = [sglpkgname]
 
     tdnf_py_install(pkgs=pkgs)
-    assert(utils.check_package(sglpkgname))
+    assert utils.check_package(sglpkgname)
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
+    assert not utils.check_package(sglpkgname)
 
 
 def test_tdnf_python_erase_multiple(utils):
     pkgs = [sglpkgname, mulpkgname]
 
     tdnf_py_install(pkgs=pkgs)
-    assert(utils.check_package(sglpkgname))
-    assert(utils.check_package(mulpkgname))
+    assert utils.check_package(sglpkgname)
+    assert utils.check_package(mulpkgname)
     tdnf_py_erase(pkgs=pkgs)
-    assert(not utils.check_package(sglpkgname))
-    assert(not utils.check_package(mulpkgname))
+    assert not utils.check_package(sglpkgname)
+    assert not utils.check_package(mulpkgname)
 
 
 def check_repodata(data, filter=0):
     if filter != 2:
-        assert(data.enabled == 1)
-        assert(data.name.decode('utf-8') == 'basic')
-        assert(data.id.decode('utf-8') == 'photon-test')
-        assert(data.baseurl.decode('utf-8') == 'http://localhost:8080/photon-test')
+        assert data.enabled == 1
+        assert data.name.decode('utf-8') == 'basic'
+        assert data.id.decode('utf-8') == 'photon-test'
+        assert data.baseurl.decode('utf-8') == 'http://localhost:8080/photon-test'
     else:
-        assert(data.enabled == 0)
-        assert(data.name.decode('utf-8') == '@cmdline')
-        assert(data.id.decode('utf-8') == '@cmdline')
-        assert(not hasattr(data, 'baseurl'))
+        assert data.enabled == 0
+        assert data.name.decode('utf-8') == '@cmdline'
+        assert data.id.decode('utf-8') == '@cmdline'
+        assert not hasattr(data, 'baseurl')
 
 
 def test_tdnf_python_repolist(utils):
@@ -224,6 +224,6 @@ def test_tdnf_python_distro_sync(utils):
 
 
 def test_tdnf_python_repofilter(utils):
-    assert(tdnf.REPOLISTFILTER_ALL == 0)
-    assert(tdnf.REPOLISTFILTER_ENABLED == 1)
-    assert(tdnf.REPOLISTFILTER_DISABLED == 2)
+    assert tdnf.REPOLISTFILTER_ALL == 0
+    assert tdnf.REPOLISTFILTER_ENABLED == 1
+    assert tdnf.REPOLISTFILTER_DISABLED == 2

--- a/pytests/tests/test_update.py
+++ b/pytests/tests/test_update.py
@@ -23,7 +23,7 @@ def teardown_test(utils):
 
 def test_update_invalid_arg(utils):
     ret = utils.run(['tdnf', 'update', '-y', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_update_single_version_package(utils):
@@ -31,7 +31,7 @@ def test_update_single_version_package(utils):
     if not utils.check_package(spkg):
         utils.install_package(spkg)
     ret = utils.run(['tdnf', 'update', '-y', spkg])
-    assert(ret['stderr'][0] == 'Nothing to do.')
+    assert ret['stderr'][0] == 'Nothing to do.'
 
 
 def test_update_multi_version_package(utils):
@@ -46,8 +46,8 @@ def test_update_multi_version_package(utils):
 
     # perform an upgrade
     ret = utils.run(['tdnf', 'update', '-y', '--nogpgcheck', mpkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     # Verify that it cannot be further upgraded
     ret = utils.run(['tdnf', 'update', '-y', mpkg])
-    assert(ret['stderr'][0] == 'Nothing to do.')
+    assert ret['stderr'][0] == 'Nothing to do.'

--- a/pytests/tests/test_updateinfo.py
+++ b/pytests/tests/test_updateinfo.py
@@ -23,30 +23,30 @@ def teardown_test(utils):
 
 def helper_test_updateinfo_sub_cmd(utils, sub_cmd):
     ret = utils.run(['tdnf', 'updateinfo', sub_cmd])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'updateinfo', sub_cmd, utils.config["sglversion_pkgname"]])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'updateinfo', sub_cmd, 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_updateinfo_top(utils):
     spkg = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     ret = utils.run(['tdnf', 'updateinfo'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'updateinfo', utils.config["sglversion_pkgname"]])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
     ret = utils.run(['tdnf', 'updateinfo', 'invalid_package'])
-    assert(ret['retval'] == 1011)
+    assert ret['retval'] == 1011
 
 
 def test_updateinfo_sub_cmd(utils):
     spkg = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', spkg])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     for arg in ['all', 'installed', 'available', 'obsoletes', 'extras', 'recent',
                 'summary', 'list', 'info']:
@@ -60,16 +60,16 @@ def test_updateinfo_notinstalled(utils):
     spkg = utils.config["sglversion_pkgname"]
 
     ret = utils.run(['tdnf', 'updateinfo', 'upgrades'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', mpkg + '-' + mpkg_version])
     ret = utils.run(['tdnf', 'updateinfo', 'upgrades', mpkg])
-    assert(len(ret['stdout']) == 1)
+    assert len(ret['stdout']) == 1
 
     for cmd in ['updates', 'upgrades', 'downgrades', '--updates', '--upgrades', '--downgrades']:
         ret = utils.run(['tdnf', 'updateinfo', cmd, 'invalid_package'])
-        assert(ret['retval'] == 1011)
+        assert ret['retval'] == 1011
 
         # spkg is not installed, expect error
         ret = utils.run(['tdnf', 'updateinfo', cmd, spkg])
-        assert(ret['retval'] == 1011)
+        assert ret['retval'] == 1011

--- a/pytests/tests/test_version.py
+++ b/pytests/tests/test_version.py
@@ -23,11 +23,11 @@ def test_version(utils):
     expected_version_string = utils.config['project_name'] + ': ' + \
         utils.config['project_version']
     ret = utils.run(['tdnf', '--version'])
-    assert(ret['retval'] == 0)
-    assert(ret['stdout'][0] == expected_version_string)
+    assert ret['retval'] == 0
+    assert ret['stdout'][0] == expected_version_string
 
 
 # memcheck
 def test_version_memcheck(utils):
     ret = utils.run_memcheck(['tdnf', '--version'])
-    assert(ret['retval'] == 0)
+    assert ret['retval'] == 0

--- a/pytests/tests/test_whatprovides.py
+++ b/pytests/tests/test_whatprovides.py
@@ -21,22 +21,22 @@ def teardown_test(utils):
 
 def test_whatprovides_no_arg(utils):
     ret = utils.run(['tdnf', 'whatprovides'])
-    assert(ret['retval'] == 907)
+    assert ret['retval'] == 907
 
 
 def test_whatprovides_invalid_arg(utils):
     ret = utils.run(['tdnf', 'whatprovides', 'invalid_arg'])
-    assert(ret['stderr'][0] == 'No data available')
+    assert ret['stderr'][0] == 'No data available'
 
 
 def test_whatprovides_valid_file_notinstalled(utils):
     ret = utils.run(['tdnf', 'whatprovides', '/lib/systemd/system/tdnf-test-one.service'])
-    assert('tdnf-test-one' in "\n".join(ret['stdout']))
-    assert(ret['retval'] == 0)
+    assert 'tdnf-test-one' in "\n".join(ret['stdout'])
+    assert ret['retval'] == 0
 
 
 def test_whatprovides_valid_file_installed(utils):
     ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', 'tdnf-test-one'])
     ret = utils.run(['tdnf', 'whatprovides', '/lib/systemd/system/tdnf-test-one.service'])
-    assert('tdnf-test-one' in "\n".join(ret['stdout']))
-    assert(ret['retval'] == 0)
+    assert 'tdnf-test-one' in "\n".join(ret['stdout'])
+    assert ret['retval'] == 0


### PR DESCRIPTION
`assert` is a keyword, not a function. `assert(foo=bar)` should be `assert foo==bar`. Latest `flake8` version complained about  missing white space after the keyword.

Fixed using `sed`:
```
sed -i 's/assert(\(.*\))\(.*\)$/assert \1\2/' pytests/tests/*.py
```

