### PR TITLE
install a providing and obsoleting package when found

### DIFF
--- a/client/goal.c
+++ b/client/goal.c
@@ -332,7 +332,7 @@ TDNFSolv(
     dwError = TDNFSolvAddPkgLocks(pTdnf, pQueueJobs, pTdnf->pSack->pPool);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFSolvAddMinVersions(pTdnf, pQueueJobs, pTdnf->pSack->pPool);
+    dwError = TDNFSolvAddMinVersions(pTdnf, pTdnf->pSack->pPool);
     BAIL_ON_TDNF_ERROR(dwError);
 
     pSolv = solver_create(pTdnf->pSack->pPool);
@@ -893,7 +893,6 @@ error:
 uint32_t
 TDNFSolvAddMinVersions(
     PTDNF pTdnf,
-    Queue* pQueueJobs,
     Pool *pPool
     )
 {
@@ -903,7 +902,7 @@ TDNFSolvAddMinVersions(
     Map *pMapMinVersions = NULL;
     char *pszTmp = NULL;
 
-    if(!pTdnf || !pQueueJobs || !pPool)
+    if(!pTdnf || !pPool)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -553,7 +553,6 @@ TDNFSolvAddPkgLocks(
 uint32_t
 TDNFSolvAddMinVersions(
     PTDNF pTdnf,
-    Queue* pQueueJobs,
     Pool *pPool
     );
 

--- a/pytests/repo/tdnf-test-dummy-obsoleted.spec
+++ b/pytests/repo/tdnf-test-dummy-obsoleted.spec
@@ -1,5 +1,5 @@
-Summary:        Dummy obsoletes spec
-Name:           tdnf-test-dummy-obsoletes-0
+Summary:        Dummy obsoleted spec
+Name:           tdnf-test-dummy-obsoleted
 Version:        0.1
 Release:        1
 Vendor:         VMware, Inc.
@@ -9,7 +9,7 @@ Url:            http://www.vmware.com
 Group:          Applications/tdnftest
 
 %description
-Part of tdnf test spec. Basic dummy obsoletes spec.
+Part of tdnf test spec. This packges will be obsoleted.
 
 %prep
 

--- a/pytests/repo/tdnf-test-dummy-obsoleting.spec
+++ b/pytests/repo/tdnf-test-dummy-obsoleting.spec
@@ -1,0 +1,27 @@
+Summary:        Dummy obsoletes spec
+Name:           tdnf-test-dummy-obsoleting
+Version:        0.1
+Release:        1
+Vendor:         VMware, Inc.
+Distribution:   Photon
+License:        VMware
+Url:            http://www.vmware.com
+Group:          Applications/tdnftest
+
+Provides:      tdnf-test-dummy-obsoleted
+Obsoletes:      tdnf-test-dummy-obsoleted
+
+%description
+Part of tdnf test spec. This package obsoletes the -obsoleted package.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+*  Fri Aug 07 2020 Shreenidhi Shedi <sshedi@vmware.com> 0.1-1
+-  First version

--- a/pytests/repo/tdnf-test-dummy-obsoleting2.spec
+++ b/pytests/repo/tdnf-test-dummy-obsoleting2.spec
@@ -1,5 +1,5 @@
-Summary:        Dummy obsoletes spec
-Name:           tdnf-test-dummy-obsoletes-1
+Summary:        Dummy obsoletes spec 2
+Name:           tdnf-test-dummy-obsoleting2
 Version:        0.1
 Release:        1
 Vendor:         VMware, Inc.
@@ -8,10 +8,11 @@ License:        VMware
 Url:            http://www.vmware.com
 Group:          Applications/tdnftest
 
-Obsoletes:      tdnf-test-dummy-obsoletes-0
+#Provides:      tdnf-test-dummy-obsoleted
+Obsoletes:      tdnf-test-dummy-obsoleted
 
 %description
-Part of tdnf test spec. Basic dummy obsoletes spec.
+Part of tdnf test spec. This is another package that obsoletes the -obsoleted package.
 
 %prep
 

--- a/pytests/repo/tdnf-test-dummy-obsoleting3.spec
+++ b/pytests/repo/tdnf-test-dummy-obsoleting3.spec
@@ -1,0 +1,27 @@
+Summary:        Dummy obsoletes spec 3
+Name:           tdnf-test-dummy-obsoleting3
+Version:        0.1
+Release:        1
+Vendor:         VMware, Inc.
+Distribution:   Photon
+License:        VMware
+Url:            http://www.vmware.com
+Group:          Applications/tdnftest
+
+Provides:      tdnf-test-dummy-obsoleted
+#Obsoletes:      tdnf-test-dummy-obsoleted
+
+%description
+Part of tdnf test spec. This is another package that obsoletes the -obsoleted package.
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+*  Fri Aug 07 2020 Shreenidhi Shedi <sshedi@vmware.com> 0.1-1
+-  First version

--- a/pytests/tests/test_install.py
+++ b/pytests/tests/test_install.py
@@ -8,6 +8,10 @@
 
 import pytest
 
+PKGNAME_OBSED_VER = "tdnf-test-dummy-obsoleted=0.1"
+PKGNAME_OBSED = "tdnf-test-dummy-obsoleted"
+PKGNAME_OBSING = "tdnf-test-dummy-obsoleting"
+
 
 @pytest.fixture(scope='module', autouse=True)
 def setup_test(utils):
@@ -111,6 +115,35 @@ def test_install_missing_dep(utils):
 
     utils.run(['tdnf', 'install', '-y', '--nogpgcheck', pkgname, pkgname_missing])
     assert not utils.check_package(pkgname)
+
+
+# install an obsoleted package, expect the obsoleting package to be installed
+# the obsoleting package must also provide the obsoleted one
+def test_install_obsoletes(utils):
+    utils.erase_package(PKGNAME_OBSED)
+    utils.erase_package(PKGNAME_OBSING)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', PKGNAME_OBSED])
+    assert utils.check_package(PKGNAME_OBSING)
+
+
+# install an obsoleted package with version - expect the obsoleted package to be installed
+def test_install_obsoleted_version(utils):
+    utils.erase_package(PKGNAME_OBSED_VER)
+    utils.erase_package(PKGNAME_OBSING)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', PKGNAME_OBSED_VER])
+    assert utils.check_package(PKGNAME_OBSED)
+
+
+# same as test_install_obsoletes, but the obsoleted package already installed
+def test_install_obsoleted_installed(utils):
+    # make sure we install the obsoleted one by using version
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', PKGNAME_OBSED_VER])
+    utils.erase_package(PKGNAME_OBSING)
+
+    utils.run(['tdnf', 'install', '-y', '--nogpgcheck', PKGNAME_OBSED])
+    assert utils.check_package(PKGNAME_OBSING)
 
 
 def test_install_memcheck(utils):

--- a/solv/includes.h
+++ b/solv/includes.h
@@ -31,6 +31,7 @@
 #include <solv/solverdebug.h>
 #include <solv/testcase.h>
 #include <solv/chksum.h>
+#include <solv/policy.h>
 
 #include <tdnf.h>
 #include <tdnf-common-defines.h>

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1240,6 +1240,80 @@ error:
     goto cleanup;
 }
 
+/* code based on mlschroe's suggestion in PR 378 */
+
+/* check if package s obsoletes is */
+static
+int
+is_obsoleting(Pool *pool, Solvable *s, Solvable *is)
+{
+    Id obs, *obsp;
+    Id n = is - pool->solvables;
+    if (!s->obsoletes)
+        return 0;
+    obsp = s->repo->idarraydata + s->obsoletes;
+    while ((obs = *obsp++) != 0) { /* for all obsoletes */
+        if (pool_match_nevr(pool, pool->solvables + n, obs)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+uint32_t
+SolvFindBestAvailable(
+    PSolvSack pSack,
+    const char* pszPkgName,
+    Id* pdwId
+    )
+{
+    uint32_t dwError = 0;
+    Pool *pool = pSack->pPool; /* FOR_PROVIDES needs this name */
+    Id idName = pool_str2id(pool, pszPkgName, 1);
+    Id p, pp;
+    Queue q = {0};
+
+    if(!pSack || IsNullOrEmptyString(pszPkgName) || !pdwId)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    queue_init(&q);
+
+    /* step 1: look at packages with the specified name */
+    FOR_PROVIDES(p, pp, idName)
+    if (pool->solvables[p].name == idName)
+        queue_push(&q, p);
+    if (!q.count)
+    {
+        dwError = ERROR_TDNF_NO_MATCH;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    pool_best_solvables(pool, &q, 0);
+    queue_truncate(&q, 1);        /* use the first element */
+
+    /* step 2: check if a package has a provides/obsoletes combination
+    * for the best package */
+    FOR_PROVIDES(p, pp, idName)
+    {
+        if (pool->solvables[p].name == idName)
+            continue;               /* already done in step 1 */
+        if (!is_obsoleting(pool, pool->solvables + p, pool->solvables + q.elements[0]))
+            continue;
+        queue_push(&q, p);
+    }
+    pool_best_solvables(pool, &q, 0);
+
+    *pdwId = q.elements[0];
+
+cleanup:
+    queue_free(&q);
+    return dwError;
+error:
+    goto cleanup;
+}
+
 uint32_t
 SolvFindHighestAvailable(
     PSolvSack pSack,
@@ -1248,12 +1322,8 @@ SolvFindHighestAvailable(
     )
 {
     uint32_t dwError = 0;
-    int dwPkgIndex = 0;
-    int dwEvrCompare = 0;
-    Id  dwAvailableId = 0;
-    Id  dwHighestAvailable = 0;
     PSolvPackageList pAvailablePkgList = NULL;
-    uint32_t dwCount = 0;
+    Queue *pqAvail;
 
     if(!pSack || IsNullOrEmptyString(pszPkgName) || !pdwId)
     {
@@ -1261,38 +1331,25 @@ SolvFindHighestAvailable(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    dwError = SolvFindBestAvailable(pSack, pszPkgName, pdwId);
+    if (dwError == 0)
+        goto cleanup;
+
     dwError = SolvFindAvailablePkgByName(
                   pSack,
                   pszPkgName,
                   &pAvailablePkgList);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = SolvGetPackageId(pAvailablePkgList, 0, &dwHighestAvailable);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    dwError = SolvGetPackageListSize(pAvailablePkgList, &dwCount);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    for(dwPkgIndex = 1; (uint32_t)dwPkgIndex < dwCount; dwPkgIndex++)
-    {
-        dwError = SolvGetPackageId(
-                      pAvailablePkgList,
-                      dwPkgIndex,
-                      &dwAvailableId);
+    pqAvail = &pAvailablePkgList->queuePackages;
+    pool_best_solvables(pSack->pPool, pqAvail, 0);
+    if (pqAvail->count == 0) { /* can this happen? */
+        dwError = ERROR_TDNF_NO_MATCH;
         BAIL_ON_TDNF_ERROR(dwError);
-        dwError = SolvCmpEvr(
-                      pSack,
-                      dwAvailableId,
-                      dwHighestAvailable,
-                      &dwEvrCompare);
-        BAIL_ON_TDNF_ERROR(dwError);
-        if(dwEvrCompare > 0)
-        {
-            dwHighestAvailable = dwAvailableId;
-        }
     }
 
-    *pdwId = dwHighestAvailable;
+    *pdwId = pqAvail->elements[0];
+
 cleanup:
     if(pAvailablePkgList)
     {


### PR DESCRIPTION
This uses `pool_whatprovides()` to find package providers and uses libsolv's `pool_best_solvables()` to determine the best available package when doing an `install` or `upgrade`. If no package is found using `pool_whatprovides()` (because the desired package spec contains a version or a relation), fall back to the old method, but still use `pool_best_solvables()` to determine the best result.