### PR TITLE
bump version of actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/build-tdnf-rpms.yml
+++ b/.github/workflows/build-tdnf-rpms.yml
@@ -22,7 +22,7 @@ jobs:
               run: |
                 docker run --rm -v$(pwd)/rpms:/rpms ${DIST} /bin/sh -c 'tdnf -y --repofrompath=tdnf,/rpms install tdnf-pytests && pytest /usr/share/tdnf/pytests/'
             - name: upload RPMs
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: tdnf-rpms
                   path: rpms


### PR DESCRIPTION
See https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/