### PR TITLE
fix unset releasever, and bail if unset

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -402,7 +402,7 @@ TDNFConfigExpandVars(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if(!pConf->pszVarReleaseVer)
+    if(!pConf->pszVarReleaseVer || IsNullOrEmptyString(pTdnf->pArgs->pszReleaseVer))
     {
         int i;
 
@@ -417,6 +417,7 @@ TDNFConfigExpandVars(
             else if (dwError != ERROR_TDNF_NO_DISTROVERPKG)
                 BAIL_ON_TDNF_ERROR(dwError);
         }
+        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     if(!pConf->pszVarBaseArch)

--- a/client/varsdir.c
+++ b/client/varsdir.c
@@ -108,8 +108,10 @@ char *replace_vars(struct cnfnode *cn_vars, const char *source)
         cn_var = find_child(cn_vars, name);
         if (cn_var) {
             q = cnfnode_getval(cn_var);
-            while(*q && (d < dest + sizeof(dest)-1))
-                *d++ = *q++;
+            if (q != NULL) {
+                while(*q && (d < dest + sizeof(dest)-1))
+                    *d++ = *q++;
+            } /* NULL => empty */
         } /* handle not found vars as empty */
     }
     *d = 0;


### PR DESCRIPTION
When `releasever` was unset it would segfault. This can happen when installing into an empty install root. Also fixing the error when no distrover package can be found which was broken with PR #492.