### PR TITLE
add --repofromdir option

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -261,16 +261,14 @@ TDNFCheckLocalPackages(
     )
 {
     uint32_t dwError = 0;
-    char* pszRPMPath = NULL;
-    DIR *pDir = NULL;
-    struct dirent *pEnt = NULL;
     Repo *pCmdlineRepo = 0;
-    Id    dwPkgAdded = 0;
     Queue queueJobs = {0};
     Solver *pSolv = NULL;
-    uint32_t dwPackagesFound = 0;
+    uint32_t count = 0;
     Pool *pCmdLinePool = NULL;
     TDNF_SKIPPROBLEM_TYPE dwSkipProblem = SKIPPROBLEM_NONE;
+    Solvable *s = NULL;
+    Id p;
 
     if(!pTdnf || !pTdnf->pSack || !pTdnf->pSack->pPool || !pszLocalPath)
     {
@@ -279,12 +277,7 @@ TDNFCheckLocalPackages(
     }
 
     queue_init(&queueJobs);
-    pDir = opendir(pszLocalPath);
-    if(pDir == NULL)
-    {
-        dwError = errno;
-        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
-    }
+
     pr_info("Checking all packages from: %s\n", pszLocalPath);
 
     pCmdLinePool = pool_create();
@@ -297,38 +290,14 @@ TDNFCheckLocalPackages(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    while ((pEnt = readdir (pDir)) != NULL )
-    {
-        int nLenRpmExt = strlen(TDNF_RPM_EXT);
-        int nLen = strlen(pEnt->d_name);
-        if (nLen <= nLenRpmExt ||
-            strcmp(pEnt->d_name + nLen - nLenRpmExt, TDNF_RPM_EXT))
-        {
-            continue;
-        }
-        dwError = TDNFJoinPath(
-                      &pszRPMPath,
-                      pszLocalPath,
-                      pEnt->d_name,
-                      NULL);
-        BAIL_ON_TDNF_ERROR(dwError);
+    dwError = SolvReadRpmsFromDirectory(pCmdlineRepo, pszLocalPath);
+    BAIL_ON_TDNF_ERROR(dwError);
 
-        dwPkgAdded = repo_add_rpm(
-                         pCmdlineRepo,
-                         pszRPMPath,
-                         REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE);
-        if(!dwPkgAdded)
-        {
-            dwError = ERROR_TDNF_INVALID_PARAMETER;
-            BAIL_ON_TDNF_ERROR(dwError);
-        }
-        queue_push2(&queueJobs, SOLVER_SOLVABLE|SOLVER_INSTALL, dwPkgAdded);
-        dwPackagesFound++;
-        TDNF_SAFE_FREE_MEMORY(pszRPMPath);
-        pszRPMPath = NULL;
+    FOR_REPO_SOLVABLES(pCmdlineRepo, p, s) {
+        queue_push2(&queueJobs, SOLVER_SOLVABLE|SOLVER_INSTALL, p);
+        count++;
     }
-    repo_internalize(pCmdlineRepo);
-    pr_info("Found %u packages\n", dwPackagesFound);
+    pr_info("Found %u packages\n", count);
 
     pSolv = solver_create(pCmdLinePool);
     if(pSolv == NULL)
@@ -362,11 +331,6 @@ cleanup:
         solver_free(pSolv);
     }
     queue_free(&queueJobs);
-    if(pDir)
-    {
-        closedir(pDir);
-    }
-    TDNF_SAFE_FREE_MEMORY(pszRPMPath);
     return dwError;
 
 error:

--- a/client/api.c
+++ b/client/api.c
@@ -693,9 +693,14 @@ TDNFOpenHandle(
     dwError = SolvInitSack(
                   &pSack,
                   pTdnf->pConf->pszCacheDir,
-                  pTdnf->pArgs->pszInstallRoot,
-                  pArgs->nAllDeps);
+                  pTdnf->pArgs->pszInstallRoot);
     BAIL_ON_TDNF_ERROR(dwError);
+
+    if(!pArgs->nAllDeps)
+    {
+        dwError = SolvReadInstalledRpms(pSack->pPool->installed, pszCacheDir);
+        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+    }
 
     dwError = TDNFLoadRepoData(
                   pTdnf,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1056,12 +1056,6 @@ TDNFGetFileSize(
     int *pnSize
     );
 
-uint32_t
-TDNFIsDir(
-    const char* pszPath,
-    int* pnPathIsDir
-    );
-
 int
 TDNFIsGlob(
     const char* pszString

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -785,6 +785,13 @@ TDNFCreateRepoFromPath(
     );
 
 uint32_t
+TDNFCreateRepoFromDirectory(
+    PTDNF_REPO_DATA* ppRepo,
+    const char *pzsId,
+    const char *pszPath
+    );
+
+uint32_t
 TDNFCreateRepo(
     PTDNF_REPO_DATA* ppRepo,
     const char *pszId

--- a/client/utils.c
+++ b/client/utils.c
@@ -330,42 +330,6 @@ error:
     goto cleanup;
 }
 
-uint32_t
-TDNFIsDir(
-    const char* pszPath,
-    int* pnPathIsDir
-    )
-{
-    uint32_t dwError = 0;
-    int nPathIsDir = 0;
-    struct stat stStat = {0};
-
-    if(!pnPathIsDir || IsNullOrEmptyString(pszPath))
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    if(stat(pszPath, &stStat))
-    {
-        dwError = errno;
-        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
-    }
-
-    nPathIsDir = S_ISDIR(stStat.st_mode);
-
-    *pnPathIsDir = nPathIsDir;
-cleanup:
-    return dwError;
-
-error:
-    if(pnPathIsDir)
-    {
-        *pnPathIsDir = 0;
-    }
-    goto cleanup;
-}
-
 /* update time if file exists, create if not */
 uint32_t
 TDNFTouchFile(

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -273,6 +273,12 @@ TDNFReadFileToStringArray(
     char ***pppszArray
     );
 
+uint32_t
+TDNFIsDir(
+    const char* pszPath,
+    int* pnPathIsDir
+    );
+
 //setopt.c
 uint32_t
 AddSetOpt(

--- a/common/utils.c
+++ b/common/utils.c
@@ -869,3 +869,38 @@ error:
     goto cleanup;
 }
 
+uint32_t
+TDNFIsDir(
+    const char* pszPath,
+    int* pnPathIsDir
+    )
+{
+    uint32_t dwError = 0;
+    int nPathIsDir = 0;
+    struct stat stStat = {0};
+
+    if(!pnPathIsDir || IsNullOrEmptyString(pszPath))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(stat(pszPath, &stStat))
+    {
+        dwError = errno;
+        BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+    }
+
+    nPathIsDir = S_ISDIR(stStat.st_mode);
+
+    *pnPathIsDir = nPathIsDir;
+cleanup:
+    return dwError;
+
+error:
+    if(pnPathIsDir)
+    {
+        *pnPathIsDir = 0;
+    }
+    goto cleanup;
+}

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -265,6 +265,7 @@ typedef struct _TDNF_REPO_DATA
     int nEnabled;
     int nSkipIfUnavailable;
     int nGPGCheck;
+    int nHasMetaData;
     long lMetadataExpire;
     char* pszId;
     char* pszName;

--- a/solv/includes.h
+++ b/solv/includes.h
@@ -11,6 +11,7 @@
 #include <stdbool.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <dirent.h>
 
 // libsolv
 #include <solv/evr.h>

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -534,11 +534,16 @@ SolvCountPackages(
     );
 
 uint32_t
+SolvReadRpmsFromDirectory(
+    Repo *pRepo,
+    const char *pszDir
+);
+
+uint32_t
 SolvReadInstalledRpms(
-    Pool* pPool,
-    Repo** ppRepo,
-    const char* pszCacheFileName
-    );
+    Repo* pRepo,
+    const char *pszCacheFileName
+);
 
 uint32_t
 SolvLoadRepomd(

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -335,10 +335,8 @@ uint32_t
 SolvInitSack(
     PSolvSack *ppSack,
     const char* pszCacheDir,
-    const char* pszRootDir,
-    int nInstallAllDeps
-    );
-
+    const char* pszRootDir
+);
 
 // tdnfquery.c
 uint32_t

--- a/solv/tdnfpool.c
+++ b/solv/tdnfpool.c
@@ -116,19 +116,19 @@ SolvInitSack(
     pool_setarch(pPool, systemInfo.machine);
     pool_set_flag(pPool, POOL_FLAG_ADDFILEPROVIDESFILTERED, 1);
 
-    if(nInstallAllDeps)
+    pRepo = repo_create(pPool, SYSTEM_REPO_NAME);
+    if(pRepo == NULL)
     {
-        pRepo = repo_create(pPool, SYSTEM_REPO_NAME);
-        if(pRepo == NULL)
-        {
-           dwError = ERROR_TDNF_INVALID_PARAMETER;
-        }
+       dwError = ERROR_TDNF_INVALID_PARAMETER;
+       BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
     }
-    else
+
+    if(!nInstallAllDeps)
     {
-        dwError = SolvReadInstalledRpms(pPool, &pRepo, pszCacheDir);
+        dwError = SolvReadInstalledRpms(pRepo, pszCacheDir);
+        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
     }
-    BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+
     pool_set_installed(pPool, pRepo);
     pool_createwhatprovides(pPool);
 
@@ -139,6 +139,10 @@ cleanup:
     return dwError;
 
 error:
+    if(pRepo)
+    {
+        repo_free(pRepo, 1);
+    }
     if(pPool)
     {
         pool_free(pPool);

--- a/solv/tdnfpool.c
+++ b/solv/tdnfpool.c
@@ -67,8 +67,7 @@ uint32_t
 SolvInitSack(
     PSolvSack *ppSack,
     const char* pszCacheDir,
-    const char* pszRootDir,
-    int nInstallAllDeps
+    const char* pszRootDir
     )
 {
     uint32_t dwError = 0;
@@ -122,15 +121,7 @@ SolvInitSack(
        dwError = ERROR_TDNF_INVALID_PARAMETER;
        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
     }
-
-    if(!nInstallAllDeps)
-    {
-        dwError = SolvReadInstalledRpms(pRepo, pszCacheDir);
-        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
-    }
-
     pool_set_installed(pPool, pRepo);
-    pool_createwhatprovides(pPool);
 
     pSack->pPool = pPool;
     *ppSack = pSack;

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -55,6 +55,7 @@ static struct option pstOptions[] =
     {"releasever",    required_argument, 0, 0},            //--releasever
     {"reboot-required", no_argument, 0, 0},                //--reboot-required
     {"repo",          required_argument, 0, 0},            //--repo
+    {"repofromdir",   required_argument, 0, 0},            //--repofromdir
     {"repofrompath",  required_argument, 0, 0},            //--repofrompath
     {"repoid",        required_argument, 0, 0},            //--repoid (same as --repo)
     {"rpmverbosity",  required_argument, 0, 0},            //--rpmverbosity


### PR DESCRIPTION
This adds the `--repofromdir` option. It is similar to `--repofrompath`, except it does not require any metadata. Usage:
```
tdnf --repofromdir=vim,/root/vim install vim
```
The directory contains the packages. The directory must be on the filesystem, no URLs will be accepted. All files in the directory with names ending in `.rpm` will be added. Sub directories will be recursed, skipping names starting with a dot (`.`).

This is useful for a quick setup without the need to create a repo using `createrepo`, however it is less efficient than using a repo with metadata.