### PR TITLE
'repo' option should be same as 'repoid'

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -628,7 +628,8 @@ TDNFRepoListFinalize(
                           0,
                           pSetOpt->pszOptValue);
         }
-        else if(strcmp(pSetOpt->pszOptName, "repoid") == 0)
+        else if((strcmp(pSetOpt->pszOptName, "repo") == 0) ||
+                (strcmp(pSetOpt->pszOptName, "repoid") == 0))
         {
             if (!nRepoidSeen)
             {

--- a/pytests/tests/test_repoid.py
+++ b/pytests/tests/test_repoid.py
@@ -45,6 +45,19 @@ def test_repoid(utils):
     assert REPONAME in "\n".join(ret['stdout'])
 
 
+def test_repo(utils):
+    utils.makedirs(REPODIR)
+    utils.create_repoconf(os.path.join(REPODIR, REPOFILENAME),
+                          "http://foo.bar.com/packages",
+                          REPONAME)
+    ret = utils.run(['tdnf',
+                     '--setopt=reposdir={}'.format(REPODIR),
+                     '--repo={}'.format(REPONAME),
+                     'repolist'])
+    assert ret['retval'] == 0
+    assert REPONAME in "\n".join(ret['stdout'])
+
+
 # reposync a repo and install from it
 def test_repoid_created_repo(utils):
     reponame = 'photon-test'


### PR DESCRIPTION
The `repo` option wasn't working. I somehow missed this until now. `repo` and `repoid` should have the same effect.