### PR TITLE
Change && to || for TDNFAlterRepoState for invalid argument check

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -789,7 +789,7 @@ TDNFAlterRepoState(
 {
     uint32_t dwError = 0;
     int nIsGlob = 0;
-    if(!pRepos && IsNullOrEmptyString(pszId))
+    if(!pRepos || IsNullOrEmptyString(pszId))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);


### PR DESCRIPTION
During development of virtual snapshot functionality, I noticed this as a bug in client/repolist.c. If `pszId` is NULL, but `pRepos` is not NULL, no 1602 error will be given to the user.

If this is intentional, this PR can be closed.