### PR TITLE
Fix reinstall

### DIFF
--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -33,7 +33,7 @@ TDNFMatchForReinstall(
     Id  dwAvailableId = 0;
     char* pszNevr = NULL;
     PSolvPackageList pInstalledPkgList = NULL;
-    PSolvPackageList pAvailabePkgList = NULL;
+    PSolvPackageList pAvailablePkgList = NULL;
 
     if(!pSack || !pQueueGoal || IsNullOrEmptyString(pszName))
     {
@@ -56,10 +56,10 @@ TDNFMatchForReinstall(
     dwError = SolvFindAvailablePkgByName(
                   pSack,
                   pszNevr,
-                  &pAvailabePkgList);
+                  &pAvailablePkgList);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = SolvGetPackageId(pAvailabePkgList,
+    dwError = SolvGetPackageId(pAvailablePkgList,
                                0,
                                &dwAvailableId);
     BAIL_ON_TDNF_ERROR(dwError);
@@ -68,9 +68,9 @@ TDNFMatchForReinstall(
 
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszNevr);
-    if(pAvailabePkgList)
+    if(pAvailablePkgList)
     {
-        SolvFreePackageList(pAvailabePkgList);
+        SolvFreePackageList(pAvailablePkgList);
     }
     if(pInstalledPkgList)
     {

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -899,12 +899,6 @@ TDNFTransAddErasePkgs(
     );
 
 uint32_t
-TDNFTransAddObsoletedPkgs(
-    PTDNFRPMTS pTS,
-    PTDNF_PKG_INFO pInfo
-    );
-
-uint32_t
 TDNFTransAddErasePkg(
     PTDNFRPMTS pTS,
     const char* pszPkgName
@@ -914,14 +908,8 @@ uint32_t
 TDNFTransAddInstallPkgs(
     PTDNFRPMTS pTS,
     PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
-    );
-
-uint32_t
-TDNFTransAddReInstallPkgs(
-    PTDNFRPMTS pTS,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
+    PTDNF_PKG_INFO pInfo,
+    int nUpgrade
     );
 
 uint32_t
@@ -932,13 +920,6 @@ TDNFTransAddInstallPkg(
     const char* pszPkgName,
     PTDNF_REPO_DATA pRepo,
     int nUpgrade
-    );
-
-uint32_t
-TDNFTransAddUpgradePkgs(
-    PTDNFRPMTS pTS,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
     );
 
 uint32_t

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -405,7 +405,7 @@ TDNFPopulateTransaction(
     }
     if(pSolvedInfo->pPkgsToReinstall)
     {
-        dwError = TDNFTransAddInstallPkgs(
+        dwError = TDNFTransAddUpgradePkgs(
                       pTS,
                       pTdnf,
                       pSolvedInfo->pPkgsToReinstall);

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -358,36 +358,6 @@ error:
 }
 
 uint32_t
-TDNFTransAddErasePkgs(
-    PTDNFRPMTS pTS,
-    PTDNF_PKG_INFO pInfo)
-{
-    uint32_t dwError = 0;
-    if(!pInfo)
-    {
-        dwError = ERROR_TDNF_NO_DATA;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-    while(pInfo)
-    {
-        dwError = TDNFTransAddErasePkg(pTS, pInfo->pszName);
-        pInfo = pInfo->pNext;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-cleanup:
-    return dwError;
-
-error:
-    if(dwError == ERROR_TDNF_NO_DATA)
-    {
-        dwError = 0;
-    }
-    goto cleanup;
-}
-
-
-uint32_t
 TDNFPopulateTransaction(
     PTDNFRPMTS pTS,
     PTDNF pTdnf,
@@ -400,23 +370,25 @@ TDNFPopulateTransaction(
         dwError = TDNFTransAddInstallPkgs(
                       pTS,
                       pTdnf,
-                      pSolvedInfo->pPkgsToInstall);
+                      pSolvedInfo->pPkgsToInstall, 0);
         BAIL_ON_TDNF_ERROR(dwError);
     }
     if(pSolvedInfo->pPkgsToReinstall)
     {
-        dwError = TDNFTransAddUpgradePkgs(
+        dwError = TDNFTransAddInstallPkgs(
                       pTS,
                       pTdnf,
-                      pSolvedInfo->pPkgsToReinstall);
+                      pSolvedInfo->pPkgsToReinstall,
+                      1);
         BAIL_ON_TDNF_ERROR(dwError);
     }
     if(pSolvedInfo->pPkgsToUpgrade)
     {
-        dwError = TDNFTransAddUpgradePkgs(
+        dwError = TDNFTransAddInstallPkgs(
                       pTS,
                       pTdnf,
-                      pSolvedInfo->pPkgsToUpgrade);
+                      pSolvedInfo->pPkgsToUpgrade,
+                      1);
         BAIL_ON_TDNF_ERROR(dwError);
     }
     if(pSolvedInfo->pPkgsToRemove)
@@ -428,7 +400,7 @@ TDNFPopulateTransaction(
     }
     if(pSolvedInfo->pPkgsObsoleted)
     {
-        dwError = TDNFTransAddObsoletedPkgs(
+        dwError = TDNFTransAddErasePkgs(
                       pTS,
                       pSolvedInfo->pPkgsObsoleted);
         BAIL_ON_TDNF_ERROR(dwError);
@@ -438,7 +410,8 @@ TDNFPopulateTransaction(
         dwError = TDNFTransAddInstallPkgs(
                       pTS,
                       pTdnf,
-                      pSolvedInfo->pPkgsToDowngrade);
+                      pSolvedInfo->pPkgsToDowngrade,
+                      0);
         BAIL_ON_TDNF_ERROR(dwError);
         if(pSolvedInfo->pPkgsRemovedByDowngrade)
         {
@@ -716,7 +689,8 @@ uint32_t
 TDNFTransAddInstallPkgs(
     PTDNFRPMTS pTS,
     PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfos
+    PTDNF_PKG_INFO pInfos,
+    int nUpgrade
     )
 {
     uint32_t dwError = 0;
@@ -740,7 +714,8 @@ TDNFTransAddInstallPkgs(
                       pTdnf,
                       pInfo->pszLocation,
                       pInfo->pszName,
-                      pRepo, 0);
+                      pRepo,
+                      nUpgrade);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -867,10 +842,10 @@ error:
 }
 
 uint32_t
-TDNFTransAddUpgradePkgs(
+TDNFTransAddErasePkgs(
     PTDNFRPMTS pTS,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfos)
+    PTDNF_PKG_INFO pInfos
+    )
 {
     uint32_t dwError = 0;
     PTDNF_PKG_INFO pInfo;
@@ -883,49 +858,7 @@ TDNFTransAddUpgradePkgs(
 
     for(pInfo = pInfos; pInfo; pInfo = pInfo->pNext)
     {
-        PTDNF_REPO_DATA pRepo = NULL;
-
-        dwError = TDNFFindRepoById(pTdnf, pInfo->pszRepoName, &pRepo);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = TDNFTransAddInstallPkg(
-                      pTS,
-                      pTdnf,
-                      pInfo->pszLocation,
-                      pInfo->pszName,
-                      pRepo,
-                      1);
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-cleanup:
-    return dwError;
-
-error:
-    if(dwError == ERROR_TDNF_NO_DATA)
-    {
-        dwError = 0;
-    }
-    goto cleanup;
-}
-
-uint32_t
-TDNFTransAddObsoletedPkgs(
-    PTDNFRPMTS pTS,
-    PTDNF_PKG_INFO pInfo
-    )
-{
-    uint32_t dwError = 0;
-
-    if(!pInfo)
-    {
-        dwError = ERROR_TDNF_NO_DATA;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    while(pInfo)
-    {
         dwError = TDNFTransAddErasePkg(pTS, pInfo->pszName);
-        pInfo = pInfo->pNext;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1217,7 +1217,13 @@ SolvGetTransResultsWithType(
                 break;
         }
 
-        if (dwType == dwPkgType)
+        /* Solver uses SOLVER_TRANSACTION_CHANGE if a pkg has
+           the same nevra, but has differences. If the pkg is
+           completly identical it uses SOLVER_TRANSACTION_REINSTALL.
+           For our purposes we don't care. */
+        if ((dwType == dwPkgType) ||
+            (dwType == SOLVER_TRANSACTION_REINSTALL &&
+             dwPkgType == SOLVER_TRANSACTION_CHANGE))
             queue_push(&queueSolvedPackages, dwPkg);
     }
     dwError = SolvQueueToPackageList(&queueSolvedPackages, &pPkgList);


### PR DESCRIPTION
Packages were not reinstalled when they had the same name, epoch, version, release and architecture (NEVRA) as the installed package, but had differences in the binary blob. libsolv uses the flag `SOLVER_TRANSACTION_CHANGE` for those packages. When populating the transaction we were only looking for the `SOLVER_TRANSACTION_REINSTALL` flag, so the packages were dropped.

Additionally, we need to set the `upgrade` flag for `rpmtsAddInstallElement()` for reinstalling packages.

Also changing a few minor things while at it.