### PR TITLE
Add `--source` and `--builddeps` options

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1611,11 +1611,18 @@ TDNFResolve(
                   &queueGoal);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFGoal(
-                  pTdnf,
-                  &queueGoal,
-                  &pSolvedPkgInfo,
-                  nAlterType);
+    if (!pTdnf->pArgs->nSource) {
+        dwError = TDNFGoal(
+                      pTdnf,
+                      &queueGoal,
+                      &pSolvedPkgInfo,
+                      nAlterType);
+    } else {
+        dwError = TDNFGoalNoDeps(
+                      pTdnf,
+                      &queueGoal,
+                      &pSolvedPkgInfo);
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFCheckProtectedPkgs(pSolvedPkgInfo);

--- a/client/goal.c
+++ b/client/goal.c
@@ -418,6 +418,45 @@ error:
 }
 
 uint32_t
+TDNFGoalNoDeps(
+    PTDNF pTdnf,
+    Queue* pQueuePkgList,
+    PTDNF_SOLVED_PKG_INFO* ppInfo
+    )
+{
+    uint32_t dwError = 0;
+    PSolvPackageList pPkgList = NULL;
+    PTDNF_PKG_INFO pPkgInfo = NULL;
+    PTDNF_SOLVED_PKG_INFO pInfo = NULL;
+
+    if(!pTdnf || !ppInfo || !pQueuePkgList)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = SolvQueueToPackageList(pQueuePkgList, &pPkgList);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFPopulatePkgInfos(pTdnf->pSack, pPkgList, &pPkgInfo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    dwError = TDNFAllocateMemory(
+                  1,
+                  sizeof(TDNF_SOLVED_PKG_INFO),
+                  (void**)&pInfo);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    pInfo->pPkgsToInstall = pPkgInfo;
+    *ppInfo = pInfo;
+
+cleanup:
+    return dwError;
+error:
+    goto cleanup;
+}
+
+uint32_t
 TDNFGoal(
     PTDNF pTdnf,
     Queue* pQueuePkgList,
@@ -426,7 +465,6 @@ TDNFGoal(
     )
 {
     uint32_t dwError = 0;
-
     Queue queueJobs = {0};
     int nAllowErasing = 0;
     char** ppszExcludes = NULL;

--- a/client/init.c
+++ b/client/init.c
@@ -61,6 +61,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nJsonOutput    = pCmdArgsIn->nJsonOutput;
     pCmdArgs->nTestOnly      = pCmdArgsIn->nTestOnly;
     pCmdArgs->nSkipBroken    = pCmdArgsIn->nSkipBroken;
+    pCmdArgs->nSource        = pCmdArgsIn->nSource;
 
     pCmdArgs->nArgc = pCmdArgsIn->nArgc;
     pCmdArgs->ppszArgv = pCmdArgsIn->ppszArgv;

--- a/client/init.c
+++ b/client/init.c
@@ -62,6 +62,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nTestOnly      = pCmdArgsIn->nTestOnly;
     pCmdArgs->nSkipBroken    = pCmdArgsIn->nSkipBroken;
     pCmdArgs->nSource        = pCmdArgsIn->nSource;
+    pCmdArgs->nBuildDeps     = pCmdArgsIn->nBuildDeps;
 
     pCmdArgs->nArgc = pCmdArgsIn->nArgc;
     pCmdArgs->ppszArgv = pCmdArgsIn->ppszArgv;
@@ -126,7 +127,7 @@ TDNFCloneCmdArgs(
 
     pCmdArgs->nCmdCount = pCmdArgsIn->nCmdCount;
     dwError = TDNFAllocateMemory(
-                  pCmdArgs->nCmdCount,
+                  pCmdArgs->nCmdCount + 1,
                   sizeof(char*),
                   (void**)&pCmdArgs->ppszCmds);
     BAIL_ON_TDNF_ERROR(dwError);

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -657,7 +657,8 @@ uint32_t
 TDNFAddPackagesForInstall(
     PSolvSack pSack,
     Queue* pQueueGoal,
-    const char* pszPkgName
+    const char* pszPkgName,
+    int nSource
     )
 {
     uint32_t dwError = 0;
@@ -673,6 +674,7 @@ TDNFAddPackagesForInstall(
     dwError = SolvFindHighestAvailable(
                   pSack,
                   pszPkgName,
+                  nSource,
                   &dwHighestAvailable);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -771,6 +773,7 @@ TDNFAddPackagesForUpgrade(
     dwError = SolvFindHighestAvailable(
                   pSack,
                   pszPkgName,
+                  0,
                   &dwHighestAvailable);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -420,6 +420,13 @@ TDNFGoal(
     );
 
 uint32_t
+TDNFGoalNoDeps(
+    PTDNF pTdnf,
+    Queue* pQueuePkgList,
+    PTDNF_SOLVED_PKG_INFO* ppInfo
+    );
+
+uint32_t
 TDNFHistoryGoal(
     PTDNF pTdnf,
     Queue *pqInstall,
@@ -790,6 +797,14 @@ uint32_t
 TDNFAddNotResolved(
     char** ppszPkgsNotResolved,
     const char* pszPkgName
+    );
+
+uint32_t
+TDNFResolveBuildDependencies(
+    PTDNF pTdnf,
+    char **ppszPackageNameSpecs,
+    char **ppszPkgsNotResolved,
+    Queue* queueGoal
     );
 
 //rpmtrans.c

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -338,7 +338,8 @@ uint32_t
 TDNFAddPackagesForInstall(
     PSolvSack pSack,
     Queue* pQueueGoal,
-    const char* pszPkgName
+    const char* pszPkgName,
+    int nSource
     );
 
 uint32_t

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -341,7 +341,7 @@ TDNFPrepareSinglePkg(
     pSack = pTdnf->pSack;
 
     //Check if this is a known package. If not add to unresolved
-    dwError = SolvCountPkgByName(pSack, pszPkgName, &dwCount);
+    dwError = SolvCountPkgByName(pSack, pszPkgName, pTdnf->pArgs->nSource, &dwCount);
     if (dwError == ERROR_TDNF_NO_MATCH)
     {
         pr_err("%s package not found or not installed\n", pszPkgName);
@@ -388,10 +388,13 @@ TDNFPrepareSinglePkg(
     }
     else if (nAlterType == ALTER_INSTALL)
     {
+        int nSource = pTdnf->pArgs->nSource;
+
         dwError = TDNFAddPackagesForInstall(
                       pSack,
                       queueGoal,
-                      pszPkgName);
+                      pszPkgName,
+                      nSource);
         if (dwError == ERROR_TDNF_ALREADY_INSTALLED)
         {
             /* the package may have been already installed as a dependency,

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -457,3 +457,88 @@ error:
     }
     goto cleanup;
 }
+
+uint32_t
+TDNFResolveBuildDependencies(
+    PTDNF pTdnf,
+    char **ppszPackageNameSpecs,
+    char **ppszPkgsNotResolved,
+    Queue* queueGoal
+    )
+{
+    uint32_t dwError = 0;
+    int i;
+    PSolvQuery pQuery = NULL;
+    PSolvPackageList pPkgList = NULL;
+    Queue qDeps = {0};
+    const char *pszDep = NULL;
+
+    if(!pTdnf || !pTdnf->pSack || !ppszPackageNameSpecs)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if (ppszPackageNameSpecs[0]) {
+        dwError = SolvCreateQuery(pTdnf->pSack, &pQuery);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = TDNFApplyScopeFilter(pQuery, SCOPE_SOURCE);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvApplyPackageFilter(pQuery, ppszPackageNameSpecs);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvApplyListQuery(pQuery);
+        BAIL_ON_TDNF_ERROR(dwError);
+
+        dwError = SolvGetQueryResult(pQuery, &pPkgList);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    queue_init(&qDeps);
+
+    if (queueGoal->count > 0) {
+        /* queueGoal has the command line packages */
+        dwError = SolvRequiresFromQueue(pTdnf->pSack->pPool, queueGoal, &qDeps);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    queue_empty(queueGoal);
+
+    if (pPkgList && pPkgList->queuePackages.count > 0) {
+        dwError = SolvRequiresFromQueue(pTdnf->pSack->pPool, &pPkgList->queuePackages, &qDeps);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    for (i = 0; i < qDeps.count; i++) {
+        pszDep = pool_id2str(pTdnf->pSack->pPool, qDeps.elements[i]);
+        if (!pszDep) {
+            dwError = ERROR_TDNF_INVALID_PARAMETER;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+        if (strncmp(pszDep, "rpmlib(", 7) == 0) {
+            /* packages from cmd line require these and nothing provides
+               them */
+            continue;
+        }
+        dwError = TDNFPrepareSinglePkg(
+                      pTdnf,
+                      pszDep,
+                      ALTER_INSTALL,
+                      ppszPkgsNotResolved,
+                      queueGoal);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+cleanup:
+    queue_free(&qDeps);
+    if(pQuery) {
+        SolvFreeQuery(pQuery);
+    }
+    if(pPkgList) {
+        SolvFreePackageList(pPkgList);
+    }
+    return dwError;
+error:
+    goto cleanup;
+}

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -61,8 +61,6 @@ TDNFPrepareAllPackages(
     uint32_t dwError = 0;
     PTDNF_CMD_ARGS pCmdArgs = NULL;
     int nPkgIndex = 0;
-    int nIsFile = 0;
-    int nDummy = 0;
     char* pszPkgName = NULL;
     char* pszName = NULL;
     Queue queueLocal = {0};
@@ -173,26 +171,10 @@ TDNFPrepareAllPackages(
            }
            else
            {
-               dwError = TDNFIsFileOrSymlink(pszPkgName, &nIsFile);
-               BAIL_ON_TDNF_ERROR(dwError);
-
-               if (nIsFile && (fnmatch("*.rpm", pszPkgName, 0) == 0))
-               {
+               if (fnmatch("*.rpm", pszPkgName, 0) == 0) {
+                   /* already handled in TDNFAddCmdLinePackages */
                    continue;
                }
-
-               dwError = TDNFUriIsRemote(pszPkgName, &nDummy);
-               if (dwError == 0)
-               {
-                 /* URL => cmd line pkg, already handled */
-                 dwError = 0;
-                 continue;
-               }
-               else if (dwError == ERROR_TDNF_URL_INVALID)
-               {
-                   dwError = 0;
-               }
-               BAIL_ON_TDNF_ERROR(dwError);
 
                dwError = TDNFPrepareSinglePkg(
                              pTdnf,

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -229,6 +229,7 @@ typedef struct _TDNF_CMD_ARGS
     int nTestOnly;         //run test transaction only
     int nSkipBroken;
     int nSource;
+    int nBuildDeps;
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -81,7 +81,8 @@ typedef enum
     SCOPE_OBSOLETES,
     SCOPE_RECENT,
     SCOPE_UPGRADES,
-    SCOPE_DOWNGRADES
+    SCOPE_DOWNGRADES,
+    SCOPE_SOURCE
 }TDNF_SCOPE;
 
 //availability - updateinfo
@@ -227,6 +228,7 @@ typedef struct _TDNF_CMD_ARGS
     int nJsonOutput;       //output in json format
     int nTestOnly;         //run test transaction only
     int nSkipBroken;
+    int nSource;
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/pytests/tests/test_srpms.py
+++ b/pytests/tests/test_srpms.py
@@ -1,0 +1,81 @@
+#
+# Copyright (C) 2019 - 2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import glob
+import os
+import platform
+import pytest
+import shutil
+
+ARCH = platform.machine()
+
+DIST = os.environ.get('DIST')
+# dir that holds the SPECS dir:
+if DIST == 'fedora':
+    RPMBUILD_DIR = '/root/rpmbuild'
+else:
+    RPMBUILD_DIR = '/usr/src/photon'
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    if (os.path.isdir(RPMBUILD_DIR)):
+        shutil.rmtree(RPMBUILD_DIR)
+
+
+def get_pkg_file_path(utils, pkgname):
+    dir = os.path.join(utils.config['repo_path'], 'photon-test', 'RPMS', ARCH)
+    matches = glob.glob('{}/{}-*.rpm'.format(dir, pkgname))
+    return matches[0]
+
+
+def get_srcpkg_file_path(utils, pkgname):
+    dir = os.path.join(utils.config['repo_path'], 'photon-test-src', 'SRPMS')
+    matches = glob.glob('{}/{}-*.src.rpm'.format(dir, pkgname))
+    return matches[0]
+
+
+def test_install_srpm(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+
+    ret = utils.run(['tdnf', 'install', '--repoid=photon-test-src', '-y', '--source', '--nogpgcheck', pkgname])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)  # source RPMs are never really installed
+
+    assert len(glob.glob(os.path.join(RPMBUILD_DIR, 'SPECS', '*.spec'))) > 0
+
+
+def test_install_srpm_file_with_source_option(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_srcpkg_file_path(utils, pkgname)
+    ret = utils.run(['tdnf', 'install', '-y', '--source', '--nogpgcheck', path])
+    assert ret['retval'] == 0
+
+    assert len(glob.glob(os.path.join(RPMBUILD_DIR, 'SPECS', '*.spec'))) > 0
+
+
+# fail if trying to install an rpm with --source option
+def test_install_rpm_file_with_source_option(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_pkg_file_path(utils, pkgname)
+    ret = utils.run(['tdnf', 'install', '-y', '--source', '--nogpgcheck', path])
+    assert ret['retval'] != 0
+
+
+# fail if trying to install an srpm without --source option
+def test_install_srpm_file_without_source_option(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+    path = get_srcpkg_file_path(utils, pkgname)
+    ret = utils.run(['tdnf', 'install', '-y', '--nogpgcheck', path])
+    assert ret['retval'] != 0

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -626,6 +626,13 @@ SolvFindSolvablesByNevraStr(
     int installed
     );
 
+uint32_t
+SolvRequiresFromQueue(
+    Pool *pool,
+    Queue *pq_pkgs,  /* solvable ids */
+    Queue *pq_deps   /* string ids */
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -210,6 +210,13 @@ SolvFindAvailablePkgByName(
     );
 
 uint32_t
+SolvFindAvailableSrcPkgByName(
+    PSolvSack pSack,
+    const char* pszName,
+    PSolvPackageList* ppPkgList
+    );
+
+uint32_t
 SolvFindInstalledPkgByName(
     PSolvSack pSack,
     const char* pszName,
@@ -227,6 +234,7 @@ uint32_t
 SolvCountPkgByName(
     PSolvSack pSack,
     const char* pszName,
+    int nSource,
     uint32_t * pdwCount
     );
 
@@ -242,6 +250,7 @@ uint32_t
 SolvFindHighestAvailable(
     PSolvSack pSack,
     const char* pszPkgName,
+    int nSource,
     Id* pdwId
     );
 

--- a/solv/simplequery.c
+++ b/solv/simplequery.c
@@ -132,3 +132,25 @@ cleanup:
 error:
     goto cleanup;
 }
+
+uint32_t
+SolvRequiresFromQueue(
+    Pool *pool,
+    Queue *pq_pkgs,  /* solvable ids */
+    Queue *pq_deps   /* string ids */
+)
+{
+    uint32_t dwError = 0;
+    int i,j;
+
+    for (i = 0; i < pq_pkgs->count; i++) {
+        Queue q_tmp = {0};
+        Solvable *p_solv = pool_id2solvable(pool, pq_pkgs->elements[i]);
+        solvable_lookup_deparray(p_solv, SOLVABLE_REQUIRES, &q_tmp, -1);
+        for(j = 0; j < q_tmp.count; j++) {
+            queue_pushunique(pq_deps, q_tmp.elements[j]);
+        }
+        queue_free(&q_tmp);
+    }
+    return dwError;
+}

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -621,8 +621,15 @@ SolvApplyListQuery(
     }
 
     queue_init(&queueTmp);
-    nFlags = SELECTION_NAME | SELECTION_PROVIDES | SELECTION_GLOB;
-    nFlags |= SELECTION_CANON|SELECTION_DOTARCH|SELECTION_REL;
+    nFlags = SELECTION_NAME |     /* foo */
+             SELECTION_PROVIDES |
+             SELECTION_GLOB |     /* foo* */
+             SELECTION_CANON |    /* foo-1.2-3.ph4.noarch */
+             SELECTION_REL;       /* foo>=1.2-3 */
+
+    if (pQuery->nScope == SCOPE_SOURCE) {
+        nFlags |= SELECTION_SOURCE_ONLY;
+    }
 
     dwError = SolvGenerateCommonJob(pQuery, nFlags);
     BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -32,6 +32,7 @@ static struct option pstOptions[] =
     {"assumeno",      no_argument, &_opt.nAssumeNo, 1},    //--assumeno
     {"assumeyes",     no_argument, 0, 'y'},                //--assumeyes
     {"best",          no_argument, &_opt.nBest, 1},        //--best
+    {"builddeps",     no_argument, &_opt.nBuildDeps, 1},
     {"cacheonly",     no_argument, &_opt.nCacheOnly, 1}, //-C, --cacheonly
     {"config",        required_argument, 0, 'c'},          //-c, --config
     {"debuglevel",    required_argument, 0, 'd'},          //-d, --debuglevel
@@ -343,6 +344,7 @@ TDNFCopyOptions(
     pArgs->nTestOnly      = pOptionArgs->nTestOnly;
     pArgs->nSkipBroken    = pOptionArgs->nSkipBroken;
     pArgs->nSource        = pOptionArgs->nSource;
+    pArgs->nBuildDeps     = pOptionArgs->nBuildDeps;
 
 cleanup:
     return dwError;

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -67,6 +67,7 @@ static struct option pstOptions[] =
     {"skipdigest",    no_argument, 0, 0},                  //--skipdigest to skip verifying RPM digest
     {"skipobsoletes", no_argument, 0, 0},                  //--skipobsoletes to skip obsolete problems
     {"skipsignature", no_argument, 0, 0},                  //--skipsignature to skip verifying RPM signatures
+    {"source",        no_argument, &_opt.nSource, 1},
     {"testonly",      no_argument, &_opt.nTestOnly, 1},
     {"verbose",       no_argument, &_opt.nVerbose, 1},     //-v --verbose
     {"version",       no_argument, &_opt.nShowVersion, 1}, //--version
@@ -79,7 +80,6 @@ static struct option pstOptions[] =
     {"metadata-path", required_argument, 0, 0},
     {"newest-only",   no_argument, 0, 0},
     {"norepopath",    no_argument, 0, 0},
-    {"source",        no_argument, 0, 0},
     {"urls",          no_argument, 0, 0},
     // repoquery option
     // repoquery select options
@@ -342,6 +342,7 @@ TDNFCopyOptions(
     pArgs->nJsonOutput    = pOptionArgs->nJsonOutput;
     pArgs->nTestOnly      = pOptionArgs->nTestOnly;
     pArgs->nSkipBroken    = pOptionArgs->nSkipBroken;
+    pArgs->nSource        = pOptionArgs->nSource;
 
 cleanup:
     return dwError;


### PR DESCRIPTION
This adds the two options `--source` and `--builddeps` to download source packages and build dependencies for a package.

Usage example:
```
# cat /etc/yum.repos.d/photon-srpms.repo                                                                                                                               
[photon-srpms]
name=VMware Photon Linux $releasever ($basearch)
baseurl=https://packages.vmware.com/photon/$releasever/photon_srpms_$releasever_$basearch
gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096
gpgcheck=1
enabled=1
skip_if_unavailable=1
skip_md_filelists=1
```
```
tdnf install --source lsof
tdnf install --builddeps lsof
rpmbuild -bb /usr/src/photon/SPECS/lsof.spec
```
See built packages:
```
# ls -lR /usr/src/photon/RPMS/                                                                                                                                         
/usr/src/photon/RPMS/:
total 4
drwxr-xr-x 2 root root 4096 Feb  3 20:14 x86_64

/usr/src/photon/RPMS/x86_64:
total 144
-rw-r--r-- 1 root root 127910 Feb  3 20:14 lsof-4.95.0-1.x86_64.rpm
-rw-r--r-- 1 root root  15817 Feb  3 20:14 lsof-debuginfo-4.95.0-1.x86_64.rpm
```

Showing output of the commands:
```
# tdnf install --source lsof                                                                                                                                     
Refreshing metadata for: 'VMware Photon Linux 4.0 (x86_64)'
photon-srpms                            392205 100%
Installing:
lsof                                   src                          4.95.0-1.ph4                           photon-srpms                   1.28M                           1.29M

Total installed size:   1.28M
Total download size:   1.29M
Is this ok [y/N]: y
lsof                                   1351526 100%
Installing/Updating: lsof-4.95.0-1.ph4 (source)
Testing transaction
Running transaction
```
```
# tdnf install --builddeps lsof                                                                                                                                  

Installing:
krb5-devel                             x86_64                       1.17-9.ph4                             photon-updates               711.98k                         130.77k
libtirpc                               x86_64                       1.2.6-4.ph4                            photon-updates               197.58k                          91.54k
libtirpc-devel                         x86_64                       1.2.6-4.ph4                            photon-updates               654.85k                         200.36k

Total installed size:   1.53M
Total download size: 422.67k

Upgrading:
krb5                                   x86_64                       1.17-9.ph4                             photon-updates                 3.34M                           1.15M

Total installed size:   3.34M
Total download size:   1.15M
Is this ok [y/N]: y
krb5-devel                              133904 100%
libtirpc                                 93737 100%
libtirpc-devel                          205172 100%
krb5                                   1201085 100%
Testing transaction
Running transaction
Installing/Updating: krb5-1.17-9.ph4.x86_64
Installing/Updating: krb5-devel-1.17-9.ph4.x86_64
Installing/Updating: libtirpc-1.2.6-4.ph4.x86_64
Installing/Updating: libtirpc-devel-1.2.6-4.ph4.x86_64
Removing: krb5-1.17-7.ph4.x86_64
```

