### PR TITLE
set libsolv repo priority with (negated) value from repo config

### DIFF
--- a/client/repo.c
+++ b/client/repo.c
@@ -70,6 +70,13 @@ TDNFInitRepo(
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
+
+    /* tdnf (and dnf) have an opposite sense of priority, therefore negate it.
+       tdnf/dnf: lower value prefered
+       libsolv: higher value prefered
+    */
+    pRepo->priority = -pRepoData->nPriority;
+
     pSolvRepoInfo->pRepo = pRepo;
     pSolvRepoInfo->pszRepoCacheDir = pszRepoCacheDir;
     pRepo->appdata = pSolvRepoInfo;

--- a/pytests/tests/test_priority.py
+++ b/pytests/tests/test_priority.py
@@ -1,0 +1,60 @@
+#
+# Copyright (C) 2024 Broadcom, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import shutil
+import pytest
+
+REPODIR = "/root/priority/repo"
+REPONAME = "priority-test"
+REPOFILENAME = f"{REPONAME}.repo"
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+
+    os.makedirs(REPODIR, exist_ok=True)
+
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    if os.path.isdir(REPODIR):
+        shutil.rmtree(REPODIR)
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    if os.path.isfile(filename):
+        os.remove(filename)
+
+
+def test_priority(utils):
+    pkgname = utils.config['mulversion_pkgname']
+    pkgname_low = pkgname + "=" + utils.config['mulversion_lower']
+    ret = utils.run(["tdnf",
+                     "-y", "--nogpgcheck",
+                     "--downloadonly", f"--downloaddir={REPODIR}",
+                     "install", pkgname_low],
+                    )
+    assert ret['retval'] == 0
+
+    ret = utils.run(["createrepo", "."], cwd=REPODIR)
+    assert ret['retval'] == 0
+
+    filename = os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME)
+    baseurl = "file://{}".format(REPODIR)
+
+    utils.create_repoconf(filename, baseurl, REPONAME)
+    utils.edit_config({'priority': "25"}, repo=REPONAME)
+
+    ret = utils.run(["tdnf",
+                     "-y", "--nogpgcheck",
+                     "install", pkgname],
+                    cwd=REPODIR)
+    assert ret['retval'] == 0
+
+    utils.check_package(pkgname, version=utils.config['mulversion_lower'])


### PR DESCRIPTION
`tdnf` supports repo priority since PR #207 , but only used it to order the repositories so a repo with lower priority value will  be considered first. But if a repo with a less preferred priority had a newer package version, that would still be preferred. This change also sets the `libsolv` repo priority to the configured (negated) value, so a package from a preferred repo will be used even if the version is lower.

Test (note the default priority is 50):

```
# ./bin/tdnf --repofrompath=oldrepo,$(pwd)/oldrepo install vim
Refreshing metadata for: 'oldrepo'
oldrepo                                   3072 100%
oldrepo (primary)                          801 100%
oldrepo (file lists)                       354 100%
oldrepo (other)                            607 100%

Installing:
vim                                                         aarch64                                      9.0.2142-1.ph5                                              photon-updates                                 3.71M                                               1.58M

Total installed size:   3.71M
Total download size:   1.58M
Is this ok [y/N]: N
Error(1032) : Operation aborted.
# tdnf-config edit photon-updates priority=75
# ./bin/tdnf --repofrompath=oldrepo,$(pwd)/oldrepo install vim

Installing:
vim                                                         aarch64                                      9.0.1298-3.ph5                                              oldrepo                                        3.56M                                               1.55M

Total installed size:   3.56M
Total download size:   1.55M
Is this ok [y/N]: N
Error(1032) : Operation aborted.
# 
```