### PR TITLE
Only look for packages to reinstall when we actually want to reinstall.

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -158,6 +158,13 @@ TDNFReadConfig(
                   &pConf->nCheckUpdateCompat);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFReadKeyValueBoolean(
+                  pSection,
+                  TDNF_CONF_KEY_DISTROSYNC_REINSTALL_CHANGED,
+                  0,
+                  &pConf->nDistroSyncReinstallChanged);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     dwError = TDNFConfigReadProxySettings(
                   pSection,
                   pConf);

--- a/client/defines.h
+++ b/client/defines.h
@@ -90,6 +90,7 @@ typedef enum
 #define TDNF_CONF_KEY_MINVERSIONS         "minversions"
 #define TDNF_CONF_KEY_OPENMAX             "openmax"
 #define TDNF_CONF_KEY_CHECK_UPDATE_COMPAT "dnf_check_update_compat"
+#define TDNF_CONF_KEY_DISTROSYNC_REINSTALL_CHANGED "distrosync_reinstall_changed"
 
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"

--- a/client/goal.c
+++ b/client/goal.c
@@ -20,6 +20,16 @@
 
 #include "includes.h"
 
+static
+uint32_t
+TDNFGoalGetAllResultsIgnoreNoData(
+    Transaction* pTrans,
+    Solver* pSolv,
+    PTDNF_SOLVED_PKG_INFO* ppInfo,
+    PTDNF pTdnf,
+    int nReInstall
+);
+
 uint32_t
 TDNFGetPackagesWithSpecifiedType(
     Transaction* pTrans,
@@ -289,6 +299,7 @@ TDNFSolv(
     uint32_t dwExcludeCount,
     int nAllowErasing,
     int nAutoErase,
+    int nReInstall,
     PTDNF_SOLVED_PKG_INFO* ppInfo
     )
 {
@@ -380,7 +391,8 @@ TDNFSolv(
                   pTrans,
                   pSolv,
                   &pInfo,
-                  pTdnf);
+                  pTdnf,
+                  nReInstall);
     BAIL_ON_TDNF_ERROR(dwError);
 
     *ppInfo = pInfo;
@@ -474,6 +486,7 @@ TDNFGoal(
                        (pTdnf->pConf->nCleanRequirementsOnRemove &&
                                 !pTdnf->pArgs->nNoAutoRemove) ||
                                nAlterType == ALTER_AUTOERASE,
+                                nAlterType == ALTER_REINSTALL,
                        ppInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -535,6 +548,7 @@ TDNFHistoryGoal(
     dwError = TDNFSolv(pTdnf, &queueJobs, ppszExcludes, dwExcludeCount,
                        1, /* nAllowErasing */
                        0, /* nAutoErase */
+                       0, /* nReInstall */
                        ppInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -770,12 +784,14 @@ error:
     goto cleanup;
 }
 
+static
 uint32_t
 TDNFGoalGetAllResultsIgnoreNoData(
     Transaction* pTrans,
     Solver* pSolv,
     PTDNF_SOLVED_PKG_INFO* ppInfo,
-    PTDNF pTdnf
+    PTDNF pTdnf,
+    int nReInstall
     )
 {
     uint32_t dwError = 0;
@@ -818,11 +834,14 @@ TDNFGoalGetAllResultsIgnoreNoData(
                   &pInfo->pPkgsToRemove);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFGetReinstallPackages(
-                  pTrans,
-                  pTdnf,
-                  &pInfo->pPkgsToReinstall);
-    BAIL_ON_TDNF_ERROR(dwError);
+    if(nReInstall)
+    {
+        dwError = TDNFGetReinstallPackages(
+                      pTrans,
+                      pTdnf,
+                      &pInfo->pPkgsToReinstall);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
 
     dwError = TDNFGetObsoletedPackages(
                   pTrans,

--- a/client/goal.c
+++ b/client/goal.c
@@ -485,8 +485,9 @@ TDNFGoal(
                        nAllowErasing,
                        (pTdnf->pConf->nCleanRequirementsOnRemove &&
                                 !pTdnf->pArgs->nNoAutoRemove) ||
-                               nAlterType == ALTER_AUTOERASE,
-                                nAlterType == ALTER_REINSTALL,
+                                nAlterType == ALTER_AUTOERASE,
+                                nAlterType == ALTER_REINSTALL ||
+                                (nAlterType == ALTER_DISTRO_SYNC && pTdnf->pConf->nDistroSyncReinstallChanged),
                        ppInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -458,14 +458,6 @@ TDNFAddGoal(
     );
 
 uint32_t
-TDNFGoalGetAllResultsIgnoreNoData(
-    Transaction* pTrans,
-    Solver* pSolv,
-    PTDNF_SOLVED_PKG_INFO* ppInfo,
-    PTDNF pTdnf
-    );
-
-uint32_t
 TDNFGetPackagesWithSpecifiedType(
     Transaction* pTrans,
     PTDNF pTdnf,

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -249,6 +249,7 @@ typedef struct _TDNF_CONF
     int nKeepCache;
     int nOpenMax;          //set max number of open files
     int nCheckUpdateCompat;
+    int nDistroSyncReinstallChanged;
     char* pszRepoDir;
     char* pszCacheDir;
     char* pszPersistDir;


### PR DESCRIPTION
This fixes an issue with distro-sync which would reinstall all rebuilt packages (with same EVR as installed packages) from a repository. This situation should not happen outside of testing.