### PR TITLE
implement `--installtodir` option

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -700,10 +700,18 @@ TDNFOpenHandle(
                   pTdnf->pArgs->pszInstallRoot);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if(!pArgs->nAllDeps)
-    {
+    if(!pArgs->nAllDeps) {
         dwError = SolvReadInstalledRpms(pSack->pPool->installed, pszCacheDir);
         BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+    } else if (pArgs->nInstallToDir) {
+        if (pArgs->nDownloadOnly && !IsNullOrEmptyString(pArgs->pszDownloadDir)) {
+            dwError = SolvReadRpmsFromDirectory(pSack->pPool->installed, pArgs->pszDownloadDir);
+            BAIL_ON_TDNF_ERROR(dwError);
+        } else {
+            pr_err("--installtodir requires --downloadonly and --downloaddir");
+            dwError = ERROR_TDNF_INVALID_PARAMETER;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
     }
 
     dwError = TDNFLoadRepoData(

--- a/client/goal.c
+++ b/client/goal.c
@@ -107,19 +107,6 @@ TDNFGetReinstallPackages(
 }
 
 uint32_t
-TDNFGetUpgradePackages(
-    Transaction* pTrans,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO* pPkgInfo)
-{
-    return TDNFGetPackagesWithSpecifiedType(
-               pTrans,
-               pTdnf,
-               pPkgInfo,
-               SOLVER_TRANSACTION_UPGRADE);
-}
-
-uint32_t
 TDNFGetErasePackages(
     Transaction* pTrans,
     PTDNF pTdnf,
@@ -146,11 +133,12 @@ TDNFGetObsoletedPackages(
 }
 
 uint32_t
-TDNFGetDownGradePackages(
+TDNFGetUpDowngradePackages(
     Transaction* pTrans,
     PTDNF pTdnf,
     PTDNF_PKG_INFO* pPkgInfo,
-    PTDNF_PKG_INFO* pRemovePkgInfo)
+    PTDNF_PKG_INFO* pRemovePkgInfo,
+    int nIsUpgrade)
 {
     uint32_t dwError = 0;
     PSolvPackageList pInstalledPkgList = NULL;
@@ -170,7 +158,7 @@ TDNFGetDownGradePackages(
                   pTrans,
                   pTdnf,
                   pPkgInfo,
-                  SOLVER_TRANSACTION_DOWNGRADE);
+                  nIsUpgrade ? SOLVER_TRANSACTION_UPGRADE : SOLVER_TRANSACTION_DOWNGRADE);
     BAIL_ON_TDNF_ERROR(dwError);
     pInfo = *pPkgInfo;
     if(!pInfo)
@@ -869,17 +857,20 @@ TDNFGoalGetAllResultsIgnoreNoData(
                   &pInfo->pPkgsToInstall);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFGetUpgradePackages(
+    dwError = TDNFGetUpDowngradePackages(
                   pTrans,
                   pTdnf,
-                  &pInfo->pPkgsToUpgrade);
+                  &pInfo->pPkgsToUpgrade,
+                  &pInfo->pPkgsRemovedByUpgrade,
+                  1);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFGetDownGradePackages(
+    dwError = TDNFGetUpDowngradePackages(
                   pTrans,
                   pTdnf,
                   &pInfo->pPkgsToDowngrade,
-                  &pInfo->pPkgsRemovedByDowngrade);
+                  &pInfo->pPkgsRemovedByDowngrade,
+                  0);
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFGetErasePackages(

--- a/client/init.c
+++ b/client/init.c
@@ -64,6 +64,7 @@ TDNFCloneCmdArgs(
     pCmdArgs->nSkipBroken    = pCmdArgsIn->nSkipBroken;
     pCmdArgs->nSource        = pCmdArgsIn->nSource;
     pCmdArgs->nBuildDeps     = pCmdArgsIn->nBuildDeps;
+    pCmdArgs->nInstallToDir  = pCmdArgsIn->nInstallToDir;
 
     pCmdArgs->nArgc = pCmdArgsIn->nArgc;
     pCmdArgs->ppszArgv = pCmdArgsIn->ppszArgv;

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -491,10 +491,13 @@ TDNFGetReinstallPackages(
     );
 
 uint32_t
-TDNFGetUpgradePackages(
+TDNFGetUpDowngradePackages(
     Transaction* pTrans,
     PTDNF pTdnf,
-    PTDNF_PKG_INFO* pPkgInfo);
+    PTDNF_PKG_INFO* pPkgInfo,
+    PTDNF_PKG_INFO* pRemovePkgInfo,
+    int nIsUpgrade
+);
 
 uint32_t
 TDNFGetErasePackages(
@@ -508,14 +511,6 @@ TDNFGetObsoletedPackages(
     Transaction* pTrans,
     PTDNF pTdnf,
     PTDNF_PKG_INFO* pPkgInfo
-    );
-
-uint32_t
-TDNFGetDownGradePackages(
-    Transaction* pTrans,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO* pPkgInfo,
-    PTDNF_PKG_INFO* pRemovePkgInfo
     );
 
 uint32_t

--- a/common/utils.c
+++ b/common/utils.c
@@ -291,6 +291,7 @@ TDNFFreeSolvedPackageInfo(
     TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsToReinstall);
     TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsObsoleted);
     TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsRemovedByDowngrade);
+    TDNF_SAFE_FREE_PKGINFO(pSolvedPkgInfo->pPkgsRemovedByUpgrade);
 
     TDNF_SAFE_FREE_STRINGARRAY(pSolvedPkgInfo->ppszPkgsNotResolved);
     TDNF_SAFE_FREE_STRINGARRAY(pSolvedPkgInfo->ppszPkgsUserInstall);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -231,6 +231,7 @@ typedef struct _TDNF_CMD_ARGS
     int nSkipBroken;
     int nSource;
     int nBuildDeps;
+    int nInstallToDir;
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -187,6 +187,7 @@ typedef struct _TDNF_SOLVED_PKG_INFO
     PTDNF_PKG_INFO pPkgsUnNeeded;
     PTDNF_PKG_INFO pPkgsToReinstall;
     PTDNF_PKG_INFO pPkgsObsoleted;
+    PTDNF_PKG_INFO pPkgsRemovedByUpgrade;
     PTDNF_PKG_INFO pPkgsRemovedByDowngrade;
     char** ppszPkgsNotResolved;
     char** ppszPkgsUserInstall;

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -792,7 +792,7 @@ error:
     }
     if(ppszLocation)
     {
-        ppszLocation = NULL;
+        *ppszLocation = NULL;
     }
     TDNF_SAFE_FREE_MEMORY(pszLocation);
     goto cleanup;

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -47,6 +47,7 @@ static struct option pstOptions[] =
     {"exclude",       required_argument, 0, 0},            //--exclude
     {"help",          no_argument, 0, 'h'},                //-h --help
     {"installroot",   required_argument, 0, 'i'},          //--installroot
+    {"installtodir",  no_argument, &_opt.nInstallToDir, 1},
     {"json",          no_argument, &_opt.nJsonOutput, 1},
     {"noautoremove",  no_argument, &_opt.nNoAutoRemove, 1},
     {"nodeps",        no_argument, &_opt.nNoDeps, 1},
@@ -355,6 +356,7 @@ TDNFCopyOptions(
     pArgs->nSkipBroken    = pOptionArgs->nSkipBroken;
     pArgs->nSource        = pOptionArgs->nSource;
     pArgs->nBuildDeps     = pOptionArgs->nBuildDeps;
+    pArgs->nInstallToDir  = pOptionArgs->nInstallToDir;
 
 cleanup:
     return dwError;


### PR DESCRIPTION
This installs packages to a repository. Packages are considered 'installed' if they are present in a sub directory tree. Installing a package will look at these packages for dependency requirements, as if they were installed in the system.

This requires the `--downloadonly` and `--downloaddir` options.

The feature can be used when creating a cache repo for multiple installs.