### PR TITLE
Fix error when a repo was disabled because it's unavailable. Fixes #431

### DIFF
--- a/client/repo.c
+++ b/client/repo.c
@@ -57,6 +57,14 @@ TDNFInitRepo(
                   NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    if (pRepoData->nHasMetaData) {
+        dwError = TDNFGetRepoMD(pTdnf,
+                                pRepoData,
+                                pszRepoDataDir,
+                                &pRepoMD);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     dwError = TDNFAllocateMemory(
                   1,
                   sizeof(SOLV_REPO_INFO_INTERNAL),
@@ -74,12 +82,6 @@ TDNFInitRepo(
     pRepo->appdata = pSolvRepoInfo;
 
     if (pRepoData->nHasMetaData) {
-        dwError = TDNFGetRepoMD(pTdnf,
-                                pRepoData,
-                                pszRepoDataDir,
-                                &pRepoMD);
-        BAIL_ON_TDNF_ERROR(dwError);
-
         dwError = SolvCalculateCookieForFile(pRepoMD->pszRepoMD, pSolvRepoInfo->cookie);
         BAIL_ON_TDNF_ERROR(dwError);
         pSolvRepoInfo->nCookieSet = 1;


### PR DESCRIPTION
`TDNFGetRepoMD()` was called too late to recognize that a repo is unavailable, which caused errors later when trying to access it. This moves the call to before the repo is created and added to the pool, so we bail out before in case it's not available.

Steps to reproduce:
```
# tdnf-config create unavail-repo baseurl=http://foo.bar.com/ enabled=1 skip_if_unavailable=1
# tdnf install lsof
Refreshing metadata for: 'unavail-repo'
retrying 1/10
retrying 2/10
retrying 3/10
retrying 4/10
retrying 5/10
retrying 6/10
retrying 7/10
retrying 8/10
retrying 9/10
retrying 10/10
Error(1207) : Couldn't resolve host name
Error: Failed to synchronize cache for repo 'unavail-repo'
Disabling Repo: 'unavail-repo'
Error(1622) : Invalid argument
```

After fix:
```
# ./bin/tdnf install lsof
Refreshing metadata for: 'unavail-repo'
retrying 1/10
retrying 2/10
retrying 3/10
retrying 4/10
retrying 5/10
retrying 6/10
retrying 7/10
retrying 8/10
retrying 9/10
retrying 10/10
Error(1207) : Couldn't resolve host name
Error: Failed to synchronize cache for repo 'unavail-repo'
Disabling Repo: 'unavail-repo'

Installing:
libtirpc                               x86_64                       1.3.3-2.ph5                            photon-updates               194.10k                          92.17k
lsof                                   x86_64                       4.96.4-1.ph5                           photon-updates               207.83k                         120.93k

Total installed size: 401.92k
Total download size: 213.10k
Is this ok [y/N]: 
```

