### PR TITLE
make sslverify an option in main, setting the default for repos

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -121,8 +121,9 @@ TDNFReadConfig(
     pConf->nGPGCheck = 0;
     pConf->nCleanRequirementsOnRemove = 0;
     pConf->nKeepCache = 0;
-    pConf->nOpenMax = TDNF_DEFAULT_OPENMAX;
-    pConf->nInstallOnlyLimit = TDNF_DEFAULT_INSTALLONLY_LIMIT;
+    pConf->nOpenMax = TDNF_CONF_DEFAULT_OPENMAX;
+    pConf->nInstallOnlyLimit = TDNF_CONF_DEFAULT_INSTALLONLY_LIMIT;
+    pConf->nSSLVerify = TDNF_CONF_DEFAULT_SSLVERIFY;
 
     register_ini(NULL);
     mod_ini = find_cnfmodule("ini");
@@ -169,6 +170,10 @@ TDNFReadConfig(
         else if (strcmp(cn->name, TDNF_CONF_KEY_GPGCHECK) == 0)
         {
             pConf->nGPGCheck = isTrue(cn->value);
+        }
+        else if (strcmp(cn->name, TDNF_CONF_KEY_SSL_VERIFY) == 0)
+        {
+            pConf->nSSLVerify = isTrue(cn->value);
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_KEEP_CACHE) == 0)
         {

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -713,31 +713,6 @@ TDNFLoadReposFromFile(
     );
 
 uint32_t
-TDNFCreateCmdLineRepo(
-    PTDNF_REPO_DATA* ppRepo
-    );
-
-uint32_t
-TDNFCreateRepoFromPath(
-    PTDNF_REPO_DATA* ppRepo,
-    const char *pzsId,
-    const char *pszPath
-    );
-
-uint32_t
-TDNFCreateRepoFromDirectory(
-    PTDNF_REPO_DATA* ppRepo,
-    const char *pzsId,
-    const char *pszPath
-    );
-
-uint32_t
-TDNFCreateRepo(
-    PTDNF_REPO_DATA* ppRepo,
-    const char *pszId
-    );
-
-uint32_t
 TDNFLoadRepoData(
     PTDNF pTdnf,
     PTDNF_REPO_DATA* ppReposAll

--- a/common/config.h
+++ b/common/config.h
@@ -37,6 +37,7 @@
 #define TDNF_CONF_KEY_NO_PLUGINS          "noplugins"
 #define TDNF_CONF_KEY_PLUGIN_PATH         "pluginpath"
 #define TDNF_CONF_KEY_PLUGIN_CONF_PATH    "pluginconfpath"
+#define TDNF_CONF_KEY_SSL_VERIFY          "sslverify"
 #define TDNF_PLUGIN_CONF_KEY_ENABLED      "enabled"
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
 #define TDNF_CONF_KEY_MINVERSIONS         "minversions"
@@ -60,7 +61,7 @@
 #define TDNF_REPO_KEY_RETRIES             "retries"
 #define TDNF_REPO_KEY_MINRATE             "minrate"
 #define TDNF_REPO_KEY_THROTTLE            "throttle"
-#define TDNF_REPO_KEY_SSL_VERIFY          "sslverify"
+#define TDNF_REPO_KEY_SSL_VERIFY          TDNF_CONF_KEY_SSL_VERIFY
 #define TDNF_REPO_KEY_SSL_CA_CERT         "sslcacert"
 #define TDNF_REPO_KEY_SSL_CLI_CERT        "sslclientcert"
 #define TDNF_REPO_KEY_SSL_CLI_KEY         "sslclientkey"
@@ -94,8 +95,9 @@
 #define TDNF_SOLVCACHE_DIR_NAME           "solvcache"
 #define TDNF_REPO_METADATA_EXPIRE_NEVER   "never"
 
-#define TDNF_DEFAULT_OPENMAX              1024
-#define TDNF_DEFAULT_INSTALLONLY_LIMIT    2
+#define TDNF_CONF_DEFAULT_OPENMAX            1024
+#define TDNF_CONF_DEFAULT_INSTALLONLY_LIMIT  2
+#define TDNF_CONF_DEFAULT_SSLVERIFY          1
 
 // repo default settings
 #define TDNF_REPO_DEFAULT_ENABLED            0
@@ -104,7 +106,6 @@
 #define TDNF_REPO_DEFAULT_MINRATE            0
 #define TDNF_REPO_DEFAULT_THROTTLE           0
 #define TDNF_REPO_DEFAULT_TIMEOUT            0
-#define TDNF_REPO_DEFAULT_SSLVERIFY          1
 #define TDNF_REPO_DEFAULT_RETRIES            10
 #define TDNF_REPO_DEFAULT_PRIORITY           50
 #define TDNF_REPO_DEFAULT_METADATA_EXPIRE    172800 // 48 hours in seconds

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -250,6 +250,7 @@ typedef struct _TDNF_CMD_ARGS
 typedef struct _TDNF_CONF
 {
     int nGPGCheck;
+    int nSSLVerify;
     int nInstallOnlyLimit;
     int nCleanRequirementsOnRemove;
     int nKeepCache;


### PR DESCRIPTION
Adds the `sslverify` option to the main config, setting the default for repos. This is to avoid having to set this for a big number of repositories indvidually.

The same principle can be applied to many other options, but this was the most pressing issue.

`gpgcheck` behaves the same way, but there it implemented in another (more complex way) - this should be unified.