### PR TITLE
add option to override architecture

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -747,7 +747,8 @@ TDNFOpenHandle(
     dwError = SolvInitSack(
                   &pSack,
                   pTdnf->pConf->pszCacheDir,
-                  pTdnf->pArgs->pszInstallRoot);
+                  pTdnf->pArgs->pszInstallRoot,
+                  pTdnf->pArgs->pszArch);
     BAIL_ON_TDNF_ERROR(dwError);
 
     if(!pArgs->nAllDeps)

--- a/client/config.c
+++ b/client/config.c
@@ -433,11 +433,21 @@ TDNFConfigExpandVars(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if(!pConf->pszVarBaseArch)
+    /* pszArch (from --forcearch) overrides variable */
+    if (!IsNullOrEmptyString(pTdnf->pArgs->pszArch)) {
+        TDNF_SAFE_FREE_MEMORY(pConf->pszVarBaseArch);
+        dwError = TDNFAllocateString(pTdnf->pArgs->pszArch,
+                      &pConf->pszVarBaseArch);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* use system arch if unset */
+    if(IsNullOrEmptyString(pConf->pszVarBaseArch))
     {
         dwError = TDNFGetKernelArch(&pConf->pszVarBaseArch);
         BAIL_ON_TDNF_ERROR(dwError);
     }
+
 cleanup:
     return dwError;
 

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -83,6 +83,8 @@ TDNFRpmCreateTS(
 
     //Allow downgrades
     pTS->nProbFilterFlags = RPMPROB_FILTER_OLDPACKAGE;
+    if (pTdnf->pArgs->pszArch)
+        pTS->nProbFilterFlags |= RPMPROB_FILTER_IGNOREARCH;
     if(pSolvedInfo->pPkgsToReinstall)
     {
         pTS->nProbFilterFlags = pTS->nProbFilterFlags | RPMPROB_FILTER_REPLACEPKG;

--- a/common/utils.c
+++ b/common/utils.c
@@ -411,6 +411,7 @@ TDNFFreeCmdArgs(
         TDNF_SAFE_FREE_MEMORY(pCmdArgs->ppszCmds[nIndex]);
     }
 
+    TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszArch);
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->ppszCmds);
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszDownloadDir);
     TDNF_SAFE_FREE_MEMORY(pCmdArgs->pszInstallRoot);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -235,6 +235,7 @@ typedef struct _TDNF_CMD_ARGS
     int nSkipBroken;
     int nSource;
     int nBuildDeps;
+    char* pszArch;         //architecture if overridden
     char* pszDownloadDir;  //directory for download, if nDownloadOnly is set
     char* pszInstallRoot;  //set install root
     char* pszConfFile;     //set conf file location

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -354,7 +354,8 @@ uint32_t
 SolvInitSack(
     PSolvSack *ppSack,
     const char* pszCacheDir,
-    const char* pszRootDir
+    const char* pszRootDir,
+    const char* pszArch
 );
 
 // tdnfquery.c

--- a/solv/tdnfpool.c
+++ b/solv/tdnfpool.c
@@ -105,7 +105,8 @@ uint32_t
 SolvInitSack(
     PSolvSack *ppSack,
     const char* pszCacheDir,
-    const char* pszRootDir
+    const char* pszRootDir,
+    const char *pszArch
     )
 {
     uint32_t dwError = 0;
@@ -140,13 +141,16 @@ SolvInitSack(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    if (uname(&systemInfo))
-    {
-        dwError = ERROR_TDNF_SOLV_IO;
-        BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+    if (pszArch == NULL) {
+        if (uname(&systemInfo)) {
+            dwError = ERROR_TDNF_SOLV_IO;
+            BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
+        }
+        pool_setarch(pPool, systemInfo.machine);
+    } else {
+        pool_setarch(pPool, pszArch);
     }
 
-    pool_setarch(pPool, systemInfo.machine);
     pool_set_flag(pPool, POOL_FLAG_ADDFILEPROVIDESFILTERED, 1);
 
     pRepo = repo_create(pPool, SYSTEM_REPO_NAME);

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -32,6 +32,7 @@ static struct option pstOptions[] =
     {"enableplugin",  required_argument, 0, 0},            //--enableplugin
     {"enablerepo",    required_argument, 0, 0},            //--enablerepo
     {"exclude",       required_argument, 0, 0},            //--exclude
+    {"forcearch",     required_argument, 0, 0},
     {"help",          no_argument, 0, 'h'},                //-h --help
     {"installroot",   required_argument, 0, 'i'},          //--installroot
     {"json",          no_argument, &_opt.nJsonOutput, 1},
@@ -389,6 +390,10 @@ ParseOption(
     else if (!strcasecmp(pszName, "installroot"))
     {
         dwError = TDNFAllocateString(optarg, &pCmdArgs->pszInstallRoot);
+    }
+    else if (!strcasecmp(pszName, "forcearch") && !pCmdArgs->pszArch)
+    {
+        dwError = TDNFAllocateString(optarg, &pCmdArgs->pszArch);
     }
     else if (!strcasecmp(pszName, "downloaddir"))
     {


### PR DESCRIPTION
Implement the `--forcearch` option to enable installing for a different architecture. For example, to install for `x86_64` when running on an `aarch64` system, do:
```
tdnf --installroot=$(pwd)/installroot --releasever=5.0 --forcearch=x86_64 -y install bash
```
