### PR TITLE
fix --repofrompath with cmdline

### DIFF
--- a/pytests/tests/test_repofrompath.py
+++ b/pytests/tests/test_repofrompath.py
@@ -7,36 +7,31 @@
 #
 
 import os
+import glob
 import shutil
+import platform
 import pytest
 
-REPODIR = '/root/repofrompath/yum.repos.d'
-REPOFILENAME = 'repofrompath.repo'
-REPONAME = "repofrompath-test"
 WORKDIR = '/root/repofrompath/workdir'
+ARCH = platform.machine()
 
 
 @pytest.fixture(scope='function', autouse=True)
 def setup_test(utils):
+    create_repo(utils)
     yield
     teardown_test(utils)
 
 
 def teardown_test(utils):
-    if os.path.isdir(REPODIR):
-        shutil.rmtree(REPODIR)
     if os.path.isdir(WORKDIR):
         shutil.rmtree(WORKDIR)
-    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
-    if os.path.isfile(filename):
-        os.remove(filename)
 
 
-# reposync a repo and install from it
-def test_repofrompath_created_repo(utils):
-    reponame = 'photon-test'
+def create_repo(utils):
     workdir = WORKDIR
     utils.makedirs(workdir)
+    reponame = 'photon-test'
 
     ret = utils.run(['tdnf', '--repo={}'.format(reponame),
                      '--download-metadata',
@@ -47,6 +42,19 @@ def test_repofrompath_created_repo(utils):
     assert os.path.isdir(synced_dir)
     assert os.path.isdir(os.path.join(synced_dir, 'repodata'))
     assert os.path.isfile(os.path.join(synced_dir, 'repodata', 'repomd.xml'))
+
+
+def get_pkg_file_path(utils, pkgname):
+    dir = os.path.join(utils.config['repo_path'], 'photon-test', 'RPMS', ARCH)
+    matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
+    return matches[0]
+
+
+# reposync a repo and install from it
+def test_repofrompath_created_repo(utils):
+    workdir = WORKDIR
+    reponame = 'photon-test'
+    synced_dir = os.path.join(workdir, reponame)
 
     ret = utils.run(['tdnf',
                      '--repofrompath=synced-repo,{}'.format(synced_dir),
@@ -62,6 +70,28 @@ def test_repofrompath_created_repo(utils):
                      '--repofrompath=synced-repo,{}'.format(synced_dir),
                      '--repo=synced-repo',
                      'install', pkgname],
+                    cwd=workdir)
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+
+
+# check for issue #359 - having set a repo with --repofrompath
+# should not interfer with installing a package from the command line
+def test_repofrompath_cmdline_repo(utils):
+    workdir = WORKDIR
+    reponame = 'photon-test'
+    synced_dir = os.path.join(workdir, reponame)
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    path = get_pkg_file_path(utils, pkgname)
+
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--repofrompath=synced-repo,{}'.format(synced_dir),
+                     '--repo=synced-repo',
+                     'install', path],
                     cwd=workdir)
     assert ret['retval'] == 0
     assert utils.check_package(pkgname)


### PR DESCRIPTION
Fixes #359 . Root cause was adding a repo with `--repofrompath` overwrote the pointer to the command line (pseudo) repo.