### PR TITLE
Misc fixes

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : api.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uid_t gEuid;
@@ -439,7 +427,7 @@ TDNFClean(
             dwError = 0;
         }
         BAIL_ON_TDNF_ERROR(dwError);
-        
+
         pr_info("\n");
     }
 cleanup:

--- a/client/client.c
+++ b/client/client.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : client.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/config.c
+++ b/client/config.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : config.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 #include "../llconf/nodes.h"

--- a/client/goal.c
+++ b/client/goal.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : goal.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 static

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : gpgcheck.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/init.c
+++ b/client/init.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : init.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : packageutils.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #define _GNU_SOURCE 1
 #include "includes.h"
 

--- a/client/repo.c
+++ b/client/repo.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : repo.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 //Download repo metadata and initialize

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : repolist.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 #include "../llconf/nodes.h"
@@ -475,7 +463,7 @@ TDNFLoadReposFromFile(
             BAIL_ON_TDNF_ERROR(dwError);
         }
     }
-    
+
     /* cn_conf == NULL => we will not reach here */
     /* coverity[var_deref_op] */
     for(cn_section = cn_conf->first_child; cn_section; cn_section = cn_section->next)

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : repoutils.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : resolve.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : rpmtrans.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 #include <sys/resource.h>
 

--- a/client/updateinfo.c
+++ b/client/updateinfo.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : updateinfo.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/client/utils.c
+++ b/client/utils.c
@@ -6,20 +6,7 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : utils.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
-
 
 uint32_t
 TDNFGetErrorString(

--- a/common/memory.c
+++ b/common/memory.c
@@ -6,17 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : memory.c
- *
- * Abstract :
- *
- *
- *            common library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/common/setopt.c
+++ b/common/setopt.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : setopt.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 void

--- a/common/strings.c
+++ b/common/strings.c
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : strings.c
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : installcmd.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/options.c
+++ b/tools/cli/lib/options.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : options.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/output.c
+++ b/tools/cli/lib/output.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : output.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : parseargs.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 static TDNF_CMD_ARGS _opt = {0};

--- a/tools/cli/lib/parsecleanargs.c
+++ b/tools/cli/lib/parsecleanargs.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : parsecleanargs.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/parselistargs.c
+++ b/tools/cli/lib/parselistargs.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : parselistargs.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/parserepolistargs.c
+++ b/tools/cli/lib/parserepolistargs.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : parserepolistargs.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/parseupdateinfo.c
+++ b/tools/cli/lib/parseupdateinfo.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : parseupdateinfo.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 uint32_t

--- a/tools/cli/lib/updateinfocmd.c
+++ b/tools/cli/lib/updateinfocmd.c
@@ -6,21 +6,7 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : updateinfocmd.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
-
 
 char*
 TDNFGetUpdateInfoType(

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -113,6 +113,7 @@ int main(int argc, char **argv)
             if (strcmp(pszCmd, arCmdMap[i].pszCmdName) == 0)
             {
                 pCmd = &arCmdMap[i];
+                break;
             }
         }
 

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Module   : main.c
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #include "includes.h"
 
 static TDNF_CLI_CMD_MAP arCmdMap[] =


### PR DESCRIPTION
When quiet option is passed with tdnf commands, either assumeyes or assumeno must be passed, if not don't suppress the info messages from tdnf.

```
root@phdev:~ # tdnf install vsftpd -q
Is this ok [y/N]:
```

Above is a sample output of the issue I'm talking about. Users really don't know what we are asking y/n for here and what is happening behind the screens.

So, if assumeyes or no is not passed, just output all the info.

```
root@phdev[±|verbose-fix ?:6 ✗]:~/tdnf.git/build # ./bin/tdnf install vsftpd -q

Installing:
vsftpd                  x86_64            3.0.5-4.ph5             local             182.91k          93.16k

Total installed size: 182.91k
Total download size:  93.16k
Is this ok [y/N]:
```

Sample output with the proposed fix. I know this is the same in Fedora at the moment but we don't have to be in alignment with dnf for everything.

cc: @tapakund @dweepadvani