### PR TITLE
remove unused prototypes

### DIFF
--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -28,13 +28,6 @@
 
 extern uid_t gEuid;
 
-//clean.c
-uint32_t
-TDNFCopyEnabledRepos(
-    PTDNF_REPO_DATA pRepoData,
-    char*** pppszReposUsed
-    );
-
 //client.c
 uint32_t
 TDNFApplyScopeFilter(
@@ -113,27 +106,13 @@ TDNFCloneSetOpts(
     );
 
 uint32_t
-TDNFRefreshRepo(
-    PTDNF pTdnf,
-    int nCleanMetadata,
-    PTDNF_REPO_DATA pRepo
-    );
-
-uint32_t
 TDNFRefreshSack(
     PTDNF pTdnf,
     PSolvSack pSack,
     int nCleanMetadata
     );
 
-//makecache.c
-uint32_t
-TDNFRefreshCache(
-    PTDNF pTdnf
-    );
-
 //repoutils.c
-
 uint32_t
 TDNFRepoGetUserPass(
     PTDNF pTdnf,
@@ -563,30 +542,6 @@ TDNFConfGetRpmVerbosity(
     );
 
 uint32_t
-TDNFConfSetFlag(
-    TDNF_CONF_FLAG nFlag,
-    int nValue //0 or 1
-    );
-
-uint32_t
-TDNFConfGetFlag(
-    TDNF_CONF_FLAG nFlag,
-    int nValue //0 or 1
-    );
-
-uint32_t
-TDNFConfSetValue(
-    TDNF_CONF_TYPE nType,
-    const char* pszValue
-    );
-
-uint32_t
-TDNFConfGetValue(
-    TDNF_CONF_TYPE nType,
-    char** ppszValue
-    );
-
-uint32_t
 TDNFReadConfig(
     PTDNF pTdnf,
     const char* pszConfFile,
@@ -830,28 +785,11 @@ TDNFPrepareAllPackages(
     );
 
 uint32_t
-TDNFPrepareAndAddPkg(
-    PTDNF pTdnf,
-    const char* pszPkgName,
-    TDNF_ALTERTYPE nAlterType,
-    char** ppszPkgsNotResolved,
-    Queue* pQueueGoal
-    );
-
-uint32_t
 TDNFPrepareSinglePkg(
     PTDNF pTdnf,
     const char* pszPkgName,
     TDNF_ALTERTYPE nAlterType,
     char** ppszPkgsNotResolved,
-    Queue* pQueueGoal
-    );
-
-uint32_t
-TDNFAddFilteredPkgs(
-    PTDNF pTdnf,
-    int nScope,
-    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
     Queue* pQueueGoal
     );
 
@@ -1098,11 +1036,6 @@ TDNFAppendPath(
     );
 
 //validate.c
-uint32_t
-TDNFValidateCmdArgs(
-    PTDNF pTdnf
-    );
-
 uint32_t
 TDNFGetSkipProblemOption(
     PTDNF pTdnf,

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -314,13 +314,6 @@ TDNFSetOpt(
     );
 
 uint32_t
-TDNFSetOptNoOverwrite(
-    PTDNF_CMD_ARGS pArgs,
-    const char *pszOptName,
-    const char *pszOptValue
-    );
-
-uint32_t
 TDNFGetCmdOptValue(
     PTDNF_CMD_ARGS pArgs,
     const char *pszOptName,

--- a/tools/cli/lib/prototypes.h
+++ b/tools/cli/lib/prototypes.h
@@ -55,11 +55,6 @@ TDNFGetUpdateInfoType(
     );
 
 uint32_t
-TDNFCliUpdateInfoList(
-    PTDNF_UPDATEINFO pUpdateInfo
-    );
-
-uint32_t
 TDNFCliUpdateInfoSummary(
     PTDNF_CLI_CONTEXT pContext,
     PTDNF_CMD_ARGS pCmdArgs,

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -139,11 +139,6 @@ TDNFCliInvokeAlterHistory(
     PTDNF_HISTORY_ARGS pHistoryArgs
     );
 
-uint32_t
-TDNFCliUpdateInfoInfo(
-    PTDNF_UPDATEINFO pInfo
-    );
-
 //help.c
 void
 TDNFCliShowUsage(
@@ -367,11 +362,6 @@ TDNFCliParseUpdateInfoArgs(
     PTDNF_UPDATEINFO_ARGS* ppUpdateInfoArgs
     );
 
-void
-TDNFFreeUpdateInfoArgs(
-    PTDNF_UPDATEINFO_ARGS pUpdateInfoArgs
-    );
-
 //updateinfocmd.c
 char*
 TDNFGetUpdateInfoType(
@@ -379,20 +369,10 @@ TDNFGetUpdateInfoType(
     );
 
 uint32_t
-TDNFCliUpdateInfoList(
-    PTDNF_UPDATEINFO pUpdateInfo
-    );
-
-uint32_t
 TDNFCliUpdateInfoSummary(
     PTDNF pTdnf,
     PTDNF_CMD_ARGS pCmdArgs,
     PTDNF_UPDATEINFO_ARGS pInfoArgs
-    );
-
-void
-TDNFFreeListArgs(
-    PTDNF_LIST_ARGS pListArgs
     );
 
 uint32_t


### PR DESCRIPTION
Some cleanup. No functional difference.

Command line if this is ever needed again:
```
for f in $(find . -name prototypes.h) ; do for fn in $(cat $f  | grep '($' | sed s/\(//g) ; do git grep -q $fn *.c || echo $fn from $f not found ; done ; done
```