### PR TITLE
fix multiple --repofrompath options

### DIFF
--- a/include/tdnferror.h
+++ b/include/tdnferror.h
@@ -69,6 +69,8 @@ extern "C" {
 // cache only set, but no cache available
 #define ERROR_TDNF_CACHE_DISABLED           1034
 #define ERROR_TDNF_DOWNGRADE_NOT_ALLOWED    1035
+// There are duplicate repo ids
+#define ERROR_TDNF_DUPLICATE_REPO_ID        1037
 
 //curl errors
 #define ERROR_TDNF_CURL_INIT                  1200

--- a/pytests/tests/test_repofrompath.py
+++ b/pytests/tests/test_repofrompath.py
@@ -65,3 +65,22 @@ def test_repofrompath_created_repo(utils):
                     cwd=workdir)
     assert ret['retval'] == 0
     assert utils.check_package(pkgname)
+
+    empty_repodir = os.path.join(workdir, "empty")
+    os.makedirs(empty_repodir)
+    utils.run(["createrepo", empty_repodir])
+
+    # test again with an additional but empty repo
+    # to make sure we can use --repofrompath multiple times
+    utils.erase_package(pkgname)
+
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--repofrompath=synced-repo,{}'.format(synced_dir),
+                     '--repofrompath=empty-repo,{}'.format(empty_repodir),
+                     '--repo=synced-repo',
+                     '--repo=empty-repo',
+                     'install', pkgname],
+                    cwd=workdir)
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)

--- a/pytests/tests/test_setopt_reposdir.py
+++ b/pytests/tests/test_setopt_reposdir.py
@@ -11,8 +11,8 @@ import shutil
 import pytest
 
 REPODIR = '/root/yum.repos.d'
-REPOFILENAME = 'reposync.repo'
-REPONAME = "reposdir-test"
+REPOFILENAME = 'setopt.repo'
+REPONAME = "setopt-test"
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -32,4 +32,5 @@ def test_setopt_reposdir(utils):
                           "http://foo.bar.com/packages",
                           REPONAME)
     ret = utils.run(['tdnf', '--setopt=reposdir={}'.format(REPODIR), 'repolist'])
+    assert ret['retval'] == 0
     assert REPONAME in "\n".join(ret['stdout'])


### PR DESCRIPTION
Using multiple `--repofrompath` options was broken in the `stable-3.3` branch (it works in `stable-3.5` and `dev`). This change copies most of the `TDNFLoadRepoData ()` function from `stable-3.5` (which includes the check for duplicate repo ids).