### PR TITLE
add --setopt=cachedir= option

### DIFF
--- a/common/config.h
+++ b/common/config.h
@@ -68,9 +68,6 @@
 #define TDNF_REPO_KEY_SKIP_MD_UPDATEINFO  "skip_md_updateinfo"
 #define TDNF_REPO_KEY_SKIP_MD_OTHER       "skip_md_other"
 
-//setopt keys
-#define TDNF_SETOPT_KEY_REPOSDIR          "reposdir"
-
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"
 #define TDNF_REPO_METADATA_FILE_PATH      "repodata/repomd.xml"


### PR DESCRIPTION
add `--setopt=cachedir=` option, make it relative to host when `--installroot` is used. This is the same behavior as dnf (although it's not explicitly documented, it's advised here: https://bugzilla.redhat.com/show_bug.cgi?id=1679983). It's also similar to the behavior of the `--reposdir` option.

Example usage:
```
tdnf --installroot=/installroot/ --setopt=cachedir=/cache --releasever=5.0 install -y lsof
```
