### PR TITLE
make db dir configurable at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,10 @@ if(NOT SYSTEMD_DIR)
     set(SYSTEMD_DIR /lib/systemd/system)
 endif()
 
+if(NOT HISTORY_DB_DIR)
+    set(HISTORY_DB_DIR /var/lib/tdnf)
+endif()
+
 ##
 ## C Flags
 ##

--- a/ci/docker-entrypoint.sh
+++ b/ci/docker-entrypoint.sh
@@ -5,7 +5,8 @@ rm -rf build
 mkdir -p build
 cd build || exit 1
 
-cmake .. && make -j32 && make python -j32 && make check -j32 || exit
+mkdir -p /usr/lib/sysimage/tdnf
+cmake -DHISTORY_DB_DIR=/usr/lib/sysimage/tdnf .. && make -j32 && make python -j32 && make check -j32 || exit
 
 if ! flake8 ../pytests ; then
   echo "flake8 tests failed"

--- a/client/config.c
+++ b/client/config.c
@@ -120,6 +120,13 @@ TDNFReadConfig(
 
     dwError = TDNFReadKeyValue(
                   pSection,
+                  TDNF_CONF_KEY_PERSISTDIR,
+                  TDNF_DEFAULT_DB_LOCATION,
+                  &pConf->pszPersistDir);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFReadKeyValue(
+                  pSection,
                   TDNF_CONF_KEY_DISTROVERPKG,
                   TDNF_DEFAULT_DISTROVERPKG,
                   &pConf->pszDistroVerPkg);
@@ -321,6 +328,7 @@ TDNFFreeConfig(
         TDNF_SAFE_FREE_MEMORY(pConf->pszProxyUserPass);
         TDNF_SAFE_FREE_MEMORY(pConf->pszRepoDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszCacheDir);
+        TDNF_SAFE_FREE_MEMORY(pConf->pszPersistDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszDistroVerPkg);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarReleaseVer);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarBaseArch);

--- a/client/defines.h
+++ b/client/defines.h
@@ -129,7 +129,6 @@ typedef enum
 
 #define TDNF_AUTOINSTALLED_FILE           "autoinstalled"
 #define TDNF_HISTORY_DB_FILE              "history.db"
-#define TDNF_DEFAULT_DATA_LOCATION        "/var/lib/tdnf"
 
 // repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"

--- a/client/defines.h
+++ b/client/defines.h
@@ -79,6 +79,7 @@ typedef enum
 #define TDNF_CONF_KEY_CLEAN_REQ_ON_REMOVE "clean_requirements_on_remove"
 #define TDNF_CONF_KEY_REPODIR             "repodir"
 #define TDNF_CONF_KEY_CACHEDIR            "cachedir"
+#define TDNF_CONF_KEY_PERSISTDIR          "persistdir"
 #define TDNF_CONF_KEY_PROXY               "proxy"
 #define TDNF_CONF_KEY_PROXY_USER          "proxy_username"
 #define TDNF_CONF_KEY_PROXY_PASS          "proxy_password"
@@ -133,6 +134,11 @@ typedef enum
 // repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
 #define TDNF_DEFAULT_CACHE_LOCATION       "/var/cache/tdnf"
+
+/* pszPersistDir - default is configurable at build time,
+   and configurable with "persistdir" at run time */
+#define TDNF_DEFAULT_DB_LOCATION          HISTORY_DB_DIR
+
 #define TDNF_DEFAULT_DISTROVERPKG         "system-release"
 #define TDNF_DEFAULT_DISTROARCHPKG        "x86_64"
 #define TDNF_RPM_CACHE_DIR_NAME           "rpms"

--- a/client/history.c
+++ b/client/history.c
@@ -28,7 +28,7 @@ TDNFGetHistoryCtx(
 
     dwError = TDNFJoinPath(&pszDataDir,
                            pTdnf->pArgs->pszInstallRoot,
-                           HISTORY_DB_DIR,
+                           pTdnf->pConf->pszPersistDir,
                            NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/history.c
+++ b/client/history.c
@@ -28,13 +28,13 @@ TDNFGetHistoryCtx(
 
     dwError = TDNFJoinPath(&pszDataDir,
                            pTdnf->pArgs->pszInstallRoot,
-                           TDNF_DEFAULT_DATA_LOCATION,
+                           HISTORY_DB_DIR,
                            NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFJoinPath(&pszHistoryDb,
             pszDataDir,
-            TDNF_HISTORY_DB_FILE,
+            HISTORY_DB_FILE,
             NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -50,7 +50,11 @@ TDNFGetHistoryCtx(
         }
     }
 
-    dwError = TDNFUtilsMakeDir(pszDataDir);
+    dwError = TDNFUtilsMakeDirs(pszDataDir);
+    if (dwError == ERROR_TDNF_ALREADY_EXISTS)
+    {
+        dwError = 0;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     ctx = create_history_ctx(pszHistoryDb);

--- a/history/CMakeLists.txt
+++ b/history/CMakeLists.txt
@@ -8,6 +8,11 @@
 
 set(TDNF_HISTORY_UTIL_BIN tdnf-history-util)
 
+configure_file(
+    config.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/config.h
+)
+
 add_executable(${TDNF_HISTORY_UTIL_BIN}
     main.c
 )

--- a/history/config.h.in
+++ b/history/config.h.in
@@ -1,0 +1,5 @@
+#pragma once
+
+#define HISTORY_DB_FILE "history.db"
+
+#cmakedefine HISTORY_DB_DIR "@HISTORY_DB_DIR@"

--- a/history/history.h
+++ b/history/history.h
@@ -11,6 +11,8 @@
 #include <sqlite3.h>
 #include <rpm/rpmlib.h>
 
+#include "config.h"
+
 #define HISTORY_TRANS_TYPE_BASE 0
 #define HISTORY_TRANS_TYPE_DELTA 1
 

--- a/history/main.c
+++ b/history/main.c
@@ -77,7 +77,7 @@ void usage(const char *cmdname)
 
 int main(int argc, char *argv[])
 {
-    char *db_file = "/var/lib/tdnf/history.db";
+    char *db_file = HISTORY_DB_DIR"/"HISTORY_DB_FILE;
     char *rpm_root_dir = "/";
     rpmts ts = NULL;
     struct history_ctx *ctx = NULL;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -249,6 +249,7 @@ typedef struct _TDNF_CONF
     int nKeepCache;
     char* pszRepoDir;
     char* pszCacheDir;
+    char* pszPersistDir;
     char* pszProxy;
     char* pszProxyUserPass;
     char* pszDistroVerPkg;


### PR DESCRIPTION
We may want to move the history database from `/var` to a sub directory of `/usr`. This change will make the directory for the db configurable at compile time.

The directory can be set by an argument to `cmake` like this:
`cmake -DHISTORY_DB_DIR=/usr/lib/sysimage/tdnf`
The default ist still `/var/lib/tdnf`.

The directory can also be set at run time using `persistdir` (just like `dnf`).