### PR TITLE
add --arch option to repoquery command

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1472,7 +1472,14 @@ TDNFRepoQuery(
     dwError = SolvApplyListQuery(pQuery);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    /* now filter for extras or duplicates */
+    /* filter for arch(es) */
+    if (pRepoqueryArgs->ppszArchs)
+    {
+        dwError = SolvApplyArchFilter(pQuery, pRepoqueryArgs->ppszArchs);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* filter for extras or duplicates */
     if (pRepoqueryArgs->nExtras)
     {
         dwError = SolvApplyExtrasFilter(pQuery);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -375,6 +375,8 @@ typedef enum {
     REPOQUERY_DEP_KEY_COUNT
 }REPOQUERY_DEP_KEY;
 
+#define TDNF_REPOQUERY_MAXARCHS 10
+
 typedef struct _TDNF_REPOQUERY_ARGS
 {
     char *pszSpec;
@@ -388,6 +390,7 @@ typedef struct _TDNF_REPOQUERY_ARGS
     int nUserInstalled;
     char *pszFile;         /* packages that own this file */
     char ***pppszWhatKeys;
+    char **ppszArchs;
 
     /* query options */
     int nChangeLogs;

--- a/pytests/repo/tdnf-test-noarch.spec
+++ b/pytests/repo/tdnf-test-noarch.spec
@@ -1,0 +1,35 @@
+#
+# tdnf-test-one spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-test-noarch
+Version:    1.0.1
+Release:    1
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+BuildArch:  noarch
+
+%description
+Part of tdnf test spec. Basic install/remove/upgrade test
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/lib/systemd/system/
+cat << EOF >> %_topdir/%buildroot/lib/systemd/system/%{name}.service
+[Unit]
+Description=%{name} for arch related tests
+
+EOF
+
+%files
+/lib/systemd/system/%{name}.service
+
+%changelog
+*   Mon Oct 10 2022 Oliver Kurth <okurth@vmware.com> 1.0.1
+-   Initial build.  First version

--- a/pytests/tests/test_repoquery.py
+++ b/pytests/tests/test_repoquery.py
@@ -7,7 +7,9 @@
 #
 
 import pytest
+import platform
 
+ARCH = platform.machine()
 BASE_PKG = 'tdnf-repoquery-base'
 
 
@@ -229,3 +231,13 @@ def test_userinstalled(utils):
 
     ret = utils.run(['tdnf', 'repoquery', '--userinstalled', pkgname])
     assert pkgname not in "\n".join(ret['stdout'])
+
+
+def test_arch(utils):
+    ret = utils.run(['tdnf', 'repoquery', '--arch', ARCH])
+    assert 'noarch' not in "\n".join(ret['stdout'])
+    assert ARCH in "\n".join(ret['stdout'])
+
+    ret = utils.run(['tdnf', 'repoquery', '--arch', 'noarch'])
+    assert 'noarch' in "\n".join(ret['stdout'])
+    assert ARCH not in "\n".join(ret['stdout'])

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -510,6 +510,11 @@ SolvApplyUserInstalledFilter(
     PSolvQuery pQuery,
     struct history_ctx *pHistoryCtx);
 
+uint32_t
+SolvApplyArchFilter(
+    PSolvQuery pQuery,
+    char **ppszArchs);
+
 // tdnfrepo.c
 uint32_t
 SolvReadYumRepo(

--- a/tools/cli/lib/parserepoqueryargs.c
+++ b/tools/cli/lib/parserepoqueryargs.c
@@ -74,7 +74,25 @@ TDNFCliParseRepoQueryArgs(
          pSetOpt;
          pSetOpt = pSetOpt->pNext)
     {
-        if (strcasecmp(pSetOpt->pszOptName, "file") == 0)
+        if (strcasecmp(pSetOpt->pszOptName, "arch") == 0)
+        {
+            int i;
+            if (pRepoqueryArgs->ppszArchs == NULL)
+            {
+                dwError = TDNFAllocateMemory(TDNF_REPOQUERY_MAXARCHS+1, sizeof(char *),
+                    (void **)&pRepoqueryArgs->ppszArchs);
+                BAIL_ON_CLI_ERROR(dwError);
+            }
+            for (i = 0; i < TDNF_REPOQUERY_MAXARCHS && pRepoqueryArgs->ppszArchs[i]; i++);
+            if (i < TDNF_REPOQUERY_MAXARCHS)
+            {
+                dwError = TDNFAllocateString(
+                    pSetOpt->pszOptValue,
+                    &(pRepoqueryArgs->ppszArchs[i]));
+                BAIL_ON_CLI_ERROR(dwError);
+            }
+        }
+        else if (strcasecmp(pSetOpt->pszOptName, "file") == 0)
         {
             dwError = TDNFAllocateString(pSetOpt->pszOptValue,
                                          &pRepoqueryArgs->pszFile);
@@ -187,6 +205,7 @@ TDNFCliFreeRepoQueryArgs(
 {
     if(pRepoqueryArgs)
     {
+        TDNF_CLI_SAFE_FREE_STRINGARRAY(pRepoqueryArgs->ppszArchs);
         if (pRepoqueryArgs->pppszWhatKeys)
         {
             int i;


### PR DESCRIPTION
This adds the `--arch` option to `repoquery` command. Example usage:
```
tdnf repoquery --arch=noarch
```
To filter for multiple architectures:
```
tdnf repoquery --arch=noarch --arch=x86_64
```