### PR TITLE
reposync fix infinite loop

### DIFF
--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -547,6 +547,7 @@ TDNFPkgInfoFilterNewest(
         {
             pPkgInfo->pNext = ppPkgInfos[i];
             pPkgInfo = ppPkgInfos[i];
+            pPkgInfo->pNext = NULL;
         }
     }
 

--- a/pytests/tests/test_reposync.py
+++ b/pytests/tests/test_reposync.py
@@ -432,3 +432,18 @@ def test_reposync_newest(utils):
     assert mulversion_pkgname_found
 
     shutil.rmtree(synced_dir)
+
+
+# reposync with --newest-only option caused an infinite loop
+def test_reposync_newest_multiplerepos(utils):
+    reponame = "photon-srpms"
+    workdir = WORKDIR
+    utils.makedirs(workdir)
+
+    ret = utils.run(['tdnf',
+                     '--enablerepo={}'.format(reponame),
+                     '--newest-only',
+                     '--urls',
+                     'reposync'],
+                    cwd=workdir)
+    assert ret['retval'] == 0


### PR DESCRIPTION
When running:
```
tdnf reposync --urls --newest-only --enablerepo photon-srpms
```
`tdnf` never exits. Root cause is a loop in a linked list created when the `--newest-only` option is set.

This also adds a test, however it fails to reproduce the problem when the fix is not applied.