### PR TITLE
BugFix segfault caused due to missing name param

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -487,7 +487,7 @@ TDNFLoadReposFromFile(
         dwError = TDNFReadKeyValue(
                       pSections,
                       TDNF_REPO_KEY_NAME,
-                      NULL,
+                      pszRepo,
                       &pRepo->pszName);
         BAIL_ON_TDNF_ERROR(dwError);
 


### PR DESCRIPTION
If a repository definition is missing the name parameter the repositroy is later processed and a segfault occurs.

Adding a check to ensure that the repository is not processed in the event that the name parameter is missing.

fixes #400