### PR TITLE
remove broken code and ignore the size field in metalink data

### DIFF
--- a/plugins/metalink/utils.c
+++ b/plugins/metalink/utils.c
@@ -472,24 +472,8 @@ TDNFXmlParseData(
         elementInfo->dwError = TDNFParseFileTag(userData);
         BAIL_ON_TDNF_ERROR(elementInfo->dwError);
     }
-    else if(!strcmp(elementInfo->startElement, TAG_NAME_SIZE))
-    {
-        //Get File Size.
-        TDNFAllocateStringN(val, len, &size);
-
-        if(!size)
-        {
-            elementInfo->dwError = ERROR_TDNF_METALINK_PARSER_MISSING_FILE_SIZE;
-            pr_err("XML Parser Error:File size is missing: %s", size);
-            BAIL_ON_TDNF_ERROR(elementInfo->dwError);
-        }
-        if(sscanf(size, "%ld", &(elementInfo->ml_ctx->size)) != 1)
-        {
-            elementInfo->dwError = ERROR_TDNF_INVALID_PARAMETER;
-            pr_err("XML Parser Warning: size is invalid value: %s\n", size);
-            BAIL_ON_TDNF_ERROR(elementInfo->dwError);
-        }
-    }
+    /* ignore "size" field for now. */
+    /* else if(!strcmp(elementInfo->startElement, TAG_NAME_SIZE)) {} */
     else if(!strcmp(elementInfo->startElement, TAG_NAME_HASH))
     {
         elementInfo->dwError = TDNFParseHashTag(userData, val, len);

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -160,6 +160,7 @@ repodir=${TEST_REPO_DIR}/yum.repos.d
 cachedir=${TEST_REPO_DIR}/cache/tdnf
 EOF
 
+# size field is a dummy value - it will be ignored
 cat << EOF > ${PUBLISH_PATH}/metalink
 <?xml version="1.0" encoding="utf-8"?>
 <metalink version="3.0" xmlns="http://www.metalinker.org/" type="dynamic" pubdate="Wed, 05 Feb 2020 08:14:56 GMT">
@@ -167,6 +168,7 @@ cat << EOF > ${PUBLISH_PATH}/metalink
   <file name="repomd.xml">
    <verification>
    </verification>
+   <size>123</size>
    <resources maxconnections="1">
     <url protocol="http" type="file" location="IN" preference="100">http://localhost:8080/photon-test/repodata/repomd.xml</url>
    </resources>


### PR DESCRIPTION
When the `size` tag was present in metalink file, the metalink plugin would throw an error:
```
$ sudo tdnf --repoid=epel --releasever=9 makecache
Loaded plugin: tdnfmetalink
Loaded plugin: tdnfrepogpgcheck
epel                                     23689 100%
XML Parser Warning: size is invalid value: 

Unable to parse metalink, ERROR: code=1622
Error: TDNFMetalinkGetBaseURLs 1622
Plugin error: metalink plugin error: (null)

Error(1622) : Invalid argument
Error: Failed to synchronize cache for repo 'Extra Packages for Enterprise Linux 9 - aarch64'
Error(1622) : Invalid argument
```
The code that checks the `size` field was wrong and useless, so removing it, and adding the field to the test file.

Future enhancements can evaluate the `size` field (and others, like `verification`), but with this change `tdnf` will be able to use metalink files from EPEL.