### PR TITLE
implement snapshot option for repos

### DIFF
--- a/client/init.c
+++ b/client/init.c
@@ -175,6 +175,15 @@ TDNFRefreshSack(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    for (i = 0; i < nCount; i++) {
+        pRepo = ppRepoArray[i];
+
+        if (pRepo->nEnabled && pRepo->pszSnapshotUrl) {
+            dwError = TDNFApplySnapshot(pRepo, pSack, pRepo->pRepo);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
 cleanup:
     TDNF_SAFE_FREE_MEMORY(pszRepoCacheDir);
     TDNF_SAFE_FREE_MEMORY(ppRepoArray);

--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -590,6 +590,9 @@ TDNFPackageGetDowngrade(
                                     &dwAvailableId);
         BAIL_ON_TDNF_ERROR(dwError);
 
+        if (pSack->pPool->considered && !MAPTST(pSack->pPool->considered, dwAvailableId))
+            continue;
+
         dwError = SolvCmpEvr(
                       pSack,
                       dwAvailableId,

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -574,6 +574,14 @@ TDNFReadConfFilesFromDir(
     );
 
 //repo.c
+
+uint32_t
+TDNFApplySnapshot(
+    PTDNF_REPO_DATA pRepoData,
+    PSolvSack pSack,
+    Repo* pRepo
+    );
+
 uint32_t
 TDNFInitRepoFromMetadata(
     Repo *pRepo,

--- a/client/repo.c
+++ b/client/repo.c
@@ -8,6 +8,73 @@
 
 #include "includes.h"
 
+
+uint32_t
+TDNFApplySnapshot(
+    PTDNF_REPO_DATA pRepoData,
+    PSolvSack pSack,
+    Repo* pRepo
+    )
+{
+    uint32_t dwError = 0;
+    Pool* pPool = NULL;
+    char** ppszSnapshotPackages = NULL;
+    char *pszPkg = NULL;
+    int i;
+    Queue qResult = {0};
+
+    if(!pRepoData || !pRepoData->pszSnapshotUrl || !pSack || !pSack->pPool)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    pPool = pSack->pPool;
+
+    queue_init(&qResult);
+
+    dwError = TDNFReadFileToStringArray(pRepoData->pszSnapshotUrl, &ppszSnapshotPackages);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    for(i = 0; ppszSnapshotPackages[i]; i++) {
+        pszPkg = ppszSnapshotPackages[i];
+        if (pszPkg[0] == '#')
+            continue;
+
+        dwError = SolvFindSolvablesByNEqualsEvrFromRepo(pPool, pRepo,
+                                                        pszPkg, &qResult);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if (!pPool->considered)
+    {
+        dwError = TDNFAllocateMemory(
+                             1,
+                             sizeof(Map),
+                             (void**)&pPool->considered);
+        map_init(pPool->considered, pPool->nsolvables);
+        map_setall(pPool->considered);
+    }
+
+    /* unset all solvables from repo */
+    for (i = pRepo->start; i < pRepo->end; i++) {
+        Solvable *solvable = pool_id2solvable(pPool, i);
+        if (solvable->repo == pRepo)
+            MAPCLR(pPool->considered, i);
+    }
+    /* then set solvables from our snapshot list, if they are in the repo */
+    for (i = 0; i < qResult.count; i++) {
+        Id s = qResult.elements[i];
+        Solvable *solvable = pool_id2solvable(pPool, s);
+        if (solvable->repo == pRepo)
+            MAPSET(pPool->considered, s);
+    }
+
+error:
+    TDNF_SAFE_FREE_STRINGARRAY(ppszSnapshotPackages);
+    queue_free(&qResult);
+    return dwError;
+}
+
 //Download repo metadata and initialize
 uint32_t
 TDNFInitRepo(
@@ -77,6 +144,7 @@ TDNFInitRepo(
     */
     pRepo->priority = -pRepoData->nPriority;
 
+    pRepoData->pRepo = pRepo;
     pSolvRepoInfo->pRepo = pRepo;
     pSolvRepoInfo->pszRepoCacheDir = pszRepoCacheDir;
     pRepo->appdata = pSolvRepoInfo;

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -555,6 +555,21 @@ TDNFLoadReposFromFile(
             {
                 pRepo->pszMirrorList = strdup(cn->value);
             }
+            else if (strcmp(cn->name, TDNF_REPO_KEY_SNAPSHOT_URL) == 0)
+            {
+                /* we do not support URLs yet, just filenames */
+                if (cn->value[0] == '/')
+                    pRepo->pszSnapshotUrl = strdup(cn->value);
+                else {
+                    /* path should be relative to repo dir */
+                    dwError = TDNFJoinPath(
+                                  &pRepo->pszSnapshotUrl,
+                                  pTdnf->pConf->pszRepoDir,
+                                  cn->value,
+                                  NULL);
+                    BAIL_ON_TDNF_ERROR(dwError);
+                }
+            }
             else if (strcmp(cn->name, TDNF_REPO_KEY_SKIP) == 0)
             {
                 pRepo->nSkipIfUnavailable = isTrue(cn->value);
@@ -748,6 +763,11 @@ TDNFRepoListFinalize(
         if(pRepo->pszMirrorList)
         {
             dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszMirrorList);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+        if(pRepo->pszSnapshotUrl)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszSnapshotUrl);
             BAIL_ON_TDNF_ERROR(dwError);
         }
         if (pRepo->ppszUrlGPGKeys)

--- a/common/config.h
+++ b/common/config.h
@@ -72,6 +72,7 @@
 #define TDNF_REPO_KEY_SKIP_MD_FILELISTS   "skip_md_filelists"
 #define TDNF_REPO_KEY_SKIP_MD_UPDATEINFO  "skip_md_updateinfo"
 #define TDNF_REPO_KEY_SKIP_MD_OTHER       "skip_md_other"
+#define TDNF_REPO_KEY_SNAPSHOT_URL        "snapshot"
 
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -285,6 +285,8 @@ typedef struct _TDNF_CONF
     char *pszPluginConfPath;
 }TDNF_CONF, *PTDNF_CONF;
 
+typedef struct s_Repo Repo;
+
 typedef struct _TDNF_REPO_DATA
 {
     int nEnabled;
@@ -297,6 +299,7 @@ typedef struct _TDNF_REPO_DATA
     char** ppszBaseUrls;
     char* pszMetaLink;
     char* pszMirrorList;
+    char* pszSnapshotUrl;
     char** ppszUrlGPGKeys;
     int nSSLVerify;
     char* pszSSLCaCert;
@@ -313,6 +316,8 @@ typedef struct _TDNF_REPO_DATA
     int nSkipMDUpdateInfo;
     int nSkipMDOther;
     char *pszCacheName;
+
+    Repo *pRepo;
 
     struct _TDNF_REPO_DATA* pNext;
 }TDNF_REPO_DATA, *PTDNF_REPO_DATA;

--- a/pytests/tests/test_snapshots.py
+++ b/pytests/tests/test_snapshots.py
@@ -1,0 +1,122 @@
+#
+# Copyright (C) 2025 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import json
+import pytest
+import os
+
+
+REPOFILENAME = "snapshot.repo"
+REPONAME = "snapshot"
+
+EXCLUDED_PKGS = ["tdnf-multi=1.0.1-1", "tdnf-multi=1.0.1-2", "tdnf-multi=1.0.1-4"]
+INCLUDED_PKGS = ["tdnf-multi=1.0.1-3"]
+
+
+def create_snapshot_repo(utils, reponame):
+    snapshot_file = os.path.join(utils.config['repo_path'], "yum.repos.d", f"{reponame}.list")
+
+    ret = utils.run(["tdnf", "repoquery", "--available", "--qf", "%{name}=%{evr}"])
+    snapshot_list = ret['stdout']
+
+    with open(snapshot_file, "wt") as f:
+        for pkg in snapshot_list:
+            if pkg not in EXCLUDED_PKGS:
+                f.write(f"{pkg}\n")
+
+    baseurls = "http://localhost:8080/photon-test"
+    utils.create_repoconf(os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME), baseurls, reponame)
+    utils.edit_config({'snapshot': f"{reponame}.list"}, repo=REPONAME)
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    create_snapshot_repo(utils, REPONAME)
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    for filename in [os.path.join(utils.config['repo_path'], "yum.repos.d", REPOFILENAME), os.path.join(utils.config['repo_path'], "yum.repos.d", f"{REPONAME}.list")]:
+        try:
+            os.remove(filename)
+        except OSError:
+            pass
+
+    for pkg in EXCLUDED_PKGS + INCLUDED_PKGS:
+        utils.erase_package(pkg)
+
+
+def test_install(utils):
+
+    # expect failure to install excluded package
+    for pkg in EXCLUDED_PKGS:
+        ret = utils.run(["tdnf", "-y", "install", "--disablerepo=*", "--repoid", REPONAME, pkg])
+        assert ret['retval'] != 0
+
+    # expect succes to install included package
+    for pkg in INCLUDED_PKGS:
+        ret = utils.run(["tdnf", "-y", "install", "--repoid", REPONAME, pkg])
+        assert ret['retval'] == 0
+
+
+def test_update(utils):
+    # clean up before test
+    for pkg in EXCLUDED_PKGS + INCLUDED_PKGS:
+        utils.erase_package(pkg)
+
+    # install from non-snapshot repo
+    ret = utils.run(["tdnf", "-y", "install", "tdnf-multi=1.0.1-1"])
+    assert ret['retval'] == 0
+
+    ret = utils.run(["tdnf", "-y", "--repoid", REPONAME, "update", "tdnf-multi"])
+    assert ret['retval'] == 0
+
+    ret = utils.run(["tdnf", "-j", "--installed", "list"])
+    infolist = json.loads("\n".join(ret['stdout']))
+    print(f"infolist={infolist}\n")
+
+    found = False
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        print(f"nevr={nevr}\n")
+        if nevr in INCLUDED_PKGS:
+            found = True
+        assert nevr not in EXCLUDED_PKGS
+
+    assert found
+
+
+def test_list(utils):
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", "list"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS
+
+
+def test_info(utils):
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", "info"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS
+
+
+def test_repoquery(utils):
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", "repoquery"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -638,6 +638,14 @@ SolvFindSolvablesByNevraStr(
     );
 
 uint32_t
+SolvFindSolvablesByNEqualsEvrFromRepo(
+    Pool *pool,
+    Repo *repo,
+    const char *nevra,
+    Queue* qresult
+    );
+
+uint32_t
 SolvRequiresFromQueue(
     Pool *pool,
     Queue *pq_pkgs,  /* solvable ids */

--- a/solv/simplequery.c
+++ b/solv/simplequery.c
@@ -54,6 +54,26 @@ int split_nevra(char *nevra, char **name, char **evr, char **arch)
     return 0;
 }
 
+/* split string like "pkg-name=1.2.4-1.ph5"
+   into "pkg-name" and "1.2.4-1.ph5" 
+   There is no arch
+*/
+static
+int split_name_equals_evr(char *nevr, char **name, char **evr)
+{
+    char *p = nevr;
+    while(*p && *p != '=')
+        p++;
+    if (*p)
+        *p = 0;
+    else
+        return -1;
+    *evr = p+1;
+    *name = nevr;
+
+    return 0;
+}
+
 /* Find packages by nevra as specified with ids. Must be either installed
    or not as set by the 'installed' flag. Adds result to qresult, can
    be multiples if package is in multiple repos. */
@@ -85,7 +105,36 @@ SolvFindSolvablesByNevraId(
 
 cleanup:
     return dwError;
+error:
+    goto cleanup;
+}
 
+/* Find packages specfied by nevr (no arch),
+   from specified repository */
+uint32_t
+SolvFindSolvablesByNevrIdFromRepo(
+    Pool *pool,
+    Repo *repo,
+    Id name,
+    Id evr,
+    Queue* qresult
+    )
+{
+    uint32_t dwError = 0;
+    Id p;
+
+    ASSERT_ARG(pool);
+    ASSERT_ARG(qresult);
+
+    for (p = repo->start; p < repo->end; p++) {
+        Solvable *s = pool_id2solvable(pool, p);
+        if (s->name == name && s->evr == evr) {
+            queue_push(qresult, p);
+        }
+    }
+
+cleanup:
+    return dwError;
 error:
     goto cleanup;
 }
@@ -122,6 +171,49 @@ SolvFindSolvablesByNevraStr(
     if (id_name && id_evr && id_arch)
     {
         dwError = SolvFindSolvablesByNevraId(pool, id_name, id_evr, id_arch, qresult, installed);
+        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+    }
+
+cleanup:
+    if (n)
+        free(n);
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+/* Find packages in repo matching string of the
+   form "pkg-name=1.2-4.ph5" */
+uint32_t
+SolvFindSolvablesByNEqualsEvrFromRepo(
+    Pool *pool,
+    Repo *repo,
+    const char *nevr,
+    Queue* qresult
+)
+{
+    uint32_t dwError = 0;
+    char *n = NULL, *name, *evr;
+    Id id_name, id_evr;
+
+    ASSERT_ARG(pool);
+    ASSERT_ARG(qresult);
+
+    n = strdup(nevr);
+    ASSERT_MEM(n);
+
+    if (split_name_equals_evr(n, &name, &evr) != 0)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+    }
+
+    id_name = pool_str2id(pool, name, 0);
+    id_evr = pool_str2id(pool, evr, 0);
+    if (id_name && id_evr)
+    {
+        dwError = SolvFindSolvablesByNevrIdFromRepo(pool, repo, id_name, id_evr, qresult);
         BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
     }
 

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -918,6 +918,7 @@ error:
     goto cleanup;
 }
 
+/* dead function, remove */
 uint32_t
 SolvGetLatest(
     PSolvSack pSack,
@@ -1402,14 +1403,18 @@ SolvFindBestAvailable(
     queue_init(&q);
 
     /* step 1: look at packages with the specified name */
-    FOR_PROVIDES(p, pp, idName)
-    if (pool->solvables[p].name == idName)
-        queue_push(&q, p);
+    FOR_PROVIDES(p, pp, idName) {
+        if (pool->considered && !MAPTST(pool->considered, p))
+            continue;
+        if (pool->solvables[p].name == idName)
+            queue_push(&q, p);
+    }
     if (!q.count)
     {
         dwError = ERROR_TDNF_NO_MATCH;
         BAIL_ON_TDNF_ERROR(dwError);
     }
+
     pool_best_solvables(pool, &q, 0);
     queue_truncate(&q, 1);        /* use the first element */
 
@@ -1445,6 +1450,7 @@ SolvFindHighestAvailable(
     uint32_t dwError = 0;
     PSolvPackageList pAvailablePkgList = NULL;
     Queue *pqAvail;
+    int i;
 
     if(!pSack || IsNullOrEmptyString(pszPkgName) || !pdwId)
     {
@@ -1476,7 +1482,19 @@ SolvFindHighestAvailable(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    *pdwId = pqAvail->elements[0];
+    if (pSack->pPool->considered) {
+        for (i = 0; i < pqAvail->count; i++) {
+            if (MAPTST(pSack->pPool->considered, pqAvail->elements[i])) {
+                *pdwId = pqAvail->elements[i];
+                break;
+            }
+        }
+        if (i == pqAvail->count) {
+            dwError = ERROR_TDNF_NO_MATCH;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    } else
+        *pdwId = pqAvail->elements[0];
 
 cleanup:
     if(pAvailablePkgList)

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -603,7 +603,7 @@ SolvApplyListQuery(
              SELECTION_PROVIDES |
              SELECTION_GLOB |     /* foo* */
              SELECTION_CANON |    /* foo-1.2-3.ph4.noarch */
-	     SELECTION_DOTARCH |  /* foo.noarch */
+             SELECTION_DOTARCH |  /* foo.noarch */
              SELECTION_REL;       /* foo>=1.2-3 */
 
     if (pQuery->nScope == SCOPE_SOURCE) {
@@ -636,6 +636,8 @@ SolvApplyListQuery(
             {
                 FOR_POOL_SOLVABLES(p)
                 {
+                    if (pool->considered && !MAPTST(pool->considered, p))
+                        continue;
                     if(is_pseudo_package(pool, &pool->solvables[p]))
                         continue;
                     queue_push(&queueTmp, p);
@@ -650,6 +652,8 @@ SolvApplyListQuery(
 
                     FOR_REPO_SOLVABLES(repo, p, s)
                     {
+                        if (pool->considered && !MAPTST(pool->considered, p))
+                            continue;
                         if (is_pseudo_package(pool, &pool->solvables[p]))
                             continue;
                         queue_push(&queueTmp, p);
@@ -660,6 +664,8 @@ SolvApplyListQuery(
             {
                 FOR_JOB_SELECT(p, pp, how, what)
                 {
+                    if (pool->considered && !MAPTST(pool->considered, p))
+                        continue;
                     if (is_pseudo_package(pool, &pool->solvables[p]))
                         continue;
                     queue_push(&queueTmp, p);
@@ -678,6 +684,8 @@ SolvApplyListQuery(
         Pool *pool = pQuery->pSack->pPool;
         FOR_POOL_SOLVABLES(p)
         {
+            if (pool->considered && !MAPTST(pool->considered, p))
+                continue;
             if(is_pseudo_package(pool, &pool->solvables[p]))
                 continue;
             queue_push(&pQuery->queueResult, p);


### PR DESCRIPTION
Add `snaspshot` option for repositories. It needs to be set to a file which contains a list of packages which will be accepted for the repository. Other packages in that repository will be disabled.

This is to implement snapshots of repositories that contain packages of different versions that are continuously updated by adding new packages. A snapshot file should list the current packages at the time of an update.

The snapshot file needs to be a list of package names wity versions, in the form `<name>=<evr>`, like `pkg-name=1.2-4.ph5`.

Example to create a snapshot of today, assuming `photon-updates` contains just the latest current versions:

With `tdnf` >= 3.6.0
```
tdnf repoquery --repoid=photon-updates --available --qf "%{name}=%{evr}" > snapshot-20250425.list
```
or
```
tdnf list --repoid photon-updates --available -j | jq -r '.[] | [.Name, .Evr] | join("=")' > snapshot-20250425.list
```
Or create a list of all installed packages, for example to reproduce the current set of installed packages in another host:
```
tdnf repoquery --installed --qf "%{name}=%{evr}" > snapshot.list
```

This can be used later by configuring a repository, assuming the `photon` repo contains all packages of all versions:
```
[photon-20250425]
name = VMware Photon Linux $releasever ($basearch)
baseurl = https://packages.vmware.com/photon/$releasever/photon_$releasever_$basearch
gpgkey = file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096
gpgcheck = 1
enabled = 0
skip_if_unavailable = 1
skip_md_filelists = 1
snapshot = /etc/yum.repos.d/snapshot-20250425.list
```

Note that the snapshot is *per repository*. Packages in other repositories will still be installable, regardless if they are in the list or not. Therefore, to use the repository above, disable all other that may have other versions or use `--repoid=photon-20250425`.
