### PR TITLE
handle empty rpm db for history db

### DIFF
--- a/history/history.c
+++ b/history/history.c
@@ -281,10 +281,12 @@ int db_maxid(sqlite3 *db, const char *table_name, int *pmaxid)
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
-    check_cond(step == SQLITE_ROW);
-
-    *pmaxid = sqlite3_column_int(res, COLUMN_RPMS_ID);
-    sqlite3_finalize(res); res = NULL;
+    check_cond(step == SQLITE_ROW || step == SQLITE_DONE);
+    if (step == SQLITE_ROW) {
+        *pmaxid = sqlite3_column_int(res, COLUMN_RPMS_ID);
+    } else if (step == SQLITE_DONE) {
+        *pmaxid = 0;
+    }
 error:
     if (res)
         sqlite3_finalize(res);


### PR DESCRIPTION
When the history db was initialized with an empty rpm db, `tdnf` would later throw an error and fail when trying to access the history db. Root cause was a missing check for `SQLITE_DONE`, which was returned in that case.

For the record, this was the error:
```
tdnf install -y lsof                                                                                                                                           

Installing:
lsof                                   x86_64                       4.95.0-1.ph4                           photon-updates               207.70k                         121.54k

Total installed size: 207.70k
Total download size: 121.54k
lsof                                    124456 100%
check_cond failed in db_maxid line 284
check_rc failed in history_set_state line 1218
check_rc failed in history_sync line 1513
Error(1801) : Unknown error 201
```
A workaround is to move the db away (or delete it, it's empty anyway):
```
mv /usr/lib/sysimage/tdnf/history.db /usr/lib/sysimage/tdnf/history.db.away
```

