### PR TITLE
tdnf: Add check to identify duplicate repo id

### DIFF
--- a/client/defines.h
+++ b/client/defines.h
@@ -232,6 +232,7 @@ typedef enum
     {ERROR_TDNF_INVALID_INPUT, "ERROR_TDNF_INVALID_INPUT", "Invalid input."},\
     {ERROR_TDNF_CACHE_DISABLED, "ERROR_TDNF_CACHE_DISABLED", "cache only is set, but no repo data found"},\
     {ERROR_TDNF_CACHE_DIR_OUT_OF_DISK_SPACE, "ERROR_TDNF_CACHE_DIR_OUT_OF_DISK_SPACE", "Insufficient disk space at cache directory /var/cache/tdnf (unless specified differently in config). Try freeing space first."},\
+    {ERROR_TDNF_DUPLICATE_REPO_ID,         "ERROR_TDNF_DUPLICATE_REPO_ID",         "Duplicate repo id"}, \
     {ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND, "ERROR_TDNF_EVENT_CTXT_ITEM_NOT_FOUND", "An event context item was not found. This is usually related to plugin events. Try --noplugins to deactivate all plugins or --disableplugin=<plugin> to deactivate a specific one. You can permanently deactivate an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE, "ERROR_TDNF_EVENT_CTXT_ITEM_INVALID_TYPE", "An event item type had a mismatch. This is usually related to plugin events. Try --noplugins to deactivate all plugins or --disableplugin=<plugin> to deactivate a specific one. You can permanently deactivate an offending plugin by setting enable=0 in the plugin config file."},\
     {ERROR_TDNF_NO_GPGKEY_CONF_ENTRY,         "ERROR_TDNF_NO_GPGKEY_CONF_ENTRY",         "gpgkey entry is missing for this repo. please add gpgkey in repo file or use --nogpgcheck to ignore."}, \

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -28,6 +28,8 @@ TDNFLoadRepoData(
     DIR *pDir = NULL;
     struct dirent *pEnt = NULL;
     char **ppszUrlIdTuple = NULL;
+    PTDNF_REPO_DATA pRepoParsePre = NULL;
+    PTDNF_REPO_DATA pRepoParseNext = NULL;
 
     if(!pTdnf || !pTdnf->pConf || !pTdnf->pArgs || !ppReposAll)
     {
@@ -115,10 +117,20 @@ TDNFLoadRepoData(
 
         TDNF_SAFE_FREE_MEMORY(pszRepoFilePath);
         pszRepoFilePath = NULL;
-
         /* may have added multiple repos, go to last one */
         while (*ppRepoNext)
             ppRepoNext = &((*ppRepoNext)->pNext);
+    }
+
+    for (pRepoParsePre = pReposAll; pRepoParsePre; pRepoParsePre = pRepoParsePre->pNext) {
+
+        for (pRepoParseNext = pRepoParsePre->pNext; pRepoParseNext; pRepoParseNext = pRepoParseNext->pNext) {
+            if (!strcmp(pRepoParsePre->pszId, pRepoParseNext->pszId)) {
+                pr_err("ERROR: duplicate repo id: %s\n", pRepoParsePre->pszId);
+                dwError = ERROR_TDNF_DUPLICATE_REPO_ID;
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+        }
     }
 
     *ppReposAll = pReposAll;

--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -72,6 +72,8 @@ extern "C" {
 #define ERROR_TDNF_DOWNGRADE_NOT_ALLOWED    1035
 // cache directory out of memory
 #define ERROR_TDNF_CACHE_DIR_OUT_OF_DISK_SPACE 1036
+// There are duplicate repo id
+#define ERROR_TDNF_DUPLICATE_REPO_ID        1037
 
 //curl errors
 #define ERROR_TDNF_CURL_INIT                  1200

--- a/pytests/tests/test_baseurls.py
+++ b/pytests/tests/test_baseurls.py
@@ -12,7 +12,6 @@ import pytest
 
 WORKDIR = '/root/baseurls/workdir'
 REPOFILENAME = 'baseurls.repo'
-TESTREPO = 'photon-test'
 REPONAME = 'baseurls-repo'
 
 
@@ -33,7 +32,7 @@ def teardown_test(utils):
 
 
 def test_multiple_baseurls(utils):
-    reponame = TESTREPO
+    reponame = REPONAME
     workdir = WORKDIR
     utils.makedirs(workdir)
 

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -27,7 +27,8 @@ def setup_test(utils):
 def teardown_test(utils):
     if os.path.isdir(INSTALLROOT):
         shutil.rmtree(INSTALLROOT)
-    pass
+    if os.path.isdir(REPODIR):
+        shutil.rmtree(REPODIR)
 
 
 def install_root(utils, no_reposd=False):

--- a/pytests/tests/test_repolist.py
+++ b/pytests/tests/test_repolist.py
@@ -50,6 +50,8 @@ def setup_test(utils):
 def teardown_test(utils):
     os.remove(os.path.join(utils.config['repo_path'], 'yum.repos.d', 'foo.repo'))
     os.remove(os.path.join(utils.config['repo_path'], 'yum.repos.d', 'bar.repo'))
+    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", 'test.repo'))
+    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", 'test1.repo'))
 
 
 def find_repo(repolist, id):
@@ -126,3 +128,35 @@ def test_repolist_invalid(utils):
 def test_repolist_memcheck(utils):
     ret = utils.run_memcheck(['tdnf', 'repolist'])
     assert ret['retval'] == 0
+
+
+# multiple repoid
+def test_multiple_repoid(utils):
+    reponame = 'test.repo'
+    repofile_test = os.path.join(utils.config['repo_path'], 'yum.repos.d', reponame)
+    utils.edit_config(
+        {
+            'name': 'Test Repo',
+            'enabled': '1',
+            'baseurl': 'http://pkgs.test.org/test'
+        },
+        section='test',
+        filename=repofile_test
+    )
+
+    reponame = 'test1.repo'
+    repofile_test1 = os.path.join(utils.config['repo_path'], 'yum.repos.d', reponame)
+    utils.edit_config(
+        {
+            'name': 'Test Repo',
+            'enabled': '1',
+            'baseurl': 'http://pkgs.test1.org/test1'
+        },
+        section='test',
+        filename=repofile_test1
+    )
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'makecache'])
+    assert ret['retval'] == 1037

--- a/pytests/tests/test_setopt_reposdir.py
+++ b/pytests/tests/test_setopt_reposdir.py
@@ -11,7 +11,7 @@ import shutil
 import pytest
 
 REPODIR = '/root/yum.repos.d'
-REPOFILENAME = 'reposync.repo'
+REPOFILENAME = 'setopt.repo'
 REPONAME = "reposdir-test"
 
 
@@ -32,4 +32,5 @@ def test_setopt_reposdir(utils):
                           "http://foo.bar.com/packages",
                           REPONAME)
     ret = utils.run(['tdnf', '--setopt=reposdir={}'.format(REPODIR), 'repolist'])
+    assert ret['retval'] == 0
     assert REPONAME in "\n".join(ret['stdout'])


### PR DESCRIPTION
When a repository(Repo id) is set multiple times, tdnf should throw an error to prevent issues.

Recently a customer was disabling all photon* repos in the files in /etc/yum.repos.d, and replaced them with another repo config, which used the same repo ids ('photon', 'photon-updates', etc.). The URLs in the original repo configs  (pointing to packages.vmware.com) were not reachable. The URLs in the replaced repo configs were reachable. However, tdnf used the URLs from the original repo configs, which lead to timeouts. Disabling the repositories is not enough - tdnf still uses the settings, and the setting that is used is arbitrary. This issue could have been prevented if tdnf threw an error.