### PR TITLE
show complex (relational) deps in repoquery, and to install build reqs

### DIFF
--- a/client/resolve.c
+++ b/client/resolve.c
@@ -510,7 +510,7 @@ TDNFResolveBuildDependencies(
     }
 
     for (i = 0; i < qDeps.count; i++) {
-        pszDep = pool_id2str(pTdnf->pSack->pPool, qDeps.elements[i]);
+        pszDep = pool_dep2str(pTdnf->pSack->pPool, qDeps.elements[i]);
         if (!pszDep) {
             dwError = ERROR_TDNF_INVALID_PARAMETER;
             BAIL_ON_TDNF_ERROR(dwError);

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -2217,7 +2217,7 @@ SolvGetDependenciesFromId(
 
     for (i = 0; i < nNumDeps; i++)
     {
-        pszDep = pool_id2str(pSack->pPool, queueDeps.elements[i]);
+        pszDep = pool_dep2str(pSack->pPool, queueDeps.elements[i]);
         dwError = TDNFAllocateString(pszDep, &ppszDependencies[i]);
         BAIL_ON_TDNF_ERROR(dwError);
     }


### PR DESCRIPTION
Before:
```
# tdnf repoquery --requires zsh
coreutils
...
```
or:
```
# tdnf repoquery --requires tdnf
...
tdnf-cli-libs
...
```

With this change:
```
# ./bin/tdnf repoquery --requires zsh        
(coreutils or coreutils-selinux)
...
```

```
# ./bin/tdnf repoquery --requires tdnf
...
tdnf-cli-libs = 3.5.8-1.ph5
...
```

