### PR TITLE
fix skip options

### DIFF
--- a/pytests/tests/test_check_skip.py
+++ b/pytests/tests/test_check_skip.py
@@ -9,13 +9,6 @@
 import pytest
 
 
-def run_cmd(utils, opt, retval):
-    cmd = ['tdnf', 'check']
-    cmd.extend(opt)
-    ret = utils.run(cmd)
-    assert ret['retval'] == retval
-
-
 @pytest.fixture(scope='module', autouse=True)
 def setup_test(utils):
     yield
@@ -26,36 +19,31 @@ def teardown_test(utils):
     pass
 
 
-def test_check_skipconflicts(utils):
-    run_cmd(utils, ['--skipconflicts'], 1301)
-
-
-def test_check_skipobsoletes(utils):
-    run_cmd(utils, ['--skipobsoletes'], 1301)
-
-
-def test_check_providers(utils):
-    run_cmd(utils, ['--skipconflicts', '--skipobsoletes'], 1301)
-
-
-def test_dummy_conflicts(utils):
+def test_skipobsoletes(utils):
     ret = utils.run(['tdnf', 'check', '--skipobsoletes'])
+    assert ret['retval'] == 1301
     assert ' conflicts ' in '\n'.join(ret['stderr'])
     assert ' provides ' in '\n'.join(ret['stderr'])
+    assert ' obsoletes ' not in '\n'.join(ret['stderr'])
 
 
-def test_dummy_obsoletes(utils):
+def test_skipconflicts(utils):
     ret = utils.run(['tdnf', 'check', '--skipconflicts'])
+    assert ret['retval'] == 1301
     assert ' obsoletes ' in '\n'.join(ret['stderr'])
     assert ' provides ' in '\n'.join(ret['stderr'])
+    assert ' conflicts ' not in '\n'.join(ret['stderr'])
 
 
-def test_dummy_provides(utils):
+def test_skipconflicts_skipobsoletes(utils):
     ret = utils.run(['tdnf', 'check', '--skipconflicts', '--skipobsoletes'])
+    assert ret['retval'] == 1301
     assert ' provides ' in '\n'.join(ret['stderr'])
+    assert ' conflicts ' not in '\n'.join(ret['stderr'])
+    assert ' obsoletes ' not in '\n'.join(ret['stderr'])
 
 
-def test_dummy_check(utils):
+def test_check_no_skip(utils):
     ret = utils.run(['tdnf', 'check'])
     assert ' obsoletes ' in '\n'.join(ret['stderr'])
     assert ' conflicts ' in '\n'.join(ret['stderr'])

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1692,6 +1692,11 @@ SolvReportProblems(
         type = solver_ruleinfo(pSolv, dwProblemId,
                                &dwSource, &dwTarget, &dwDep);
 
+       if (SkipBasedOnType(pSolv, type, dwSource, dwSkipProblem))
+       {
+           continue;
+       }
+
         pszProblem = solver_problemruleinfo2str(pSolv, type, dwSource,
                                                 dwTarget, dwDep);
 
@@ -1704,11 +1709,7 @@ SolvReportProblems(
             }
         }
 
-        if (!SkipBasedOnType(pSolv, type, dwSource, dwSkipProblem))
-        {
-            dwError = ERROR_TDNF_SOLV_FAILED;
-        }
-        
+        dwError = ERROR_TDNF_SOLV_FAILED;
         pr_err("%u. %s\n", ++total_prblms, pszProblem);
     }
 


### PR DESCRIPTION
The options `--skipobsoletes` and `--skipconflicts` options were being ignored. This has been broken with https://github.com/vmware/tdnf/pull/346.