### PR TITLE
make max number of open files configurable

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -144,6 +144,13 @@ TDNFReadConfig(
                   &pConf->ppszMinVersions);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFReadKeyValueInt(
+                  pSection,
+                  TDNF_CONF_KEY_OPENMAX,
+                  TDNF_DEFAULT_OPENMAX,
+                  &pConf->nOpenMax);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFConfigReadProxySettings(
                   pSection,
                   pConf);

--- a/client/defines.h
+++ b/client/defines.h
@@ -94,6 +94,8 @@ typedef enum
 #define TDNF_PLUGIN_CONF_KEY_ENABLED      "enabled"
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
 #define TDNF_CONF_KEY_MINVERSIONS         "minversions"
+#define TDNF_CONF_KEY_OPENMAX             "openmax"
+
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"
 #define TDNF_REPO_KEY_ENABLED             "enabled"
@@ -145,6 +147,8 @@ typedef enum
 #define TDNF_REPODATA_DIR_NAME            "repodata"
 #define TDNF_SOLVCACHE_DIR_NAME           "solvcache"
 #define TDNF_REPO_METADATA_EXPIRE_NEVER   "never"
+
+#define TDNF_DEFAULT_OPENMAX              1024
 
 // repo default settings
 #define TDNF_REPO_DEFAULT_ENABLED            0

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -599,6 +599,60 @@ error:
     goto cleanup;
 }
 
+/*
+ * Restrict number of open files. When rpm cannot access /proc
+ * it tries to set the close on exec flag for every possible
+ * fd, which may take a long time if the limit is very high.
+ * See also https://github.com/rpm-software-management/rpm/issues/2081.
+ * This can be disabled by setting "openmax=0" in the configuration.
+ */
+
+uint32_t
+TDNFSetOpenMax(PTDNF pTdnf)
+{
+    uint32_t dwError = 0;
+    char *pszProcPath = NULL;
+    int nIsDir = 0;
+
+    if(!pTdnf || !pTdnf->pConf || !pTdnf->pArgs)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* First, check if /proc is available - if rpm can
+       open it there is no issue. */
+    dwError = TDNFJoinPath(&pszProcPath,
+                           pTdnf->pArgs->pszInstallRoot ?
+                               pTdnf->pArgs->pszInstallRoot : "",
+                           "/proc/self/fd",
+                           NULL);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFIsDir(pszProcPath, &nIsDir);
+    if (dwError == ERROR_TDNF_SYSTEM_BASE + ENOENT) {
+        nIsDir = 0;
+        dwError = 0;
+    }
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    if (!nIsDir) {
+        int nOpenMax = pTdnf->pConf->nOpenMax;
+        struct rlimit rl = {nOpenMax, nOpenMax};
+        if (setrlimit(RLIMIT_NOFILE, &rl) != 0) {
+            /* shouldn't be fatal */
+            pr_err("warning: could not set rlimit: %s (%d)."
+		   "This may cause degraded performance.\n",
+	           strerror(errno), errno);
+        }
+    }
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszProcPath);
+    return dwError;
+error:
+    goto cleanup;
+}
+
 uint32_t
 TDNFRunTransaction(
     PTDNFRPMTS pTS,
@@ -611,7 +665,7 @@ TDNFRunTransaction(
     uint32_t dwSkipDigest = 0;
     int rc;
 
-    if(!pTS || !pTdnf || !pTdnf->pArgs)
+    if(!pTS || !pTdnf || !pTdnf->pConf || !pTdnf->pArgs)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -664,19 +718,10 @@ TDNFRunTransaction(
 
     if (!pTdnf->pArgs->nTestOnly)
     {
-        if (pTdnf->pArgs->pszInstallRoot &&
-            (strcmp(pTdnf->pArgs->pszInstallRoot, "/") != 0))
-        {
-            /*
-             * Restrict number of open files. When rpm cannot access /proc
-             * it tries to set the close on exec flag for every possible
-             * fd, which may take a long time if the limit is very high.
-             * See also https://github.com/rpm-software-management/rpm/issues/2081
-            */
-            struct rlimit rl = {1024, 1024};
-            setrlimit(RLIMIT_NOFILE, &rl);
+        if (pTdnf->pConf->nOpenMax > 0) {
+            dwError = TDNFSetOpenMax(pTdnf);
+            BAIL_ON_TDNF_ERROR(dwError);
         }
-
         pr_info("Running transaction\n");
 
         rpmtsSetFlags(pTS->pTS, pTS->nTransFlags);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -247,6 +247,7 @@ typedef struct _TDNF_CONF
     int nInstallOnlyLimit;
     int nCleanRequirementsOnRemove;
     int nKeepCache;
+    int nOpenMax;          //set max number of open files
     char* pszRepoDir;
     char* pszCacheDir;
     char* pszPersistDir;


### PR DESCRIPTION
Improve the change in PR #391 to make it configurable, or disable it. Also, check if `/proc` can be used because in that case we will not hit the problem, instead of just checking if we are installing to another installroot. By default the limit is still set to 1024.