### PR TITLE
implement vars

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(${LIB_TDNF} SHARED
     updateinfo.c
     utils.c
     history.c
+    varsdir.c
 )
 
 target_link_libraries(${LIB_TDNF}

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1084,4 +1084,8 @@ TDNFGetHistoryCtx(
     int nMustExist
 );
 
+
+struct cnfnode *parse_varsdirs(char *dirs[]);
+char *replace_vars(struct cnfnode *cn_vars, const char *source);
+
 #endif /* __CLIENT_PROTOTYPES_H__ */

--- a/client/repo.c
+++ b/client/repo.c
@@ -46,6 +46,11 @@ TDNFInitRepo(
     BAIL_ON_TDNF_ERROR(dwError);
 
     if (pRepoData->nHasMetaData) {
+        dwError = TDNFUtilsMakeDirs(pszRepoDataDir);
+        if (dwError == ERROR_TDNF_ALREADY_EXISTS)
+        {
+            dwError = 0;
+        }
         dwError = TDNFGetRepoMD(pTdnf,
                                 pRepoData,
                                 pszRepoDataDir,

--- a/client/varsdir.c
+++ b/client/varsdir.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2024 Broadcom, Inc. All Rights Reserved.
+ *
+ * Licensed under the GNU Lesser General Public License v2.1 (the "License");
+ * you may not use this file except in compliance with the License. The terms
+ * of the License are located in the COPYING file of this distribution.
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+
+#include "../llconf/nodes.h"
+
+struct cnfnode *parse_varsdirs(char *dirs[])
+{
+    struct cnfnode *cn_top = NULL;
+    DIR *fdir = NULL;
+    FILE *fptr = NULL;
+    int i;
+
+    cn_top = create_cnfnode("(root)");
+
+    for (i = 0; dirs[i]; i++) {
+        fdir = opendir(dirs[i]);
+        if (!fdir) {
+            if (errno == ENOENT)
+                /* ignore non-existing directories */
+                continue;
+            else
+                goto error;
+        }
+
+        struct dirent *dent;
+        while((dent = readdir(fdir))) {
+            char buf[256], path[256];
+            char *p;
+
+            p = dent->d_name;
+            /* skip disallowed filenames */
+            /* See https://dnf.readthedocs.io/en/latest/conf_ref.html#varfiles-label :
+               "Filenames may contain only alphanumeric characters and underscores and be in lowercase." */
+            while(*p && ((*p == '_') || isdigit(*p) || islower(*p)))
+                p++;
+            if (*p) {
+                continue;
+            }
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+            snprintf(path, sizeof(path), "%s/%s", dirs[i], dent->d_name);
+#pragma GCC diagnostic pop
+            fptr = fopen(path, "rt");
+            if (fptr == NULL) {
+                goto error;
+            }
+            if (fgets(buf, sizeof(buf), fptr) == NULL) {
+                /* might be EOF which is fine */
+                if (errno)
+                    goto error;
+            }
+            /* strip trailing spaces and newlines */
+            p = buf + strlen(buf)-1;
+            while (p >= buf && isspace(*p)) p--;
+            p[1] = 0;
+
+            struct cnfnode *cn_var = create_cnfnode(dent->d_name);
+            cnfnode_setval(cn_var, buf);
+            append_node(cn_top, cn_var);
+
+            fclose(fptr);
+        }
+        closedir(fdir);
+    }
+    return(cn_top);
+
+error:
+    if (fdir) closedir(fdir);
+    if (fptr) fclose(fptr);
+    if (cn_top) destroy_cnftree(cn_top);
+    return NULL;
+}
+
+char *replace_vars(struct cnfnode *cn_vars, const char *source)
+{
+    char dest[256];
+    char *p, *d;
+    const char *q, *s;
+    struct cnfnode *cn_var;
+
+    d = dest;
+    s = source;
+    while (*s && d < dest + sizeof(dest)-1) {
+        char name[256];
+        while(*s && *s != '$' && (d < dest + sizeof(dest)-1))
+            *d++ = *s++;
+        if (!*s)
+            break;
+
+        s++;
+        p = name;
+        while(*s && (p < name + sizeof(name)-1) && (isdigit(*s) || islower(*s)))
+            *p++ = *s++;
+        *p = 0;
+
+        cn_var = find_child(cn_vars, name);
+        if (cn_var) {
+            q = cnfnode_getval(cn_var);
+            while(*q && (d < dest + sizeof(dest)-1))
+                *d++ = *q++;
+        } /* handle not found vars as empty */
+    }
+    *d = 0;
+
+    return strdup(dest);
+}

--- a/common/config.h
+++ b/common/config.h
@@ -41,6 +41,7 @@
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
 #define TDNF_CONF_KEY_MINVERSIONS         "minversions"
 #define TDNF_CONF_KEY_OPENMAX             "openmax"
+#define TDNF_CONF_KEY_VARS_DIRS           "varsdir"
 #define TDNF_CONF_KEY_CHECK_UPDATE_COMPAT "dnf_check_update_compat"
 #define TDNF_CONF_KEY_DISTROSYNC_REINSTALL_CHANGED "distrosync_reinstall_changed"
 
@@ -82,6 +83,7 @@
 // repo defaults
 #define TDNF_DEFAULT_REPO_LOCATION        "/etc/yum.repos.d"
 #define TDNF_DEFAULT_CACHE_LOCATION       "/var/cache/tdnf"
+#define TDNF_DEFAULT_VARS_DIRS            "/etc/tdnf/vars /etc/dnf/vars /etc/yum/vars"
 
 /* pszPersistDir - default is configurable at build time,
    and configurable with "persistdir" at run time */
@@ -114,8 +116,8 @@
 #define TDNF_REPO_DEFAULT_SKIP_MD_OTHER      0
 
 // var names
-#define TDNF_VAR_RELEASEVER               "$releasever"
-#define TDNF_VAR_BASEARCH                 "$basearch"
+#define TDNF_VAR_RELEASEVER               "releasever"
+#define TDNF_VAR_BASEARCH                 "basearch"
 /* dummy setopt values */
 #define TDNF_SETOPT_NAME_DUMMY             "opt.dummy.name"
 #define TDNF_SETOPT_VALUE_DUMMY            "opt.dummy.value"

--- a/common/prototypes.h
+++ b/common/prototypes.h
@@ -49,14 +49,14 @@ TDNFSafeAllocateString(
 
 uint32_t
 TDNFStringSepCount(
-    char *pszBuf,
+    const char *pszBuf,
     char *pszSep,
     size_t *nSepCount
     );
 
 uint32_t
 TDNFSplitStringToArray(
-    char *pszBuf,
+    const char *pszBuf,
     char *pszSep,
     char ***pppszTokens
     );

--- a/common/strings.c
+++ b/common/strings.c
@@ -126,7 +126,7 @@ TDNFSplitStringToArray(
 {
     uint32_t dwError = 0;
     char **ppszToks = NULL;
-    const char *p, *p0;
+    const char *p;
     size_t i, n;
 
     if (!pszBuf || IsNullOrEmptyString(pszSep) || !pppszTokens)
@@ -144,6 +144,7 @@ TDNFSplitStringToArray(
     i = 0;
     p = pszBuf;
     while(*p) {
+        const char *p0;
         while (*p && strchr(pszSep, *p))
             p++;
         if (!*p)

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -274,6 +274,7 @@ typedef struct _TDNF_CONF
     char** ppszPkgLocks;
     char** ppszProtectedPkgs;
     char **ppszInstallOnlyPkgs;
+    char **ppszVarsDirs;
     char *pszPluginPath;
     char *pszPluginConfPath;
 }TDNF_CONF, *PTDNF_CONF;

--- a/pytests/tests/test_vars.py
+++ b/pytests/tests/test_vars.py
@@ -1,0 +1,70 @@
+#
+# Copyright (C) 2024 Broadcom, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import shutil
+import pytest
+
+WORKDIR = '/root/vars/workdir'
+REPOFILENAME = 'baseurls.repo'
+REPONAME = 'baseurls-repo'
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    workdir = WORKDIR
+    utils.makedirs(workdir)
+    utils.edit_config({'varsdir': workdir})
+
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+
+def test_vars(utils):
+    reponame = REPONAME
+    workdir = WORKDIR
+
+    varsdir = workdir
+    port_var = "8080"
+    dir_var = "photon-test"
+
+    with open(os.path.join(varsdir, "port"), "wt") as f:
+        f.write(port_var + "\n")
+
+    with open(os.path.join(varsdir, "dir"), "wt") as f:
+        f.write(dir_var + "\n")
+
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+
+    baseurls = "http://localhost:$port/$dir"
+    utils.create_repoconf(filename, baseurls, reponame)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'makecache'],
+                    cwd=workdir)
+    assert ret['retval'] == 0
+
+    pkgname = utils.config["mulversion_pkgname"]
+    utils.erase_package(pkgname)
+    ret = utils.run(['tdnf',
+                     '-y', '--nogpgcheck',
+                     '--disablerepo=*', '--enablerepo={}'.format(reponame),
+                     'install', pkgname],
+                    cwd=workdir)
+    assert utils.check_package(pkgname)


### PR DESCRIPTION
Implement `vars`. These are variables set by creating files in a directory. The names of the variable are the file names, and their value the (stripped) content. By default, `tdnf` will search the directories `/etc/tdnf/vars /etc/dnf/vars /etc/yum/vars`, and this can be set with `varsdir` in the main configuration. Variables are expanded in `baseurl` and `metalink`. This is in addition to the variables`releasever` and `basearch`.