### PR TITLE
tree-wide: remove out dated author info from source files

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header : defines.h
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #pragma once
 
 #include "config.h"

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header   : prototypes.h
- *
- * Abstract :
- *
- *            tdnfclientlib
- *
- *            client library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #ifndef __CLIENT_PROTOTYPES_H__
 #define __CLIENT_PROTOTYPES_H__
 

--- a/common/defines.h
+++ b/common/defines.h
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header : defines.h
- *
- * Abstract :
- *
- *            commonlib
- *
- *            common library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #pragma once
 
 #define STRINGIFYX(N) STRINGIFY(N)

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -6,18 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header   : prototypes.h
- *
- * Abstract :
- *
- *            commonlib
- *
- *            common library
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- */
-
 #ifndef __COMMON_PROTOTYPES_H__
 #define __COMMON_PROTOTYPES_H__
 

--- a/tools/cli/defines.h
+++ b/tools/cli/defines.h
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header : defines.h
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #pragma once
 
 #define BAIL_ON_CLI_ERROR(unError) \

--- a/tools/cli/includes.h
+++ b/tools/cli/includes.h
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header   : includes.h
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #ifndef __CLI_INCLUDES_H__
 #define __CLI_INCLUDES_H__
 

--- a/tools/cli/lib/includes.h
+++ b/tools/cli/lib/includes.h
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header   : includes.h
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #ifndef __CLI_LIB_INCLUDES_H__
 #define __CLI_LIB_INCLUDES_H__
 

--- a/tools/cli/lib/prototypes.h
+++ b/tools/cli/lib/prototypes.h
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header : prototypes.h
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #pragma once
 
 //parseargs.c

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -6,19 +6,6 @@
  * of the License are located in the COPYING file of this distribution.
  */
 
-/*
- * Header : prototypes.h
- *
- * Abstract :
- *
- *            tdnf
- *
- *            command line tool
- *
- * Authors  : Priyesh Padmavilasom (ppadmavilasom@vmware.com)
- *
- */
-
 #pragma once
 
 //invoke tdnf library methods


### PR DESCRIPTION
These were missed in:
https://github.com/vmware/tdnf/commit/af6609f66486ccc4cd96e6dccf8faeb367f81b1d