### PR TITLE
fix rpm verbosity default, and fix rpm scriptlet output when json is enabled

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -31,7 +31,7 @@ TDNFConfGetRpmVerbosity(
     )
 {
     rpmlogLvl nLogLevel = RPMLOG_INFO;
-    if(pTdnf)
+    if(pTdnf && pTdnf->pArgs->nRpmVerbosity >= 0)
     {
         nLogLevel = pTdnf->pArgs->nRpmVerbosity;
     }

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -153,6 +153,8 @@ extern "C" {
 
 #define ERROR_TDNF_SIZE_MISMATCH             1527
 
+#define ERROR_TDNF_RPMTS_FDDUP_FAILED        1528
+
 /* event context */
 #define ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND      1551
 #define ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE   1552

--- a/pytests/repo/tdnf-verbose-scripts.spec
+++ b/pytests/repo/tdnf-verbose-scripts.spec
@@ -1,0 +1,51 @@
+#
+# tdnf test spec file
+#
+Summary:    basic install test file.
+Name:       tdnf-verbose-scripts
+Version:    1.0.1
+Release:    2
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Basic install/remove/upgrade test
+
+%prep
+
+%build
+
+%install
+mkdir -p %_topdir/%buildroot/lib/systemd/system/
+echo %_topdir/%buildroot/lib/systemd/system/%{name}.service
+cat << EOF >> %_topdir/%buildroot/lib/systemd/system/%{name}.service
+[Unit]
+Description=%{name}.service for rpm script test.
+
+EOF
+
+%post
+echo "echo from post"
+echo "echo to stderr from post" >&2
+
+%postun
+echo "echo from postun"
+echo "echo to stderr from postun" >&2
+
+%pre
+echo "echo from pre"
+echo "echo to stderr from pre" >&2
+
+%preun
+echo "echo from preun"
+echo "echo to stderr from preun" >&2
+
+%files
+/lib/systemd/system/%{name}.service
+
+%changelog
+*   Tue Jul 11 2023 Oliver Kurth <okurth@vmware.com>
+-   test script output redirection

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -172,6 +172,8 @@ TDNFCliParseArgs(
     pCmdArgs->nArgc = argc;
     pCmdArgs->ppszArgv = argv;
 
+    pCmdArgs->nRpmVerbosity = -1;
+
     opterr = 0;//tell getopt to not print errors
     while (1)
     {
@@ -497,7 +499,7 @@ ParseRpmVerbosity(
         }
     }
 
-    *pnRpmVerbosity = TDNF_RPMLOG_ERR;
+    *pnRpmVerbosity = TDNF_RPMLOG_INFO;
 
     return dwError;
 }


### PR DESCRIPTION
Two fixes:
* the rpm verbosity was always set to 0 (RPMLOG_EMERG) by default. Fixing this to set it to info (RPMLOG_INFO). This enables stdout from scriptlets when redirected (but has no effect when not redirected)
* when json output is enabled, redirect stdout from scriptlets to stderr to leave json output intact
