### PR TITLE
show repo name in json output when installing

### DIFF
--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -373,6 +373,7 @@ JDPkgList(
         CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkgInfo->pszArch));
         CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkgInfo->pszVersion, pPkgInfo->pszRelease));
         CHECK_JD_RC(jd_map_add_int(jd_pkg, "InstallSize", pPkgInfo->dwInstallSizeBytes));
+        CHECK_JD_RC(jd_map_add_string(jd_pkg, "Repo", pPkgInfo->pszRepoName));
 
         CHECK_JD_RC(jd_list_add_child(jd_list, jd_pkg));
         JD_SAFE_DESTROY(jd_pkg);


### PR DESCRIPTION
When installing (or for any alter command), the repo name wasn't shown. Fixing this:
```
# ./bin/tdnf -j --assumeyes install lsof | jq .
{
  "Install": [
    {
      "Name": "libtirpc",
      "Arch": "aarch64",
      "Evr": "1.3.3-3.ph5",
      "InstallSize": 206778,
      "Repo": "photon-updates"
    },
    {
      "Name": "lsof",
      "Arch": "aarch64",
      "Evr": "4.96.4-1.ph5",
      "InstallSize": 241341,
      "Repo": "photon-updates"
    }
  ]
}
```