### PR TITLE
tdnf-python: use newer apis for setting program name

### DIFF
--- a/python/tdnfmodule.c
+++ b/python/tdnfmodule.c
@@ -141,33 +141,55 @@ error:
     goto cleanup;
 }
 
-int
-main(
-    int argc,
-    char *argv[]
-    )
+static int __Pyx_main(int argc, wchar_t **argv)
 {
-    wchar_t *program = Py_DecodeLocale(argv[0], NULL);
-    if (program == NULL) {
-        pr_err("Fatal error: cannot decode argv[0]\n");
-        exit(1);
-    }
-
     /* Add a built-in module, before Py_Initialize */
     PyImport_AppendInittab("_tdnf", PyInit__tdnf);
 
+#if PY_VERSION_HEX < 0x03080000
     /* Pass argv[0] to the Python interpreter */
-    Py_SetProgramName(program);
+    Py_SetProgramName(argv[0]);
 
     /* Initialize the Python interpreter.  Required. */
     Py_Initialize();
+#else
+    {
+        PyStatus status;
 
-    /* Optionally import the module; alternatively,
-       import can be deferred until the embedded script
-       imports it. */
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
+
+        if (argc && argv) {
+            status = PyConfig_SetString(&config, &config.program_name, argv[0]);
+            if (PyStatus_Exception(status)) {
+                PyConfig_Clear(&config);
+                return 1;
+            }
+
+            status = PyConfig_SetArgv(&config, argc, argv);
+            if (PyStatus_Exception(status)) {
+                PyConfig_Clear(&config);
+                return 1;
+            }
+        }
+
+        status = Py_InitializeFromConfig(&config);
+        if (PyStatus_Exception(status)) {
+            PyConfig_Clear(&config);
+            return 1;
+        }
+
+        PyConfig_Clear(&config);
+    }
+#endif /* PY_VERSION_HEX < 0x03080000 */
+
+    /*
+     * Optionally import the module; alternatively,
+     * import can be deferred until the embedded script
+     * imports it.
+     */
     PyImport_ImportModule("_tdnf");
 
-    PyMem_RawFree(program);
     return 0;
 }
 


### PR DESCRIPTION
Newer versions of python has deprecated Py_SetProgramName(...), and we see this warning while building tdnf python. This patch addresses this by using latest APIs for setting program name.

Build log snippet:
```
/root/tdnf.git/python/tdnfmodule.c:160:5: warning: ‘Py_SetProgramName’ is deprecated [-Wdeprecated-declarations]
  160 |     Py_SetProgramName(program);
      |     ^~~~~~~~~~~~~~~~~
In file included from /usr/include/python3.11/Python.h:94,
                 from /root/tdnf.git/python/includes.h:11,
                 from /root/tdnf.git/python/tdnfmodule.c:9:
/usr/include/python3.11/pylifecycle.h:37:38: note: declared here
   37 | Py_DEPRECATED(3.11) PyAPI_FUNC(void) Py_SetProgramName(const wchar_t *);
```