### PR TITLE
expand vars for 'gpgkey' URL setting

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -745,6 +745,14 @@ TDNFRepoListFinalize(
             dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMirrorList);
             BAIL_ON_TDNF_ERROR(dwError);
         }
+        if (pRepo->ppszUrlGPGKeys)
+        {
+            for (int i = 0; pRepo->ppszUrlGPGKeys[i]; i++)
+            {
+                dwError = TDNFConfigReplaceVars(pTdnf, &(pRepo->ppszUrlGPGKeys[i]));
+                BAIL_ON_TDNF_ERROR(dwError);
+            }
+        }
 
         if (pRepo->pszMetaLink)
         {


### PR DESCRIPTION
Expand variables (eg. `releasever`) in the GPG key URL in repo config files:
```
gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$releasever
```
