### PR TITLE
Fix metalink checksum verification (issue #373)

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -225,12 +225,6 @@ TDNFFreeHistoryInfoItems(
     int nCount
 );
 
-uint32_t
-TDNFCheckRepoMDFileHashFromMetalink(
-    const char *pszFile,
-    TDNF_ML_CTX *ml_ctx
-    );
-
 //remoterepo.c
 uint32_t
 TDNFDownloadFileFromRepo(

--- a/client/structs.h
+++ b/client/structs.h
@@ -81,40 +81,6 @@ typedef struct _TDNF_EVENT_DATA_
     struct _TDNF_EVENT_DATA_ *pNext;
 } TDNF_EVENT_DATA, *PTDNF_EVENT_DATA;
 
-//Metalink Structures.
-typedef struct _TDNF_ML_LIST_
-{
-    struct _TDNF_ML_LIST_ *next;
-    void* data;
-} TDNF_ML_LIST, TDNF_ML_URL_LIST, TDNF_ML_HASH_LIST;
-
-//Metalink hash info per hash type.
-typedef struct _TDNF_ML_HASH_INFO_
-{
-    char *type;
-    char *value;
-} TDNF_ML_HASH_INFO;
-
-//Metalink url info per hash type.
-typedef struct _TDNF_ML_URL_INFO_
-{
-    char *protocol;
-    char *type;
-    char *location;
-    char *url;
-    int  preference;
-} TDNF_ML_URL_INFO;
-
-//Metalink global parsed info.
-typedef struct _TDNF_ML_CTX_
-{
-    char           *filename;
-    signed long    timestamp;
-    signed long    size;
-    TDNF_ML_LIST   *hashes;
-    TDNF_ML_LIST   *urls;
-} TDNF_ML_CTX;
-
 typedef struct progress_cb_data {
     time_t cur_time;
     time_t prev_time;

--- a/plugins/metalink/prototypes.h
+++ b/plugins/metalink/prototypes.h
@@ -50,6 +50,12 @@ TDNFParseUrlTag(
     xmlNode *node
     );
 
+uint32_t
+TDNFCheckRepoMDFileHashFromMetalink(
+    const char *pszFile,
+    TDNF_ML_CTX *ml_ctx
+    );
+
 // api.c
 
 const char *

--- a/plugins/metalink/structs.h
+++ b/plugins/metalink/structs.h
@@ -8,6 +8,40 @@
 
 #pragma once
 
+//Metalink Structures.
+typedef struct _TDNF_ML_LIST_
+{
+    struct _TDNF_ML_LIST_ *next;
+    void* data;
+} TDNF_ML_LIST, TDNF_ML_URL_LIST, TDNF_ML_HASH_LIST;
+
+//Metalink hash info per hash type.
+typedef struct _TDNF_ML_HASH_INFO_
+{
+    char *type;
+    char *value;
+} TDNF_ML_HASH_INFO;
+
+//Metalink url info per hash type.
+typedef struct _TDNF_ML_URL_INFO_
+{
+    char *protocol;
+    char *type;
+    char *location;
+    char *url;
+    int  preference;
+} TDNF_ML_URL_INFO;
+
+//Metalink global parsed info.
+typedef struct _TDNF_ML_CTX_
+{
+    char           *filename;
+    signed long    timestamp;
+    signed long    size;
+    TDNF_ML_LIST   *hashes;
+    TDNF_ML_LIST   *urls;
+} TDNF_ML_CTX;
+
 /* per repo */
 typedef struct _TDNF_METALINK_DATA_
 {


### PR DESCRIPTION
Find 'best' available checksum type and use all available checksums of this type in metalink file for verification. Fixes issue #373.

Also move a few bits from header files in core to the plugin.
