### PR TITLE
Fix crash in rpmtsCheck() if rpmtsRun() fails

### DIFF
--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -549,12 +549,31 @@ int
 doCheck(PTDNFRPMTS pTS)
 {
     int nResult = 0;
-    rpmpsi psi = NULL;
-    rpmProblem prob = NULL;
+
     nResult = rpmtsCheck(pTS->pTS);
-    char *pErrorStr = NULL;
 
     rpmps ps = rpmtsProblems(pTS->pTS);
+    if(ps)
+    {
+        int nProbs = rpmpsNumProblems(ps);
+        if(nProbs > 0)
+        {
+            nResult = ERROR_TDNF_RPM_CHECK;
+        }
+        rpmpsFree(ps);
+    }
+
+    return nResult;
+}
+
+void
+reportProblems(PTDNFRPMTS pTS)
+{
+    rpmps ps = NULL;
+    rpmpsi psi = NULL;
+    char *pErrorStr = NULL;
+
+    ps = rpmtsProblems(pTS->pTS);
     if(ps)
     {
         int nProbs = rpmpsNumProblems(ps);
@@ -565,7 +584,7 @@ doCheck(PTDNFRPMTS pTS)
             psi = rpmpsInitIterator(ps);
             while(rpmpsNextIterator(psi) >= 0)
             {
-                prob = rpmpsGetProblem(psi);
+                rpmProblem prob = rpmpsGetProblem(psi);
                 char *msg = rpmProblemString(prob);
                 if (strstr(msg, "no digest") != NULL)
                 {
@@ -577,24 +596,32 @@ doCheck(PTDNFRPMTS pTS)
                     if (rpmProblemGetType(prob) == RPMPROB_REQUIRES)
                     {
                         uint32_t dwError = 0;
+
                         dwError = TDNFAllocateString(rpmProblemGetStr(prob), &pErrorStr);
                         BAIL_ON_TDNF_ERROR(dwError);
 
                         dwError = TDNFDetectPreTransFailure(pTS->pTS, pErrorStr);
                         BAIL_ON_TDNF_ERROR(dwError);
+
+                        TDNF_SAFE_FREE_MEMORY(pErrorStr);
                     }
                 }
-                rpmProblemFree(prob);
             }
-            rpmpsFreeIterator(psi);
-            nResult = ERROR_TDNF_RPM_CHECK;
         }
     }
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pErrorStr);
-    return nResult;
+    if (psi)
+    {
+        rpmpsFreeIterator(psi);
+    }
+    if (ps)
+    {
+        rpmpsFree(ps);
+    }
+    return;
+
 error:
-    nResult = ERROR_TDNF_RPM_CHECK;
     goto cleanup;
 }
 
@@ -678,9 +705,9 @@ cleanup:
     return dwError;
 
 error:
-    if(pTS && dwError != ERROR_TDNF_RPM_CHECK)
+    if(pTS)
     {
-        doCheck(pTS);
+        reportProblems(pTS);
     }
     goto cleanup;
 }


### PR DESCRIPTION
The preexisting logic in `doCheck` is very helpful for extracting and displaying problems, but the call to `rpmtsCheck` itself should not be re-executed if the failure occurred after the initial check. Once `rpmtsClean()` has been called, data within `pTS` has been emptied and `rpmtsCheck` will segfault on NULL dereference.

Also address a few potential issues with the lifetime of the problem objects:
* The `rpmps` object is ref-counted internally and should be released with `rpmpsFree`; the latter function frees all of the problems within it when the ref count reaches 0.
* If multiple problems are reported, then `pErrorStr` needs to be freed multiple times.

---

_NOTE: This is my first (attempted) contribution to this project, so I wasn't sure how/which tests to re-run. I'd appreciate any and all feedback you have for me to make this PR acceptable._