### PR TITLE
Remove pthread_mutex API usage from TDNF.

### DIFF
--- a/client/includes.h
+++ b/client/includes.h
@@ -31,7 +31,6 @@
 #include <sys/types.h>
 
 #include <dirent.h>
-#include <pthread.h>
 
 #include "../solv/includes.h"
 

--- a/client/structs.h
+++ b/client/structs.h
@@ -51,12 +51,6 @@ typedef struct _TDNF_RPM_TS_
     PTDNF_CACHED_RPM_LIST   pCachedRpmsArray;
 } TDNFRPMTS, *PTDNFRPMTS;
 
-typedef struct _TDNF_ENV_
-{
-    pthread_mutex_t mutexInitialize;
-    int nInitialized;
-} TDNF_ENV, *PTDNF_ENV;
-
 typedef struct _TDNF_REPO_METADATA
 {
     char *pszRepoCacheDir;


### PR DESCRIPTION
As a single-threaded application, mutexes are unnecessary.