### PR TITLE
implement 'mirrorlist' for repos

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -413,6 +413,8 @@ TDNFClean(
             pr_info(" expire-cache");
             dwError = TDNFRemoveLastRefreshMarker(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
+            dwError = TDNFRemoveMirrorList(pTdnf, pRepo);
+            BAIL_ON_TDNF_ERROR(dwError);
         }
 
         /* remove the top level repo cache dir if it's not empty */

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -111,6 +111,12 @@ TDNFRemoveLastRefreshMarker(
     );
 
 uint32_t
+TDNFRemoveMirrorList(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    );
+
+uint32_t
 TDNFRemoveTmpRepodata(
     const char* pszTmpRepodataDir
     );

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -551,6 +551,10 @@ TDNFLoadReposFromFile(
             {
                 pRepo->pszMetaLink = strdup(cn->value);
             }
+            else if (strcmp(cn->name, TDNF_REPO_KEY_MIRRORLIST) == 0)
+            {
+                pRepo->pszMirrorList = strdup(cn->value);
+            }
             else if (strcmp(cn->name, TDNF_REPO_KEY_SKIP) == 0)
             {
                 pRepo->nSkipIfUnavailable = isTrue(cn->value);
@@ -736,11 +740,22 @@ TDNFRepoListFinalize(
             dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMetaLink);
             BAIL_ON_TDNF_ERROR(dwError);
         }
+        if(pRepo->pszMirrorList)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMirrorList);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
 
         if (pRepo->pszMetaLink)
         {
             dwError = SolvCreateRepoCacheName(pRepo->pszId,
                                               pRepo->pszMetaLink,
+                                              &pRepo->pszCacheName);
+        }
+        else if (pRepo->pszMirrorList)
+        {
+            dwError = SolvCreateRepoCacheName(pRepo->pszId,
+                                              pRepo->pszMirrorList,
                                               &pRepo->pszCacheName);
         }
         else if (pRepo->ppszBaseUrls && pRepo->ppszBaseUrls[0])
@@ -871,6 +886,7 @@ TDNFFreeReposInternal(
         TDNF_SAFE_FREE_MEMORY(pRepo->pszName);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszBaseUrls);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMetaLink);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszUser);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszPass);

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -224,14 +224,16 @@ error:
     goto cleanup;
 }
 
+static
 uint32_t
-TDNFRemoveLastRefreshMarker(
+_TDNFRemoveRepoCacheFile(
     PTDNF pTdnf,
-    PTDNF_REPO_DATA pRepo
+    PTDNF_REPO_DATA pRepo,
+    const char *pszFilename
     )
 {
     uint32_t dwError = 0;
-    char* pszLastRefreshMarker = NULL;
+    char *pszPath = NULL;
 
     if(!pTdnf || !pRepo || !pTdnf->pConf)
     {
@@ -240,22 +242,40 @@ TDNFRemoveLastRefreshMarker(
     }
 
     dwError = TDNFGetCachePath(pTdnf, pRepo,
-                               TDNF_REPO_METADATA_MARKER, NULL,
-                               &pszLastRefreshMarker);
+                               pszFilename, NULL,
+                               &pszPath);
     BAIL_ON_TDNF_ERROR(dwError);
-    if (pszLastRefreshMarker)
+    if (pszPath)
     {
-        if(unlink(pszLastRefreshMarker) && errno != ENOENT)
+        if(unlink(pszPath) && errno != ENOENT)
         {
            dwError = errno;
            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
         }
     }
 cleanup:
-    TDNF_SAFE_FREE_MEMORY(pszLastRefreshMarker);
+    TDNF_SAFE_FREE_MEMORY(pszPath);
     return dwError;
 error:
     goto cleanup;
+}
+
+uint32_t
+TDNFRemoveLastRefreshMarker(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    )
+{
+    return _TDNFRemoveRepoCacheFile(pTdnf, pRepo, TDNF_REPO_METADATA_MARKER);
+}
+
+uint32_t
+TDNFRemoveMirrorList(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    )
+{
+    return _TDNFRemoveRepoCacheFile(pTdnf, pRepo, TDNF_REPO_METADATA_MIRRORLIST);
 }
 
 uint32_t

--- a/common/config.h
+++ b/common/config.h
@@ -50,6 +50,7 @@
 #define TDNF_REPO_KEY_BASEURL             "baseurl"
 #define TDNF_REPO_KEY_ENABLED             "enabled"
 #define TDNF_REPO_KEY_METALINK            "metalink"
+#define TDNF_REPO_KEY_MIRRORLIST          "mirrorlist"
 #define TDNF_REPO_KEY_NAME                "name"
 #define TDNF_REPO_KEY_SKIP                "skip_if_unavailable"
 #define TDNF_REPO_KEY_GPGCHECK            "gpgcheck"
@@ -72,6 +73,7 @@
 
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"
+#define TDNF_REPO_METADATA_MIRRORLIST     "mirrorlist"
 #define TDNF_REPO_METADATA_FILE_PATH      "repodata/repomd.xml"
 #define TDNF_REPO_METADATA_FILE_NAME      "repomd.xml"
 #define TDNF_REPO_METALINK_FILE_NAME      "metalink"

--- a/common/utils.c
+++ b/common/utils.c
@@ -437,6 +437,7 @@ TDNFFreeRepos(
         TDNF_SAFE_FREE_MEMORY(pRepo->pszName);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszBaseUrls);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMetaLink);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
 
         pRepos = pRepo->pNext;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -291,6 +291,7 @@ typedef struct _TDNF_REPO_DATA
     char* pszName;
     char** ppszBaseUrls;
     char* pszMetaLink;
+    char* pszMirrorList;
     char** ppszUrlGPGKeys;
     int nSSLVerify;
     char* pszSSLCaCert;

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -195,8 +195,9 @@ class TestUtils(object):
 
     def check_package(self, package, version=None):
         ''' Check if a package exists '''
-        ret = self.run(["tdnf", "list", "-j", "--installed", package])
+        ret = self.run(["tdnf", "--disablerepo=*", "list", "-j", "--installed", package])
         pkglist = json.loads('\n'.join(ret['stdout']))
+        assert type(pkglist) is list, f"unexpected json type from 'tdnf list': pkglist={pkglist}"
         for p in pkglist:
             if p['Name'] == package and (version is None or p['Evr'] == version):
                 return True

--- a/pytests/tests/test_mirrorlist.py
+++ b/pytests/tests/test_mirrorlist.py
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2024 Broadcom, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import shutil
+import pytest
+
+WORKDIR = '/root/mirrortest/workdir'
+REPONAME = 'mirrortest'
+REPOFILENAME = f"{REPONAME}.repo"
+MIRRORLIST_FILENAME = "mirror.list"
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+
+def create_repo_conf(repos, reposdir="/etc/yum.repos.d", insecure=False):
+    """
+    Create .repo file as per configurations passed.
+    Parameters:
+    - repos: Dictionary containing repo_id as key and value as dictionary containing repo configurations.
+             Ex: {'repo_id1': {'baseurl': 'https://foo/bar', 'enabled': 0}, 'repo_id2': {'basurl': '/mnt/media/RPMS', 'enabled': 1}}
+    - reposdir (Optional): Parent dir where .repo needs to be placed. Default Value - /etc/yum.repos.d/{repo_name}.repo
+    Returns:
+    - None
+    """
+    os.makedirs(reposdir, exist_ok=True)
+    for repo in repos:
+        if insecure:
+            repos[repo]["sslverify"] = 0
+        with open(os.path.join(reposdir, f"{repo}.repo"), "w", encoding="utf-8") as repo_file:
+            repo_file.write(f"[{repo}]\n")
+            for key, value in repos[repo].items():
+                repo_file.write(f"{key}={value}\n")
+
+
+def test_mirrrorlist(utils):
+    reponame = REPONAME
+    workdir = WORKDIR
+    utils.makedirs(workdir)
+    mirrorlist_path = os.path.join(workdir, MIRRORLIST_FILENAME)
+
+    # we should get a 404 for the first url and skip to the next one
+    baseurls = ["http://localhost:8080/doesntexist", "http://localhost:8080/photon-test"]
+    with open(mirrorlist_path, "wt") as f:
+        for url in baseurls:
+            f.write(f"{url}\n")
+
+    create_repo_conf({reponame: {'enabled': 1, 'gpgcheck:': 0, 'mirrorlist': f"file://{mirrorlist_path}"}},
+                     os.path.join(utils.config['repo_path'], "yum.repos.d"),
+                     True)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'makecache'],
+                    cwd=workdir)
+    assert ret['retval'] == 0
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'install', pkgname],
+                    cwd=workdir)
+    assert utils.check_package(pkgname)


### PR DESCRIPTION
Fetch mirror list if set. Variables in the `mirrorlist` link will be expanded, just like for `baseurl`. The downloaded list file will be reused, but expires after the same time as meta data expires. URLs will be tried in order - same behavior as if all URLs were set directly with `baseurl`.
