### PR TITLE
minor download progress improvement

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -264,8 +264,9 @@ TDNFDownloadFile(
         fclose(fp);
         fp = NULL;
     }
+
     /* finish progress line output,
-       but only if progrees was enabled */
+       but only if progress was enabled */
     if (!nNoOutput) {
         pr_info("\n");
     }
@@ -417,7 +418,7 @@ TDNFDownloadPackage(
     }
     else if(dwError == 0)
     {
-        pr_info("%s package already downloaded", pszPkgName);
+        pr_info("%s package already downloaded\n", pszPkgName);
     }
     BAIL_ON_TDNF_ERROR(dwError);
 

--- a/client/repo.c
+++ b/client/repo.c
@@ -745,10 +745,12 @@ TDNFDownloadRepoMDPart(
     PTDNF pTdnf,
     PTDNF_REPO_DATA pRepo,
     const char *pszLocation,
-    const char *pszDestPath
+    const char *pszDestPath,
+    const char *pszPartName
     )
 {
     uint32_t dwError = 0;
+    char *pszInfo;
 
     if(!pTdnf || !pRepo ||
        IsNullOrEmptyString(pszLocation) ||
@@ -766,12 +768,15 @@ TDNFDownloadRepoMDPart(
             BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
         }
 
+        dwError = TDNFAllocateStringPrintf(&pszInfo, "%s (%s)", pRepo->pszId, pszPartName);
+        BAIL_ON_TDNF_ERROR(dwError);
+
         dwError = TDNFDownloadFileFromRepo(
                       pTdnf,
                       pRepo,
                       pszLocation,
                       pszDestPath,
-                      pRepo->pszId);
+                      pszInfo);
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -817,7 +822,8 @@ TDNFEnsureRepoMDParts(
                   pTdnf,
                   pRepo,
                   pRepoMDRel->pszPrimary,
-                  pRepoMD->pszPrimary);
+                  pRepoMD->pszPrimary,
+                  "primary");
     BAIL_ON_TDNF_ERROR(dwError);
 
     if(!pRepo->nSkipMDFileLists && !IsNullOrEmptyString(pRepoMDRel->pszFileLists))
@@ -832,7 +838,8 @@ TDNFEnsureRepoMDParts(
                       pTdnf,
                       pRepo,
                       pRepoMDRel->pszFileLists,
-                      pRepoMD->pszFileLists);
+                      pRepoMD->pszFileLists,
+                      "file lists");
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -848,7 +855,8 @@ TDNFEnsureRepoMDParts(
                       pTdnf,
                       pRepo,
                       pRepoMDRel->pszUpdateInfo,
-                      pRepoMD->pszUpdateInfo);
+                      pRepoMD->pszUpdateInfo,
+                      "update info");
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -864,7 +872,8 @@ TDNFEnsureRepoMDParts(
                       pTdnf,
                       pRepo,
                       pRepoMDRel->pszOther,
-                      pRepoMD->pszOther);
+                      pRepoMD->pszOther,
+                      "other");
         BAIL_ON_TDNF_ERROR(dwError);
     }
     *ppRepoMD = pRepoMD;


### PR DESCRIPTION
show which metadata part is downloaded, and new line after "already downloaded"

Example:
```
# ./bin/tdnf -y --downloadonly --downloaddir=/download/ --alldeps install bash
Refreshing metadata for: 'VMware Photon Linux 5.0 (x86_64)'
photon                                    3579 100%
photon (primary)                       1055790 100%
photon (update info)                     13944 100%
photon (other)                          525910 100%
Refreshing metadata for: 'VMware Photon Linux 5.0 (x86_64) Updates'
photon-updates                            3570 100%
photon-updates (primary)                565059 100%
photon-updates (file lists)            2679822 100%
photon-updates (update info)              4933 100%
photon-updates (other)                  251027 100%
```