### PR TITLE
use the version provided by distroverpkg if it exists

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -675,6 +675,9 @@ TDNFOpenHandle(
                   TDNF_CONF_GROUP);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    dwError = TDNFConfigExpandVars(pTdnf);
+    BAIL_ON_TDNF_ERROR(dwError);
+
     GlobalSetDnfCheckUpdateCompat(pTdnf->pConf->nCheckUpdateCompat);
 
     dwError = TDNFHasOpt(pTdnf->pArgs, TDNF_CONF_KEY_REPOSDIR, &nHasOptReposDir);

--- a/client/config.c
+++ b/client/config.c
@@ -447,9 +447,6 @@ TDNFConfigReplaceVars(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFConfigExpandVars(pTdnf);
-    BAIL_ON_TDNF_ERROR(dwError);
-
     cn_vars = parse_varsdirs(pTdnf->pConf->ppszVarsDirs);
     if (cn_vars == NULL) {
         pr_err("parsing vars failed: %s (%d)\n", strerror(errno), errno);

--- a/client/config.c
+++ b/client/config.c
@@ -369,7 +369,7 @@ TDNFConfigExpandVars(
     if(!pConf->pszVarReleaseVer &&
        !IsNullOrEmptyString(pConf->pszDistroVerPkg))
     {
-        dwError = TDNFRawGetPackageVersion(
+        dwError = TDNFGetReleaseVersion(
                       pTdnf->pArgs->pszInstallRoot,
                       pConf->pszDistroVerPkg,
                       &pConf->pszVarReleaseVer);

--- a/client/config.c
+++ b/client/config.c
@@ -192,9 +192,11 @@ TDNFReadConfig(
         {
             pConf->pszPersistDir = strdup(cn->value);
         }
-        else if (strcmp(cn->name, TDNF_CONF_KEY_DISTROVERPKG) == 0)
+        else if (strcmp(cn->name, TDNF_CONF_KEY_DISTROVERPKGS) == 0)
         {
-            pConf->pszDistroVerPkg = strdup(cn->value);
+            dwError = TDNFSplitStringToArray(cn->value,
+                                             " ", &pConf->ppszDistroVerPkgs);
+            BAIL_ON_TDNF_ERROR(dwError);
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_EXCLUDE) == 0)
         {
@@ -283,8 +285,11 @@ TDNFReadConfig(
         pConf->pszRepoDir = strdup(TDNF_DEFAULT_REPO_LOCATION);
     if (pConf->pszCacheDir == NULL)
         pConf->pszCacheDir = strdup(TDNF_DEFAULT_CACHE_LOCATION);
-    if (pConf->pszDistroVerPkg == NULL)
-        pConf->pszDistroVerPkg = strdup(TDNF_DEFAULT_DISTROVERPKG);
+    if (pConf->ppszDistroVerPkgs == NULL) {
+        dwError = TDNFSplitStringToArray(TDNF_DEFAULT_DISTROVERPKGS,
+                                         " ", &pConf->ppszDistroVerPkgs);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
     if (pConf->pszPersistDir == NULL)
         pConf->pszPersistDir = strdup(TDNF_DEFAULT_DB_LOCATION);
 
@@ -366,14 +371,21 @@ TDNFConfigExpandVars(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if(!pConf->pszVarReleaseVer &&
-       !IsNullOrEmptyString(pConf->pszDistroVerPkg))
+    if(!pConf->pszVarReleaseVer)
     {
-        dwError = TDNFGetReleaseVersion(
-                      pTdnf->pArgs->pszInstallRoot,
-                      pConf->pszDistroVerPkg,
-                      &pConf->pszVarReleaseVer);
-        BAIL_ON_TDNF_ERROR(dwError);
+        int i;
+
+        for (i = 0; pConf->ppszDistroVerPkgs[i]; i++) {
+            dwError = TDNFGetReleaseVersion(
+                          pTdnf->pArgs->pszInstallRoot,
+                          pConf->ppszDistroVerPkgs[i],
+                          &pConf->pszVarReleaseVer);
+
+            if (dwError == 0)
+                break;
+            else if (dwError != ERROR_TDNF_NO_DISTROVERPKG)
+                BAIL_ON_TDNF_ERROR(dwError);
+        }
     }
 
     if(!pConf->pszVarBaseArch)
@@ -400,7 +412,7 @@ TDNFFreeConfig(
         TDNF_SAFE_FREE_MEMORY(pConf->pszRepoDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszCacheDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszPersistDir);
-        TDNF_SAFE_FREE_MEMORY(pConf->pszDistroVerPkg);
+        TDNF_SAFE_FREE_STRINGARRAY(pConf->ppszDistroVerPkgs);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarReleaseVer);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarBaseArch);
         TDNF_SAFE_FREE_MEMORY(pConf->pszBaseArch);

--- a/client/includes.h
+++ b/client/includes.h
@@ -44,6 +44,7 @@
 #include <rpm/rpmkeyring.h>
 #include <rpm/header.h>
 #include <rpm/rpmcli.h>
+#include <rpm/rpmtypes.h>
 
 //libcurl
 #include <curl/curl.h>

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -963,9 +963,9 @@ TDNFTouchFile(
     );
 
 uint32_t
-TDNFRawGetPackageVersion(
+TDNFGetReleaseVersion(
    const char* pszRootDir,
-   const char* pszPkg,
+   const char* pszDistroVerPkg,
    char** ppszVersion
    );
 

--- a/common/config.h
+++ b/common/config.h
@@ -92,7 +92,7 @@
    and configurable with "persistdir" at run time */
 #define TDNF_DEFAULT_DB_LOCATION          HISTORY_DB_DIR
 
-#define TDNF_DEFAULT_DISTROVERPKG         "system-release"
+#define TDNF_DEFAULT_DISTROVERPKG         "system-release(releasever)"
 #define TDNF_DEFAULT_DISTROARCHPKG        "x86_64"
 #define TDNF_RPM_CACHE_DIR_NAME           "rpms"
 #define TDNF_REPODATA_DIR_NAME            "repodata"

--- a/common/config.h
+++ b/common/config.h
@@ -30,7 +30,7 @@
 #define TDNF_CONF_KEY_PROXY_USER          "proxy_username"
 #define TDNF_CONF_KEY_PROXY_PASS          "proxy_password"
 #define TDNF_CONF_KEY_KEEP_CACHE          "keepcache"
-#define TDNF_CONF_KEY_DISTROVERPKG        "distroverpkg"
+#define TDNF_CONF_KEY_DISTROVERPKGS       "distroverpkg"
 #define TDNF_CONF_KEY_DISTROARCHPKG       "distroarchpkg"
 #define TDNF_CONF_KEY_MAX_STRING_LEN      "maxstringlen"
 #define TDNF_CONF_KEY_PLUGINS             "plugins"
@@ -92,7 +92,7 @@
    and configurable with "persistdir" at run time */
 #define TDNF_DEFAULT_DB_LOCATION          HISTORY_DB_DIR
 
-#define TDNF_DEFAULT_DISTROVERPKG         "system-release(releasever)"
+#define TDNF_DEFAULT_DISTROVERPKGS        "system-release(releasever) system-release redhat-release"
 #define TDNF_DEFAULT_DISTROARCHPKG        "x86_64"
 #define TDNF_RPM_CACHE_DIR_NAME           "rpms"
 #define TDNF_REPODATA_DIR_NAME            "repodata"

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -263,7 +263,7 @@ typedef struct _TDNF_CONF
     char* pszPersistDir;
     char* pszProxy;
     char* pszProxyUserPass;
-    char* pszDistroVerPkg;
+    char** ppszDistroVerPkgs;
     char* pszBaseArch;
     char* pszVarReleaseVer;
     char* pszVarBaseArch;


### PR DESCRIPTION
Amend the logic to find the release version: previously, `tdnf` used the version of the package that provides "system-release". `dnf` has a slightly different logic: if the package that provides it provides it with a version, use that. Otherwise, use the version of the package itself. Also, `dnf` by default looks for the provides of "system-release(releasever)" first.

There is no difference in Photon. However in Rocky Linux, "system-release(releasever)" is provided by "rocky-release", the version of which can be something like "9.4", but it provides "system-release(releasever) = 9". As a result, when expanding `$releasever`, getting metadata may fail when used in the `baseurl`.

Also converting the setting for `distroverpkg` to a list. Fedora uses "system-release" instead of "system-release(releasever)" so adding that to the list. Adding also "redhat-release" because that's also in `dnf`, but not adding 'distribution-release(releasever)', 'distribution-release', and 'suse-release'.