### PR TITLE
Add new 'dnf_check_update_compat' config file option. Defaults to disabled.

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -638,6 +638,8 @@ TDNFOpenHandle(
                   TDNF_CONF_GROUP);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    GlobalSetDnfCheckUpdateCompat(pTdnf->pConf->nCheckUpdateCompat);
+
     dwError = TDNFHasOpt(pTdnf->pArgs, TDNF_SETOPT_KEY_REPOSDIR, &nHasOptReposdir);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/config.c
+++ b/client/config.c
@@ -151,6 +151,13 @@ TDNFReadConfig(
                   &pConf->nOpenMax);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFReadKeyValueBoolean(
+                  pSection,
+                  TDNF_CONF_KEY_CHECK_UPDATE_COMPAT,
+                  0,
+                  &pConf->nCheckUpdateCompat);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFConfigReadProxySettings(
                   pSection,
                   pConf);

--- a/client/defines.h
+++ b/client/defines.h
@@ -95,6 +95,7 @@ typedef enum
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
 #define TDNF_CONF_KEY_MINVERSIONS         "minversions"
 #define TDNF_CONF_KEY_OPENMAX             "openmax"
+#define TDNF_CONF_KEY_CHECK_UPDATE_COMPAT "dnf_check_update_compat"
 
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"

--- a/common/log.c
+++ b/common/log.c
@@ -10,6 +10,7 @@
 
 static bool isQuiet = false;
 static bool isJson = false;
+static bool isDnfCheckUpdateCompat = false;
 
 void GlobalSetQuiet(int32_t val)
 {
@@ -25,6 +26,19 @@ void GlobalSetJson(int32_t val)
     {
         isJson = true;
     }
+}
+
+void GlobalSetDnfCheckUpdateCompat(int32_t val)
+{
+    if (val > 0)
+    {
+        isDnfCheckUpdateCompat = true;
+    }
+}
+
+bool GlobalGetDnfCheckUpdateCompat()
+{
+    return isDnfCheckUpdateCompat;
 }
 
 void log_console(int32_t loglevel, const char *format, ...)

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -328,6 +328,7 @@ TDNFGetOptWithDefault(
     char **ppszOptValue
     );
 
+//log.c
 void
 GlobalSetQuiet(
     int32_t val
@@ -336,6 +337,16 @@ GlobalSetQuiet(
 void
 GlobalSetJson(
     int32_t val
+    );
+
+void
+GlobalSetDnfCheckUpdateCompat(
+    int32_t val
+    );
+
+bool
+GlobalGetDnfCheckUpdateCompat(
+    void
     );
 
 void

--- a/include/tdnfclierror.h
+++ b/include/tdnfclierror.h
@@ -9,6 +9,7 @@
 #ifndef __TDNF_CLI_ERR_H__
 #define __TDNF_CLI_ERR_H__
 
+#define ERROR_TDNF_CLI_CHECK_UPDATES_AVAILABLE           100
 #define ERROR_TDNF_CLI_BASE                              900
 #define ERROR_TDNF_CLI_NO_MATCH                          (ERROR_TDNF_CLI_BASE + 1)
 #define ERROR_TDNF_CLI_INVALID_ARGUMENT                  (ERROR_TDNF_CLI_BASE + 2)

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -248,6 +248,7 @@ typedef struct _TDNF_CONF
     int nCleanRequirementsOnRemove;
     int nKeepCache;
     int nOpenMax;          //set max number of open files
+    int nCheckUpdateCompat;
     char* pszRepoDir;
     char* pszCacheDir;
     char* pszPersistDir;

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -205,6 +205,11 @@ TDNFCliPrintError(
         return dwError;
     }
 
+    if (dwErrorCode == ERROR_TDNF_CLI_CHECK_UPDATES_AVAILABLE)
+    {
+        return dwError;
+    }
+
     if (dwErrorCode < ERROR_TDNF_BASE)
     {
         dwError = TDNFCliGetErrorString(dwErrorCode, &pszError);


### PR DESCRIPTION
Add new 'dnf_check_update_compat' config file option. Defaults to disabled.
When enabled, return exit status 100 if there are package updates available.
Updated formatting of check-update to match that of list so that it can be
parsed by puppet correctly.

Background:
Puppet and other tooling expects yum/dnf/tdnf check-update to return exit code 100 if there are updates available. (If you merely want a list of the update you can call yum/dnf/tdnf list updates. There is a reason these are different commands I suppose.)

This PR adds this functionality to tdnf.
I was not sure of the best way to add this functionality given the current error handling and error code tables.

Here is an example call from puppet:

```
Debug: Prefetching tdnf resources for package
Debug: Executing: '/bin/rpm --version'
Debug: Executing '/bin/rpm -qa --nosignature --nodigest --qf '%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n' | sort'
Debug: Executing: '/bin/tdnf check-update'
Debug: Puppet::Type::Package::ProviderTdnf: /bin/tdnf check-update exited with 0; no package updates available.
```

tdnf also prints the table columns in reverse for some reason (see: `tdnf check-update | less`) which also break's puppet's parsing of the output.
Modified check-update (`TDNFCliCheckUpdateCommand`) to use the same output as list (`TDNFCliListCommand`).

Testing:
Builds and runs for me and provides the correct status code.
Puppet is also now able to parse the output to determine which packages need updating and invokes tdnf to update the packages.

```
Debug: Prefetching tdnf resources for package
Debug: Executing: '/bin/rpm --version'
Debug: Executing '/bin/rpm -qa --nosignature --nodigest --qf '%{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n' | sort'
Debug: Executing: '/bin/tdnf check-update'
Debug: Package[LNKD-ucm-enc](provider=tdnf): Yum didn't find updates, current version (2.0.9-1.el7) is the latest
Debug: /Stage[main]/Coreucm/Package[LNKD-ucm-hieraretrieve]/ensure: LNKD-ucm-hieraretrieve "2.0.24-1.el7" is installed, latest is "0:2.0.25-1.el7"
Debug: Package[LNKD-ucm-hieraretrieve](provider=tdnf): Ensuring => latest
Debug: Executing: '/bin/rpm -q LNKD-ucm-hieraretrieve --nosignature --nodigest --qf %{NAME} %|EPOCH?{%{EPOCH}}:{0}| %{VERSION} %{RELEASE} %{ARCH}\n'
Debug: Package[LNKD-ucm-hieraretrieve](provider=tdnf): Ensuring latest, so using upgrade
Debug: Executing: '/bin/tdnf -e 1 -y upgrade LNKD-ucm-hieraretrieve'
Notice: /Stage[main]/Coreucm/Package[LNKD-ucm-hieraretrieve]/ensure: ensure changed '2.0.24-1.el7' to '0:2.0.25-1.el7'
Debug: /Package[LNKD-ucm-hieraretrieve]: The container Class[Coreucm] will propagate my refresh event
Debug: Finishing transaction 48526180
```