### PR TITLE
Set a user agent for http/https tdnf requests

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -194,6 +194,15 @@ TDNFDownloadFile(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if(!IsNullOrEmptyString(pTdnf->pConf->pszUserAgentHeader))
+    {
+        dwError = curl_easy_setopt(
+                      pCurl,
+                      CURLOPT_USERAGENT,
+                      pTdnf->pConf->pszUserAgentHeader);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
     dwError = TDNFRepoApplyProxySettings(pTdnf->pConf, pCurl);
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -265,6 +265,9 @@ typedef struct _TDNF_CONF
     char* pszBaseArch;
     char* pszVarReleaseVer;
     char* pszVarBaseArch;
+    char* pszUserAgentHeader;
+    char* pszOSName;
+    char* pszOSVersion;
     char** ppszExcludes;
     char** ppszMinVersions;
     char** ppszPkgLocks;


### PR DESCRIPTION
tdnf does not set a user agent for http/https requests and the repository `pkgs.k8s.io` did block requests without user agents (because its the default policy in AWS WAF). This issue is fixed in kubernetes upstream repo. But to avoid this kind of issue in future, adding user agent for http/https tdnf requests