### PR TITLE
fix copyright years

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/client/api.c
+++ b/client/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/client.c
+++ b/client/client.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/config.c
+++ b/client/config.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/defines.h
+++ b/client/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/goal.c
+++ b/client/goal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/includes.h
+++ b/client/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/init.c
+++ b/client/init.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/repo.c
+++ b/client/repo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/client/utils.c
+++ b/client/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/common/defines.h
+++ b/common/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/lock.c
+++ b/common/lock.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2021-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/log.c
+++ b/common/log.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/common/utils.c
+++ b/common/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/etc/tdnf/CMakeLists.txt
+++ b/etc/tdnf/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/etc/tdnf/pluginconf.d/CMakeLists.txt
+++ b/etc/tdnf/pluginconf.d/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/history/history.c
+++ b/history/history.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/history/main.c
+++ b/history/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnf-common-defines.h
+++ b/include/tdnf-common-defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfclierror.h
+++ b/include/tdnfclierror.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnfplugineventmap.h
+++ b/include/tdnfplugineventmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/jsondump/jsondump.c
+++ b/jsondump/jsondump.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/jsondump/jsondump.h
+++ b/jsondump/jsondump.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/llconf/CMakeLists.txt
+++ b/llconf/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/plugins/metalink/includes.h
+++ b/plugins/metalink/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/metalink/list.c
+++ b/plugins/metalink/list.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2021-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/metalink/metalink.c
+++ b/plugins/metalink/metalink.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/metalink/prototypes.h
+++ b/plugins/metalink/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/metalink/utils.c
+++ b/plugins/metalink/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2021-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/repogpgcheck/CMakeLists.txt
+++ b/plugins/repogpgcheck/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/plugins/repogpgcheck/api.c
+++ b/plugins/repogpgcheck/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/repogpgcheck/prototypes.h
+++ b/plugins/repogpgcheck/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/pytests/CMakeLists.txt
+++ b/pytests/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2020-2021 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU Lesser General Public License v2.1 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_check_update.py
+++ b/pytests/tests/test_check_update.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_config.py
+++ b/pytests/tests/test_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_configutil.py
+++ b/pytests/tests/test_configutil.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/pytests/tests/test_provides.py
+++ b/pytests/tests/test_provides.py
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/python/includes.h
+++ b/python/includes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/python/tdnfpyrepodata.c
+++ b/python/tdnfpyrepodata.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/scripts/fix-copyright.py
+++ b/scripts/fix-copyright.py
@@ -21,6 +21,8 @@ import os
 import re
 from datetime import datetime
 
+IGNORE_COMMITS = ['38fa1f466b86ffdf550b17461b2722b4ddc07a85']
+
 class Commit:
     def __init__(self, id):
         self.id = id
@@ -41,7 +43,7 @@ def get_latest_commit(file):
     stream = os.popen('git log --pretty=fuller {}'.format(file))
     for line in stream.readlines():
         if line.startswith('commit'):
-            commit = Commit(line.split(' ')[1]).strip()
+            commit = Commit(line.strip().split(' ')[1])
         # We use the commit date, not the author date
         # see https://stackoverflow.com/questions/11856983/why-git-authordate-is-different-from-commitdate
         elif line.startswith('CommitDate:'):
@@ -89,5 +91,6 @@ if __name__ == '__main__':
     files = get_files()
     for f in files:
         commit = get_latest_commit(f)
-        year = str(commit.date.year)
-        fix_file(f, year)
+        if commit.id not in IGNORE_COMMITS:
+            year = str(commit.date.year)
+            fix_file(f, year)

--- a/solv/CMakeLists.txt
+++ b/solv/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2022 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/simplequery.c
+++ b/solv/simplequery.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2022-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfpool.c
+++ b/solv/tdnfpool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2015-2021 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms

--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2017-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU Lesser General Public License v2.1 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/options.c
+++ b/tools/cli/lib/options.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parsecleanargs.c
+++ b/tools/cli/lib/parsecleanargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parselistargs.c
+++ b/tools/cli/lib/parselistargs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/parseupdateinfo.c
+++ b/tools/cli/lib/parseupdateinfo.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/lib/prototypes.h
+++ b/tools/cli/lib/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2019 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 VMware, Inc. All Rights Reserved.
+ * Copyright (C) 2015-2023 VMware, Inc. All Rights Reserved.
  *
  * Licensed under the GNU General Public License v2 (the "License");
  * you may not use this file except in compliance with the License. The terms

--- a/tools/config/CMakeLists.txt
+++ b/tools/config/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2020 VMware, Inc. All Rights Reserved.
+# Copyright (C) 2020-2023 VMware, Inc. All Rights Reserved.
 #
 # Licensed under the GNU General Public License v2 (the "License");
 # you may not use this file except in compliance with the License. The terms


### PR DESCRIPTION
Using `./scripts/fix-copyright.py` and ignoring 38fa1f466b86ffdf550b17461b2722b4ddc07a85, which was the last copyright update.

Maybe this should really be checked in our github workflow scripts for every PR.