### PR TITLE
refactor yes/no question

### DIFF
--- a/common/log.c
+++ b/common/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -83,7 +83,7 @@ void log_console(int32_t loglevel, const char *format, ...)
     }
 
     vfprintf(stream, format, args);
-
+    fflush(stream);
 end:
     va_end(args);
 }

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms
@@ -428,13 +428,24 @@ TDNFYesOrNo(
 
     if(!pArgs->nAssumeYes && !pArgs->nAssumeNo)
     {
-        pr_crit("%s", pszQuestion);
-        while ((opt = getchar()) == '\n' || opt == '\r');
-        opt = tolower(opt);
-        if (opt != 'y' && opt != 'n')
-        {
-            dwError = ERROR_TDNF_INVALID_INPUT;
-            BAIL_ON_TDNF_ERROR(dwError);
+        while(1) {
+            pr_crit("%s", pszQuestion);
+            char buf[256] = {0};
+            char *ret;
+
+            ret = fgets(buf, sizeof(buf)-1, stdin);
+            if (ret != buf || buf[0] == 0) {
+                /* should not happen */
+                dwError = ERROR_TDNF_INVALID_INPUT;
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+            buf[strlen(buf)-1] = 0;
+            if (strcasecmp(buf, "yes") == 0 || strcasecmp(buf, "y") == 0 ||
+                    strcasecmp(buf, "n") == 0 || strcasecmp(buf, "no") == 0 ||
+                    buf[0] == 0) {
+                opt = tolower(buf[0]);
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Make the yes/no question behave better. This will terminate only on valid answers, and otherwise repeat the question. Also adding "yes" and "no" (case insensitive) to valid answers. An empty response will be interpreted the same as "n" or "no". This is the same behavior as Fedora's dnf.

Examples:
Repeat question on invalid answers, accept "no":
```
# tdnf install lsof  

Installing:
lsof                                   x86_64                       4.95.0-1.ph4                           photon-updates               207.70k                         121.54k

Total installed size: 207.70k
Total download size: 121.54k
Is this ok [y/N]: yeah
Is this ok [y/N]: maybe
Is this ok [y/N]: nope
Is this ok [y/N]: no
Error(1032) : Operation aborted.
```
Accepts "yes":
```
# tdnf install lsof                                                                                                                                              

Installing:
lsof                                   x86_64                       4.95.0-1.ph4                           photon-updates               207.70k                         121.54k

Total installed size: 207.70k
Total download size: 121.54k
Is this ok [y/N]: yes
lsof                                    124456 100%
Testing transaction
Running transaction
Installing/Updating: lsof-4.95.0-1.ph4.x86_64
```
Accepts upper case "Y":
```
# tdnf remove lsof                                                                                                                                               

Removing:
lsof                                   x86_64                       4.95.0-1.ph4                           @System                      207.70k                           0.00b

Total installed size: 207.70k
Total download size:   0.00b
Is this ok [y/N]: Y
Testing transaction
Running transaction
Removing: lsof-4.95.0-1.ph4.x86_64
root [ /build/bld-ph4 ]#
```
Empty response is "no" (default):
```# tdnf install lsof                                                                                                                                              

Installing:
lsof                                   x86_64                       4.95.0-1.ph4                           photon-updates               207.70k                         121.54k

Total installed size: 207.70k
Total download size: 121.54k
Is this ok [y/N]: 
Error(1032) : Operation aborted.
```
