### PR TITLE
show epoch when listing packages with EVR

### DIFF
--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -267,22 +267,15 @@ TDNFPopulatePkgInfoArray(
         dwError = SolvGetPackageId(pPkgList, dwPkgIndex, &dwPkgId);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        dwError = SolvGetPkgNameFromId(pSack, dwPkgId, &pPkgInfo->pszName);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgArchFromId(pSack, dwPkgId, &pPkgInfo->pszArch);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgVersionFromId(
+        dwError = SolvGetNevraFromId(
                       pSack,
                       dwPkgId,
-                      &pPkgInfo->pszVersion);
-        BAIL_ON_TDNF_ERROR(dwError);
-
-        dwError = SolvGetPkgReleaseFromId(
-                      pSack,
-                      dwPkgId,
-                      &pPkgInfo->pszRelease);
+                      &pPkgInfo->dwEpoch,
+                      &pPkgInfo->pszName,
+                      &pPkgInfo->pszVersion,
+                      &pPkgInfo->pszRelease,
+                      &pPkgInfo->pszArch,
+                      &pPkgInfo->pszEVR);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = SolvGetPkgRepoNameFromId(

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -165,7 +165,7 @@ TDNFCliListPackagesPrint(
 
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Name", pPkg->pszName));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkg->pszArch));
-            CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkg->pszVersion, pPkg->pszRelease));
+            CHECK_JD_RC(jd_map_add_string(jd_pkg, "Evr", pPkg->pszEVR));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Repo", pPkg->pszRepoName));
 
             CHECK_JD_RC(jd_list_add_child(jd, jd_pkg));
@@ -196,13 +196,8 @@ TDNFCliListPackagesPrint(
             }
 
             memset(szVersionAndRelease, 0, MAX_COL_LEN);
-            if(snprintf(
-                szVersionAndRelease,
-                MAX_COL_LEN,
-                "%s-%s ",
-                pPkg->pszVersion,
-                pPkg->pszRelease) < 0)
-            {
+            if (snprintf(szVersionAndRelease, MAX_COL_LEN, "%s ",
+                         pPkg->pszEVR) < 0) {
                 dwError = errno;
                 BAIL_ON_CLI_ERROR(dwError);
             }
@@ -326,7 +321,7 @@ TDNFCliInfoCommand(
 
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Name", pPkg->pszName));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkg->pszArch));
-            CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkg->pszVersion, pPkg->pszRelease));
+            CHECK_JD_RC(jd_map_add_string(jd_pkg, "Evr", pPkg->pszEVR));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Repo", pPkg->pszRepoName));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Url", pPkg->pszURL));
             CHECK_JD_RC(jd_map_add_int(jd_pkg, "InstallSize", pPkg->dwInstallSizeBytes));
@@ -620,7 +615,7 @@ TDNFCliProvidesCommand(
 
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Name", pPkg->pszName));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkg->pszArch));
-            CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkg->pszVersion, pPkg->pszRelease));
+            CHECK_JD_RC(jd_map_add_string(jd_pkg, "Evr", pPkg->pszEVR));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Summary", pPkg->pszSummary));
 
             CHECK_JD_RC(jd_list_add_child(jd, jd_pkg));
@@ -633,10 +628,9 @@ TDNFCliProvidesCommand(
     {
         for(pPkg = pPkgInfos; pPkg; pPkg = pPkg->pNext)
         {
-            pr_crit("%s-%s-%s.%s : %s\n",
+            pr_crit("%s-%s.%s : %s\n",
                 pPkg->pszName,
-                pPkg->pszVersion,
-                pPkg->pszRelease,
+                pPkg->pszEVR,
                 pPkg->pszArch,
                 pPkg->pszSummary);
             pr_crit("Repo\t : %s\n", pPkg->pszRepoName);
@@ -983,7 +977,7 @@ TDNFCliRepoQueryCommand(
 
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Name", pPkgInfo->pszName));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkgInfo->pszArch));
-            CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkgInfo->pszVersion, pPkgInfo->pszRelease));
+            CHECK_JD_RC(jd_map_add_string(jd_pkg, "Evr", pPkgInfo->pszEVR));
             CHECK_JD_RC(jd_map_add_string(jd_pkg, "Repo", pPkgInfo->pszRepoName));
 
             if (pPkgInfo->ppszFileList)
@@ -1226,7 +1220,7 @@ TDNFCliCheckUpdateCommand(
         {
             pPkg = &pPkgInfo[dwIndex];
             pr_crit("%*s\r", 80, pPkg->pszRepoName);
-            pr_crit("%*s-%s\r", 50, pPkg->pszVersion, pPkg->pszRelease);
+            pr_crit("%%s\r", 50, pPkg->pszEVR);
             pr_crit("%s.%s", pPkg->pszName, pPkg->pszArch);
             pr_crit("\n");
         }


### PR DESCRIPTION
When listing packages, the epoch wasn't shown. Also, on `info`, the epoch was shown as `0` when it was actually greater.

This issue has been in `tdnf` for a long time, but wasn't discovered earlier because Photon has only one package with an epoch (`perl-JSON-XS`).

Example:
Before:
```
# tdnf list perl-JSON-XS                                                                                                                                                                                                                                                       
perl-JSON-XS.aarch64                         4.03-1.ph5                @System
perl-JSON-XS.aarch64                         4.03-1.ph5           photon-updates

# tdnf info perl-JSON-XS                                                                                                                                                                                                                                                             
Name          : perl-JSON-XS
Arch          : aarch64
Epoch         : 0
Version       : 4.03
Release       : 1.ph5
```
With fix:
```
# ./bin/tdnf list perl-JSON-XS                                                                                                                                                                                                                                            
perl-JSON-XS.aarch64                         1:4.03-1.ph5              @System
perl-JSON-XS.aarch64                         1:4.03-1.ph5         photon-updates

# ./bin/tdnf info perl-JSON-XS    
Name          : perl-JSON-XS
Arch          : aarch64
Epoch         : 1
Version       : 4.03
Release       : 1.ph5
```

