### PR TITLE
fix reinstall conflicts

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -164,6 +164,8 @@ TDNFAlterCommand(
     PTDNF_SOLVED_PKG_INFO pSolvedInfo
     )
 {
+    UNUSED(nAlterType);
+
     uint32_t dwError = 0;
     if(!pTdnf || !pSolvedInfo)
     {
@@ -171,7 +173,7 @@ TDNFAlterCommand(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFRpmExecTransaction(pTdnf, pSolvedInfo, nAlterType);
+    dwError = TDNFRpmExecTransaction(pTdnf, pSolvedInfo);
     BAIL_ON_TDNF_ERROR(dwError);
 
 cleanup:

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -813,8 +813,7 @@ TDNFAddNotResolved(
 uint32_t
 TDNFRpmExecTransaction(
     PTDNF pTdnf,
-    PTDNF_SOLVED_PKG_INFO pInfo,
-    TDNF_ALTERTYPE nAlterType
+    PTDNF_SOLVED_PKG_INFO pInfo
     );
 
 void*
@@ -841,12 +840,6 @@ TDNFTransAddErasePkgs(
     );
 
 uint32_t
-TDNFTransAddObsoletedPkgs(
-    PTDNFRPMTS pTS,
-    PTDNF_PKG_INFO pInfo
-    );
-
-uint32_t
 TDNFTransAddErasePkg(
     PTDNFRPMTS pTS,
     const char* pszPkgName
@@ -856,14 +849,8 @@ uint32_t
 TDNFTransAddInstallPkgs(
     PTDNFRPMTS pTS,
     PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
-    );
-
-uint32_t
-TDNFTransAddReInstallPkgs(
-    PTDNFRPMTS pTS,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
+    PTDNF_PKG_INFO pInfo,
+    int nUpgrade
     );
 
 uint32_t
@@ -874,13 +861,6 @@ TDNFTransAddInstallPkg(
     const char* pszPkgName,
     const char* pszRepoName,
     int nUpgrade
-    );
-
-uint32_t
-TDNFTransAddUpgradePkgs(
-    PTDNFRPMTS pTS,
-    PTDNF pTdnf,
-    PTDNF_PKG_INFO pInfo
     );
 
 uint32_t


### PR DESCRIPTION
This fixes file conflict errors on reinstall with a package that has binary differences, but same NEVRA. Change is for `stable-3.1`.

This may also be a better way to do reinstalls, and maybe it should be done the same way in the other active branches. `rpm` makes a difference between `reinstall` and `replacepkgs`. This change makes `tdnf` behave as if calling `rpm` with `--reinstall`. Before it was more like `--replacepkgs`.