### PR TITLE
Ensure tdnf lock file is removed on application exit

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -22,12 +22,6 @@
 
 #include "config.h"
 
-/*
- * creating this under /var/run because /var/run/lock doesn't exist
- * in fedora docker images and as a result ci fails
- */
-#define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instance-lockfile"
-
 typedef enum
 {
     /* this should be a bitmask */

--- a/common/defines.h
+++ b/common/defines.h
@@ -33,3 +33,9 @@
     } while(0)
 
 #define TDNF_DEFAULT_MAX_STRING_LEN       16384000
+
+/*
+ * creating this under /var/run because /var/run/lock doesn't exist
+ * in fedora docker images and as a result ci fails
+ */
+#define TDNF_INSTANCE_LOCK_FILE     "/var/run/.tdnf-instance-lockfile"


### PR DESCRIPTION
On completion of a tdnf run, ensure that lock file is removed from /var/run.

Insert the PID of the running tdnf process into the lock file.

fixes #402 