### PR TITLE
Remove atoi usages from tdnf

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -29,7 +29,9 @@ TDNFConfGetRpmVerbosity(
 static
 int isTrue(const char *str)
 {
-    return strcasecmp(str, "true") == 0 || atoi(str) != 0;
+    int val = 0;
+
+    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
 }
 
 uint32_t
@@ -108,7 +110,7 @@ TDNFReadConfig(
 
         if (strcmp(cn->name, TDNF_CONF_KEY_INSTALLONLY_LIMIT) == 0)
         {
-            pConf->nInstallOnlyLimit = atoi(cn->value);
+            pConf->nInstallOnlyLimit = strtoi(cn->value);
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_CLEAN_REQ_ON_REMOVE) == 0)
         {
@@ -153,7 +155,7 @@ TDNFReadConfig(
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_OPENMAX) == 0)
         {
-            pConf->nOpenMax = atoi(cn->value);
+            pConf->nOpenMax = strtoi(cn->value);
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_CHECK_UPDATE_COMPAT) == 0)
         {

--- a/client/config.c
+++ b/client/config.c
@@ -26,14 +26,6 @@ TDNFConfGetRpmVerbosity(
     return nLogLevel;
 }
 
-static
-int isTrue(const char *str)
-{
-    int val = 0;
-
-    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
-}
-
 uint32_t
 TDNFReadConfig(
     PTDNF pTdnf,

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -223,12 +223,6 @@ _TDNFFreePlugin(
     }
 }
 
-static
-int isTrue(const char *str)
-{
-    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
-}
-
 /* read config file */
 static
 uint32_t

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -226,7 +226,7 @@ _TDNFFreePlugin(
 static
 int isTrue(const char *str)
 {
-    return strcasecmp(str, "true") == 0 || atoi(str) != 0;
+    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
 }
 
 /* read config file */

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -424,7 +424,7 @@ error:
 static
 int isTrue(const char *str)
 {
-    return strcasecmp(str, "true") == 0 || atoi(str) != 0;
+    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
 }
 
 uint32_t
@@ -525,23 +525,23 @@ TDNFLoadReposFromFile(
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_PRIORITY) == 0)
             {
-                pRepo->nPriority = atoi(cn->value);
+                pRepo->nPriority = strtoi(cn->value);
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_TIMEOUT) == 0)
             {
-                pRepo->nTimeout = atoi(cn->value);
+                pRepo->nTimeout = strtoi(cn->value);
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_RETRIES) == 0)
             {
-                pRepo->nRetries = atoi(cn->value);
+                pRepo->nRetries = strtoi(cn->value);
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_MINRATE) == 0)
             {
-                pRepo->nMinrate = atoi(cn->value);
+                pRepo->nMinrate = strtoi(cn->value);
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_THROTTLE) == 0)
             {
-                pRepo->nThrottle = atoi(cn->value);
+                pRepo->nThrottle = strtoi(cn->value);
             }
             else if (strcmp(cn->name, TDNF_REPO_KEY_SSL_VERIFY) == 0)
             {

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -421,12 +421,6 @@ error:
     goto cleanup;
 }
 
-static
-int isTrue(const char *str)
-{
-    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
-}
-
 uint32_t
 TDNFLoadReposFromFile(
     PTDNF pTdnf,

--- a/common/includes.h
+++ b/common/includes.h
@@ -21,6 +21,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <libgen.h>
+#include <limits.h>
 
 #include <tdnftypes.h>
 #include <tdnferror.h>

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -321,4 +321,6 @@ tdnflockNewAcquire(
 
 int32_t strtoi(const char *ptr);
 
+int isTrue(const char *str);
+
 #endif /* __COMMON_PROTOTYPES_H__ */

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -319,4 +319,6 @@ tdnflockNewAcquire(
     const char *descr
     );
 
+int32_t strtoi(const char *ptr);
+
 #endif /* __COMMON_PROTOTYPES_H__ */

--- a/common/utils.c
+++ b/common/utils.c
@@ -965,3 +965,19 @@ error:
     TDNF_SAFE_FREE_MEMORY(pszDirName);
     goto cleanup;
 }
+
+int32_t strtoi(const char *ptr)
+{
+    char *p = NULL;
+    long int tmp = 0;
+
+    tmp = strtol(ptr, &p, 10);
+
+    if (*p || tmp > INT_MAX || tmp < INT_MIN)
+    {
+        pr_crit("WARNING: invalid arg to %s: '%s'\n", __func__, ptr);
+        return 0;
+    }
+
+    return (int32_t) tmp;
+}

--- a/common/utils.c
+++ b/common/utils.c
@@ -981,3 +981,11 @@ int32_t strtoi(const char *ptr)
 
     return (int32_t) tmp;
 }
+
+int isTrue(const char *str)
+{
+    if (!strcasecmp(str, "false"))
+        return 0;
+
+    return !strcasecmp(str, "true") || strtoi(str);
+}

--- a/llconf/entry.c
+++ b/llconf/entry.c
@@ -137,7 +137,7 @@ void _cnf_find_entry(struct cnfresult **pcr, struct cnfnode *cn_parent,
 		if(*p != ']')
 			return; // FIXME: error condition
 
-		index = strtoi(tmp);
+		index = atoi(tmp);
 		p++;
 	}
 

--- a/llconf/entry.c
+++ b/llconf/entry.c
@@ -137,7 +137,7 @@ void _cnf_find_entry(struct cnfresult **pcr, struct cnfnode *cn_parent,
 		if(*p != ']')
 			return; // FIXME: error condition
 
-		index = atoi(tmp);
+		index = strtoi(tmp);
 		p++;
 	}
 

--- a/llconf/entry.h
+++ b/llconf/entry.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 /**
  * A structure to hold the results of #cnf_find_entry.
  */

--- a/llconf/ini.h
+++ b/llconf/ini.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 struct cnfnode *parse_ini(struct cnfmodule *cm, FILE *fptr);
 int unparse_ini(struct cnfmodule *cm, FILE *fptr, struct cnfnode *cn_root);
 void register_ini(struct cnfnode *opt_root);

--- a/llconf/lines.h
+++ b/llconf/lines.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 /** \file
  * Handling for collections of lines of text.
  *

--- a/llconf/modules.h
+++ b/llconf/modules.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 extern struct cnfmodule *cnfmodules;
 
 /** Information for registering a parser module. */

--- a/llconf/strutils.h
+++ b/llconf/strutils.h
@@ -19,6 +19,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#pragma once
+
 #define cp_buf_until(dest, p, expr) \
   { \
     char *q = buf; \

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -315,7 +315,7 @@ error:
 static
 int isTrue(const char *str)
 {
-    return strcasecmp(str, "true") == 0 || atoi(str) != 0;
+    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
 }
 
 uint32_t

--- a/plugins/repogpgcheck/repogpgcheck.c
+++ b/plugins/repogpgcheck/repogpgcheck.c
@@ -312,12 +312,6 @@ error:
     goto cleanup;
 }
 
-static
-int isTrue(const char *str)
-{
-    return strcasecmp(str, "true") == 0 || strtoi(str) != 0;
-}
-
 uint32_t
 TDNFRepoGPGCheckReadConfig(
     PTDNF_PLUGIN_HANDLE pHandle,

--- a/tools/cli/lib/parsehistoryargs.c
+++ b/tools/cli/lib/parsehistoryargs.c
@@ -72,10 +72,10 @@ TDNFCliParseHistoryArgs(
         dwError = TDNFSplitStringToArray(pArgs->ppszCmds[2], "-", &ppszRange);
         BAIL_ON_CLI_ERROR(dwError);
 
-        pHistoryArgs->nFrom = atoi(ppszRange[0]);
+        pHistoryArgs->nFrom = strtoi(ppszRange[0]);
         if (ppszRange[1])
         {
-            pHistoryArgs->nTo = atoi(ppszRange[1]);
+            pHistoryArgs->nTo = strtoi(ppszRange[1]);
         }
     }
 
@@ -93,11 +93,11 @@ TDNFCliParseHistoryArgs(
         }
         else if (strcasecmp(pSetOpt->pszOptName, "from") == 0)
         {
-            pHistoryArgs->nFrom = atoi(pSetOpt->pszOptValue);
+            pHistoryArgs->nFrom = strtoi(pSetOpt->pszOptValue);
         }
         else if (strcasecmp(pSetOpt->pszOptName, "to") == 0)
         {
-            pHistoryArgs->nTo = atoi(pSetOpt->pszOptValue);
+            pHistoryArgs->nTo = strtoi(pSetOpt->pszOptValue);
         }
     }
 


### PR DESCRIPTION
- Replace atoi with strotol
- Move isTrue function to a common place
- Remove duplicate pr_err macro definitions
- And adjustments to make the build normal after the fixes