### PR TITLE
add a command line option to set RPM macros

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -607,6 +607,7 @@ TDNFOpenHandle(
     char *pszCacheDir = NULL;
     char *pszRepoDir = NULL;
     int nHasOptReposdir = 0;
+    PTDNF_CMD_OPT pOpt = NULL;
 
     if(!pArgs || !ppTdnf)
     {
@@ -682,6 +683,15 @@ TDNFOpenHandle(
         TDNF_SAFE_FREE_MEMORY(pTdnf->pConf->pszRepoDir);
         dwError = TDNFGetCmdOptValue(pTdnf->pArgs, TDNF_SETOPT_KEY_REPOSDIR, &pTdnf->pConf->pszRepoDir);
         BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* set macros from command line */
+    for (pOpt = pTdnf->pArgs->pSetOpt; pOpt; pOpt = pOpt->pNext)
+    {
+        if (strcmp(pOpt->pszOptName, "rpmdefine") == 0)
+        {
+            rpmDefineMacro(NULL, pOpt->pszOptValue, 0);
+        }
     }
 
     dwError = TDNFLoadPlugins(pTdnf);

--- a/pytests/tests/test_rpmdefine.py
+++ b/pytests/tests/test_rpmdefine.py
@@ -1,0 +1,40 @@
+#
+# Copyright (C) 2023 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import shutil
+import pytest
+
+
+INSTALLROOT = '/root/installroot'
+REPOFILENAME = 'photon-test.repo'
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    if os.path.isdir(INSTALLROOT):
+        shutil.rmtree(INSTALLROOT)
+
+
+@pytest.mark.parametrize("dbpath", ["/usr/lib/rpm", "/usr/lib/sysimage/rpm/"])
+def test_install(utils, dbpath):
+    pkgname = utils.config["mulversion_pkgname"]
+    ret = utils.run(['tdnf', 'install',
+                     '-y', '--nogpgcheck',
+                     '--installroot', INSTALLROOT,
+                     '--releasever=5.0',
+                     '--rpmdefine', f"_dbpath {dbpath}",
+                     pkgname])
+    assert ret['retval'] == 0
+    assert os.path.isdir(os.path.join(INSTALLROOT, dbpath.lstrip("/")))
+    assert os.path.isfile(os.path.join(INSTALLROOT, dbpath.lstrip("/"), "rpmdb.sqlite"))

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -48,6 +48,7 @@ static struct option pstOptions[] =
     {"repofrompath",  required_argument, 0, 0},            //--repofrompath
     {"repoid",        required_argument, 0, 0},            //--repoid (same as --repo)
     {"rpmverbosity",  required_argument, 0, 0},            //--rpmverbosity
+    {"rpmdefine",     required_argument, 0, 0},
     {"sec-severity",  required_argument, 0, 0},            //--sec-severity
     {"security",      no_argument, 0, 0},                  //--security
     {"setopt",        required_argument, 0, 0},            //--set or override options


### PR DESCRIPTION
Similar to the `--define` option to `rpm`, this adds the option `--rpmdefine` to define a macro. Use case is for example to set the rpm db path: `tdnf --rpmdefine "_dbpath /usr/lib/sysimage/rpm" ...`