### PR TITLE
fix python test for python >= 3.11

### DIFF
--- a/pytests/tests/test_tdnf_python.py
+++ b/pytests/tests/test_tdnf_python.py
@@ -21,16 +21,24 @@ def setup_test(utils):
     sglpkgname = utils.config['sglversion_pkgname']
 
     global config
-    config = utils.config['repo_path'] + '/tdnf.conf'
+    config = os.path.join(utils.config['repo_path'], "tdnf.conf")
 
     if not utils.config.get('installed', False):
-        path = '{builddir}/python/build/lib.linux-{arch}-{pymajor}.{pyminor}'
+        # find path to our tdnf python module
+        builddir = utils.config['build_dir']
+        arch = os.uname().machine
+        pymajor = sys.version_info.major
+        pyminor = sys.version_info.minor
 
-        path = path.format(builddir=utils.config['build_dir'],
-                           arch=os.uname().machine,
-                           pymajor=str(sys.version_info.major),
-                           pyminor=str(sys.version_info.minor))
+        # only support python3
+        assert pymajor == 3
 
+        if pyminor < 11:
+            path = f"{builddir}/python/build/lib.linux-{arch}-{pymajor}.{pyminor}"
+        else:
+            path = f"{builddir}/python/build/lib.linux-{arch}-cpython-{pymajor}{pyminor}"
+
+        assert os.path.isdir(path)
         sys.path.append(path)
 
     global tdnf


### PR DESCRIPTION
Python 3.11 changed the build path for the `tdnf` python module. This caused all python tests to fail.