### PR TITLE
avoid copying a package file to cache if we can access it directly

### DIFF
--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -758,13 +758,36 @@ TDNFTransAddInstallPkg(
     {
         if (!pTdnf->pArgs->nDownloadOnly || pTdnf->pArgs->pszDownloadDir == NULL)
         {
-            dwError = TDNFDownloadPackageToCache(
-                          pTdnf,
-                          pszPackageLocation,
-                          pszPkgName,
-                          pRepo,
-                          &pszFilePath
-            );
+            int nInPlace = 0;
+            int i;
+
+            /* avoid copying a file to cache if we can access it directly */
+            for (i = 0; pRepo->ppszBaseUrls[i]; i++) {
+                if (strncasecmp(pRepo->ppszBaseUrls[i], "file://", 7) == 0)
+                {
+                    dwError = TDNFJoinPath(&pszFilePath,
+                                           &(pRepo->ppszBaseUrls[i][7]),
+                                           pszPackageLocation,
+                                           NULL);
+                    BAIL_ON_TDNF_ERROR(dwError);
+                    if(access(pszFilePath, F_OK) == 0) {
+                        nInPlace = 1;
+                        break;
+                    }
+                    TDNF_SAFE_FREE_MEMORY(pszFilePath);
+                }
+            }
+
+            if (!nInPlace)
+            {
+                dwError = TDNFDownloadPackageToCache(
+                              pTdnf,
+                              pszPackageLocation,
+                              pszPkgName,
+                              pRepo,
+                              &pszFilePath
+                );
+            }
         }
         else
         {
@@ -786,6 +809,7 @@ TDNFTransAddInstallPkg(
     if(access(pszFilePath, F_OK))
     {
         dwError = errno;
+        pr_err("could not access file %s: %s (%d)\n", pszFilePath, strerror(errno), errno);
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
 


### PR DESCRIPTION
We can save some space and time by avoiding downloading (in fact copying) packages to cache when we can just access them directly through the filesystem.

Iterate through all base URLs that start with `file://` , then just use the file directly if we can access it. Fall back to the old behavior if this fails.