### PR TITLE
ignore missing reference to filelists metadata in repomd.xml

### DIFF
--- a/client/repo.c
+++ b/client/repo.c
@@ -1263,15 +1263,18 @@ TDNFParseRepoMD(
                   pRepo,
                   TDNF_REPOMD_TYPE_FILELISTS,
                   &pRepoMD->pszFileLists);
+    /* filelists is not mandatory */
+    if(dwError == ERROR_TDNF_NO_DATA) {
+        dwError = 0;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFFindRepoMDPart(
                   pRepo,
                   TDNF_REPOMD_TYPE_UPDATEINFO,
                   &pRepoMD->pszUpdateInfo);
-    //updateinfo is not mandatory
-    if(dwError == ERROR_TDNF_NO_DATA)
-    {
+    /* updateinfo is not mandatory */
+    if(dwError == ERROR_TDNF_NO_DATA) {
         dwError = 0;
     }
     BAIL_ON_TDNF_ERROR(dwError);

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -82,7 +82,6 @@ baseurl=http://localhost:8080/photon-test
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=0
 enabled=1
-skip_md_filelists=1
 EOF
 
 cat << EOF > ${TEST_REPO_DIR}/tdnf.conf


### PR DESCRIPTION
If the filelists metadata was not mentioned in `repomd.xml`, `tdnf` failed to load the repo, even when `skip_md_filelists` was set. Fixing this.

Similar to https://github.com/vmware/tdnf/pull/275.