### PR TITLE
use configparser to edit config in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,5 @@ jobs:
             - name: run container with tests
               working-directory: ${{ github.workspace }}
               run: |
-                docker run --privileged --security-opt seccomp:unconfined --rm -e DIST -v$(pwd):/build -w/build ${DIST}/tdnf-build ./ci/docker-entrypoint.sh
+                docker run --security-opt seccomp:unconfined --rm -e DIST -v$(pwd):/build -w/build ${DIST}/tdnf-build ./ci/docker-entrypoint.sh
 

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -135,7 +135,6 @@ class TestUtils(object):
                 filename = os.path.join(self.config['repo_path'], 'yum.repos.d', repo + '.repo')
                 if section is None:
                     section = repo
-        print("filename={}\n".format(filename))
         if config is None:
             config = configparser.ConfigParser()
             config.read(filename)

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -174,13 +174,13 @@ class TestUtils(object):
         self.run(['tdnf', 'erase', '-y', pkg])
         assert not self.check_package(pkgname)
 
-    def install_package(utils, pkgname, pkgversion=None):
+    def install_package(self, pkgname, pkgversion=None):
         if pkgversion:
             pkg = pkgname + '-' + pkgversion
         else:
             pkg = pkgname
-        utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
-        assert utils.check_package(pkgname)
+        self.run(['tdnf', 'install', '-y', '--nogpgcheck', pkg])
+        assert self.check_package(pkgname)
 
     def _requests_get(self, url, verify):
         try:

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -114,6 +114,41 @@ class TestUtils(object):
         # check execution environment and enable valgrind if suitable
         self.check_valgrind()
 
+    # Change tdnf config file, repo or any ini style file
+    # Takes a dictionary as input and sets the keys to the values. If the
+    # value is None, the entry will be removed.
+    # By default, the tdnf.conf file will be edited
+    # To edit a repo, set repo
+    # By default, the section name is 'main' for tdnf.conf and the repo
+    # name if repo is set, unless filename is set
+    # By default, the filename is the path to tdnf.conf, or the repo file if set.
+    # If filename is set, the section needs to be set as well
+    def edit_config(self, changes, repo=None, section=None, filename=None):
+        config = None
+        if filename is None:
+            if repo is None:
+                filename = os.path.join(self.config['repo_path'], 'tdnf.conf')
+                config = self.tdnf_config
+                if section is None:
+                    section = 'main'
+            else:
+                filename = os.path.join(self.config['repo_path'], 'yum.repos.d', repo + '.repo')
+                if section is None:
+                    section = repo
+        print("filename={}\n".format(filename))
+        if config is None:
+            config = configparser.ConfigParser()
+            config.read(filename)
+
+        for k, v in changes.items():
+            if v is not None:
+                config[section][k] = v
+            else:
+                config.remove_option(section, k)
+
+        with open(filename, 'w') as f:
+            config.write(f, space_around_delimiters=False)
+
     def version_str_to_int(self, version):
         version_parts = version.split('.')
         return version_parts[0] * 1000 + version_parts[1] * 100 + version_parts[2]

--- a/pytests/tests/test_autoremove.py
+++ b/pytests/tests/test_autoremove.py
@@ -30,19 +30,8 @@ def teardown_test(utils):
 
 
 def generate_config_cleanreq(utils, newconfig, value):
-    orig_conffile = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-
-    with open(orig_conffile, 'r') as fin:
-        with open(newconfig, 'w') as fout:
-            for line in fin:
-                if not line.startswith('clean_requirements_on_remove'):
-                    fout.write(line)
-                else:
-                    fout.write('clean_requirements_on_remove={}\n'.format('1' if value else '0'))
-
-    with open(newconfig, 'r') as fin:
-        for line in fin:
-            print(line)
+    shutil.copy(os.path.join(utils.config['repo_path'], 'tdnf.conf'), newconfig)
+    utils.edit_config({'clean_requirements_on_remove': '1' if value else '0'}, section='main', filename=newconfig)
 
 
 # leaf1 pulls in a dependency, this should be removed when leaf1 is
@@ -194,7 +183,7 @@ def test_autoremove_conf_false_autoremove(utils):
     assert not utils.check_package(pkgname_req)
 
 
-# 'autoremve' without args cleans up all unneeded
+# 'autoremove' without args cleans up all unneeded
 # auto installed pkgs
 def test_autoremove_noargs(utils):
     pkgname = 'tdnf-test-cleanreq-leaf1'
@@ -213,7 +202,7 @@ def test_autoremove_noargs(utils):
     assert not utils.check_package(pkgname_req)
 
 
-# do not accidentally remove all autoinstaled packages
+# do not accidentally remove all autoinstalled packages
 # those that are required by userinstalled pkgs should remain
 # and removing them would drag the user installed pkgs with them
 def test_autoremove_noargs2(utils):

--- a/pytests/tests/test_cache.py
+++ b/pytests/tests/test_cache.py
@@ -34,20 +34,15 @@ def clean_cache(utils):
 
 
 def enable_cache(utils):
-    tdnf_config = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '/keepcache/d', tdnf_config])
-    utils.run(['sed', '-i', '$ a keepcache=true', tdnf_config])
+    utils.edit_config({'keepcache': 'true'})
 
 
 def disable_cache(utils):
-    tdnf_config = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '/keepcache/d', tdnf_config])
+    utils.edit_config({'keepcache': None})
 
 
 def switch_cache_path(utils, new_path):
-    tdnf_config = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '/cachedir/d', tdnf_config])
-    utils.run(['sed', '-i', '$ a cachedir={}'.format(new_path), tdnf_config])
+    utils.edit_conf({'cachedir': new_path})
 
 
 def clean_small_cache(utils):
@@ -112,8 +107,6 @@ def test_install_with_cache(utils):
 def test_install_with_keepcache_false(utils):
     clean_cache(utils)
     disable_cache(utils)
-    tdnf_config = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '$ a keepcache=false', tdnf_config])
 
     pkgname = utils.config["sglversion_pkgname"]
     if utils.check_package(pkgname):

--- a/pytests/tests/test_cache.py
+++ b/pytests/tests/test_cache.py
@@ -42,7 +42,7 @@ def disable_cache(utils):
 
 
 def switch_cache_path(utils, new_path):
-    utils.edit_conf({'cachedir': new_path})
+    utils.edit_config({'cachedir': new_path})
 
 
 def clean_small_cache(utils):

--- a/pytests/tests/test_minversions.py
+++ b/pytests/tests/test_minversions.py
@@ -8,7 +8,6 @@
 
 import os
 import pytest
-import errno
 import shutil
 
 TESTREPO = 'photon-test'
@@ -28,32 +27,16 @@ def teardown_test(utils):
     if os.path.isdir(dirname):
         shutil.rmtree(dirname)
 
-    utils.tdnf_config.remove_option('main', 'minversions')
-    filename = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    with open(filename, 'w') as f:
-        utils.tdnf_config.write(f, space_around_delimiters=False)
-
-
-# helper to create directory tree without complains when it exists:
-def makedirs(d):
-    try:
-        os.makedirs(d)
-    except OSError as e:
-        if e.errno != errno.EEXIST:
-            raise
+    utils.edit_config({'minversions': None})
 
 
 def set_minversions_conf(utils, value):
-    utils.tdnf_config['main']['minversions'] = value
-    filename = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    with open(filename, 'w') as f:
-        utils.tdnf_config.write(f, space_around_delimiters=False)
+    utils.edit_config({'minversions': value})
 
 
 def set_minversions_file(utils, value):
-    utils.tdnf_config['main']['minversions'] = value
     dirname = os.path.join(utils.config['repo_path'], 'minversions.d')
-    makedirs(dirname)
+    utils.makedirs(dirname)
     filename = os.path.join(dirname, 'test.conf')
     with open(filename, 'w') as f:
         f.write(value)

--- a/pytests/tests/test_pluginconf.py
+++ b/pytests/tests/test_pluginconf.py
@@ -9,6 +9,8 @@
 import os
 import pytest
 
+PLUGIN_NAME = 'test_plugin'
+
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_test(utils):
@@ -17,33 +19,28 @@ def setup_test(utils):
 
 
 def teardown_test(utils):
-    tdnf_conf = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '/plugins/d', tdnf_conf])
-    utils.run(['sed', '-i', '/pluginconfpath/d', tdnf_conf])
+    utils.edit_config({'plugins': None, 'pluginconfpath': None})
 
 
 def enable_plugins(utils):
     # write a plugin config file
-    tdnf_conf = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '2iplugins=1', tdnf_conf])
     plugin_conf_path = os.path.join(utils.config['repo_path'], 'pluginconf.d')
-    utils.run(['mkdir', '-p', plugin_conf_path])
-    utils.run(['sed', '-i', '2ipluginconfpath=' + plugin_conf_path, tdnf_conf])
+    utils.makedirs(plugin_conf_path)
+
+    utils.edit_config({'plugins': '1', 'pluginconfpath': plugin_conf_path})
+
     plugin_conf = os.path.join(plugin_conf_path, 'test_plugin.conf')
     with open(plugin_conf, 'w') as plugin_conf_file:
         plugin_conf_file.write('[main]\nenabled=1\n')
 
 
 def set_plugin_flag_in_conf(utils, flag):
-    tdnf_conf = os.path.join(utils.config['repo_path'], 'tdnf.conf')
-    utils.run(['sed', '-i', '/plugins/d', tdnf_conf])
-    utils.run(['sed', '-i', '2iplugins=' + flag, tdnf_conf])
+    utils.edit_config({'plugins': flag})
 
 
 def set_plugin_config_enabled_flag(utils, flag):
-    test_plugin_conf = os.path.join(utils.config['repo_path'], 'pluginconf.d/test_plugin.conf')
-    utils.run(['sed', '-i', '/enabled/d', test_plugin_conf])
-    utils.run(['sed', '-i', '2ienabled=' + flag, test_plugin_conf])
+    plugin_conf = os.path.join(utils.config['repo_path'], 'pluginconf.d', PLUGIN_NAME + '.conf')
+    utils.edit_config({'enabled': flag}, filename=plugin_conf, section='main')
 
 
 def test_plugin_conf(utils):

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -32,18 +32,11 @@ def teardown_test(utils):
 
 
 def set_gpgcheck(utils, enabled):
-    tdnf_repo = os.path.join(utils.tdnf_config.get('main', 'repodir'), 'photon-test.repo')
-    if enabled:
-        utils.run(['sed', '-i', '/gpgcheck/s/.*/gpgcheck=1/g', tdnf_repo])
-    else:
-        utils.run(['sed', '-i', '/gpgcheck/s/.*/gpgcheck=0/g', tdnf_repo])
+    utils.edit_config({'gpgcheck': '1' if enabled else '0'}, repo='photon-test')
 
 
 def set_repo_key(utils, url):
-    tdnf_repo = os.path.join(utils.tdnf_config.get('main', 'repodir'), 'photon-test.repo')
-    utils.run(['sed', '-i', '/gpgkey/s/.*/#gpgkey=/g', tdnf_repo])
-    if url:
-        utils.run(['sed', '-i', '/gpgkey/s@.*@gpgkey={}@g'.format(url), tdnf_repo])
+    utils.edit_config({'gpgkey': url}, repo='photon-test')
 
 
 # 'wrong' key in repo config, but skip signature, expect success


### PR DESCRIPTION
Replaces `sed` statements, and simplifies changing config and repo settings. Also replaces a few shell uses by using python commands.