### PR TITLE
handle error when install root is relative

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -227,6 +227,7 @@ typedef enum
     {ERROR_TDNF_RPM_GPG_NO_MATCH,   "ERROR_TDNF_RPM_GPG_NO_MATCH",     "RPM is signed but failed to match with known keys. Use --nogpgcheck to ignore."}, \
     {ERROR_TDNF_AUTOERASE_UNSUPPORTED,"ERROR_TDNF_AUTOERASE_UNSUPPORTED","autoerase / autoremove is not supported."}, \
     {ERROR_TDNF_RPM_CHECK,           "ERROR_TDNF_RPM_CHECK",           "rpm check reported errors"}, \
+    {ERROR_TDNF_RPMTS_BAD_ROOT_DIR,  "ERROR_TDNF_RPMTS_BAD_ROOT_DIR",  "Bad root directory"}, \
     {ERROR_TDNF_METADATA_EXPIRE_PARSE, "ERROR_TDNF_METADATA_EXPIRE_PARSE", "metadata_expire value could not be parsed. Check your repo files."},\
     {ERROR_TDNF_SELF_ERASE, "ERROR_TDNF_SELF_ERASE", "The operation would result in removing the protected package : tdnf"},\
     {ERROR_TDNF_DOWNGRADE_NOT_ALLOWED,\

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -246,6 +246,10 @@ TDNFCliParseArgs(
                       pszDefaultInstallRoot,
                       &pCmdArgs->pszInstallRoot);
                       BAIL_ON_CLI_ERROR(dwError);
+    } else if (pCmdArgs->pszInstallRoot[0] != '/') {
+        pr_crit("Install root must be an absolute path.\n");
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_CLI_ERROR(dwError);
     }
 
     dwError = TDNFCopyOptions(&_opt, pCmdArgs);


### PR DESCRIPTION
The install root needs to be relative. Print a better error message than "Unknown error".