### PR TITLE
print error and bail if a cmd line argument is an empty string

### DIFF
--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -264,6 +264,12 @@ TDNFCliParseArgs(
 
         while (optind < argc)
         {
+            if (argv[optind][0] == 0) {
+                pr_err("argument is empty string\n");
+                dwError = ERROR_TDNF_INVALID_PARAMETER;
+                BAIL_ON_CLI_ERROR(dwError);
+            }
+
             dwError = TDNFAllocateString(
                           argv[optind++],
                           &pCmdArgs->ppszCmds[nIndex++]);


### PR DESCRIPTION
Failures because of empty arguments are hard to debug, catch them early.