### PR TITLE
Fix history rollback for public key and protected packages

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -2103,7 +2103,7 @@ TDNFHistoryResolve(
             goto cleanup;
         case HISTORY_CMD_ROLLBACK:
             hd = history_get_delta(ctx, pHistoryArgs->nTo);
-            hfd = history_get_flags_delta(ctx, ctx->trans_id, pHistoryArgs->nTo - 1);
+            hfd = history_get_flags_delta(ctx, ctx->trans_id, pHistoryArgs->nTo);
             break;
         case HISTORY_CMD_UNDO:
             hd = history_get_delta_range(ctx, pHistoryArgs->nFrom - 1, pHistoryArgs->nTo);

--- a/client/api.c
+++ b/client/api.c
@@ -2148,6 +2148,9 @@ TDNFHistoryResolve(
         char *pszPkgName = history_get_nevra(hnm, hd->added_ids[i]);
         if (pszPkgName)
         {
+            if (strncmp(pszPkgName, "gpg-pubkey-", 11) == 0)
+                continue;
+
             Queue qResult = {0};
             queue_init(&qResult);
 
@@ -2194,6 +2197,9 @@ TDNFHistoryResolve(
         char *pszPkgName = history_get_nevra(hnm, hd->removed_ids[i]);
         if (pszPkgName)
         {
+            if (strncmp(pszPkgName, "gpg-pubkey-", 11) == 0)
+                continue;
+
             dwError = SolvFindSolvablesByNevraStr(pTdnf->pSack->pPool, pszPkgName, &qErase, SOLV_NEVRA_INSTALLED);
             BAIL_ON_TDNF_ERROR(dwError);
         }


### PR DESCRIPTION
There were three  issues with history rollback:
* when the public key packages (`gpg-pubkey-*`) were removed or added, `tdnf history rollback` was throwing an error. Root cause was a parsing error in `SolvFindSolvablesByNevraStr()`, but it's not a good idea to roll back changes in the first place: we are not able to restore a removed key package because these are not packages in repositories, and `tdnf` is not able to retrieve them.
* when a protected packages was upgraded/downgraded, `tdnf history rollback` would also throw an error. Root cause is the logic used: the rollback would remove and then add a package that was upgraded, and the removal would be checked for protected status. This change will check if the package will be re-added again.
* when rolling back there was a one-off error when rolling back flags (used to mark autoinstalled packages). The flags were rolled back to the transaction id just before the target id.

Also adding tests for the first two issues.
