### PR TITLE
do not install unsigned packages if gpgcheck is enabled

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -301,6 +301,19 @@ TDNFReadConfig(
     dwError = TDNFConfigFromCnfTree(pConf, cn_conf->first_child);
     BAIL_ON_TDNF_ERROR(dwError);
 
+    /* override from cmd line */
+    if (pTdnf->pArgs->nNoGPGCheck) {
+        pConf->nGPGCheck = 0;
+    }
+
+    /* these two have no config setting (future?) */
+    if (pTdnf->pArgs->nSkipDigest) {
+        pConf->nSkipDigest = 1;
+    }
+    if (pTdnf->pArgs->nSkipSignature) {
+        pConf->nSkipSignature = 1;
+    }
+
     pszTdnfVersion = TDNFGetVersion();
 
     if (pConf->pszOSName == NULL)

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -210,7 +210,6 @@ TDNFGPGCheckPackage(
 {
     uint32_t dwError = 0;
     Header rpmHeader = NULL;
-    int nGPGSigCheck = 0;
     FD_t fp = NULL;
     char** ppszUrlGPGKeys = NULL;
     char* pszLocalGPGKey = NULL;
@@ -218,9 +217,34 @@ TDNFGPGCheckPackage(
     int nRemote = 0;
     int i;
     int nMatched = 0;
+    char *pszTmp = NULL;
+    int nSavedVfyLevel = 0;
+    rpmVSFlags savedVSFlags = 0;
 
-    dwError = TDNFGetGPGSignatureCheck(pTdnf, pRepo, &nGPGSigCheck, NULL);
-    BAIL_ON_TDNF_ERROR(dwError);
+    if(pTS == NULL || pTdnf == NULL || pRepo == NULL || IsNullOrEmptyString(pszFilePath))
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    nSavedVfyLevel = rpmtsVfyLevel(pTS->pTS);
+    savedVSFlags = rpmtsVSFlags(pTS->pTS);
+
+    if (pRepo->nGPGCheck)
+    {
+        int level = RPMSIG_VERIFIABLE_TYPE;
+        if (pTdnf->pConf->nSkipSignature) {
+            level &= ~RPMSIG_SIGNATURE_TYPE;
+            rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NOSIGNATURES);
+        }
+        if (pTdnf->pConf->nSkipDigest) {
+            level &= ~RPMSIG_DIGEST_TYPE;
+            rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NODIGESTS);
+        }
+        rpmtsSetVfyLevel(pTS->pTS, level);
+    } else {
+        rpmtsSetVfyLevel(pTS->pTS, RPMSIG_NONE_TYPE);
+    }
 
     fp = Fopen (pszFilePath, "r.ufdio");
     if(!fp)
@@ -234,17 +258,28 @@ TDNFGPGCheckPackage(
                   fp,
                   pszFilePath,
                   &rpmHeader);
-
     Fclose(fp);
     fp = NULL;
+
+    if (pRepo->nGPGCheck && !pTdnf->pConf->nSkipSignature) {
+        /* refuse to install an unsigned package if gpgcheck is enabled */
+        if (((pszTmp = headerGetAsString(rpmHeader, RPMTAG_SIGPGP)) == NULL) &&
+            ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_SIGGPG)) == NULL) &&
+            ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_DSAHEADER)) == NULL) &&
+            ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_RSAHEADER)) == NULL))
+        {
+            dwError = ERROR_TDNF_RPM_CHECK;
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
 
     if (dwError != RPMRC_NOTTRUSTED && dwError != RPMRC_NOKEY)
     {
         BAIL_ON_TDNF_RPM_ERROR(dwError);
     }
-    else if(nGPGSigCheck)
+    else if(pRepo->nGPGCheck && !pTdnf->pConf->nSkipSignature)
     {
-        dwError = TDNFGetGPGSignatureCheck(pTdnf, pRepo, &nGPGSigCheck, &ppszUrlGPGKeys);
+        dwError = TDNFGetGPGKeys(pTdnf, pRepo, &ppszUrlGPGKeys);
         BAIL_ON_TDNF_ERROR(dwError);
 
         for (i = 0; ppszUrlGPGKeys[i]; i++) {
@@ -342,8 +377,11 @@ TDNFGPGCheckPackage(
     }
 
 cleanup:
+    rpmtsSetVSFlags(pTS->pTS, savedVSFlags);
+    rpmtsSetVfyLevel(pTS->pTS, nSavedVfyLevel);
     TDNF_SAFE_FREE_STRINGARRAY(ppszUrlGPGKeys);
     TDNF_SAFE_FREE_MEMORY(pszLocalGPGKey);
+    TDNF_SAFE_FREE_MEMORY(pszTmp);
     if(fp)
     {
         Fclose(fp);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -595,30 +595,10 @@ TDNFInitCmdLineRepo(
     );
 
 uint32_t
-TDNFGetGPGCheck(
-    PTDNF pTdnf,
-    const char* pszRepo,
-    int* pnGPGCheck
-    );
-
-uint32_t
-TDNFGetGPGSignatureCheck(
+TDNFGetGPGKeys(
     PTDNF pTdnf,
     PTDNF_REPO_DATA pRepo,
-    int* pnGPGSigCheck,
-    char*** ppszUrlGPGKeys
-    );
-
-uint32_t
-TDNFGetSkipSignatureOption(
-    PTDNF pTdnf,
-    uint32_t *pdwSkipSignature
-    );
-
-uint32_t
-TDNFGetSkipDigestOption(
-    PTDNF pTdnf,
-    uint32_t *pdwSkipDigest
+    char*** pppszUrlGPGKeys
     );
 
 uint32_t

--- a/client/repo.c
+++ b/client/repo.c
@@ -216,166 +216,34 @@ error:
 }
 
 uint32_t
-TDNFGetGPGCheck(
-    PTDNF pTdnf,
-    const char* pszRepo,
-    int* pnGPGCheck
-    )
-{
-    uint32_t dwError = 0;
-    PTDNF_REPO_DATA pRepo = NULL;
-    int nGPGCheck = 0;
-
-    if(!pTdnf || IsNullOrEmptyString(pszRepo) || !pnGPGCheck)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-    if(!pTdnf->pArgs->nNoGPGCheck)
-    {
-        dwError = TDNFGetRepoById(pTdnf, pszRepo, &pRepo);
-        if(dwError == ERROR_TDNF_NO_DATA)
-        {
-            dwError = 0;
-        }
-        BAIL_ON_TDNF_ERROR(dwError);
-        if(pRepo)
-        {
-            nGPGCheck = pRepo->nGPGCheck;
-        }
-    }
-
-    *pnGPGCheck = nGPGCheck;
-
-cleanup:
-    return dwError;
-
-error:
-    goto cleanup;
-}
-
-uint32_t
-TDNFGetSkipSignatureOption(
-    PTDNF pTdnf,
-    uint32_t *pdwSkipSignature
-    )
-{
-    uint32_t dwError = 0;
-    PTDNF_CMD_OPT pSetOpt = NULL;
-    uint32_t dwSkipSignature = 0;
-
-    if(!pTdnf || !pTdnf->pArgs)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    pSetOpt = pTdnf->pArgs->pSetOpt;
-
-    while(pSetOpt)
-    {
-        if(!strcasecmp(pSetOpt->pszOptName, "skipsignature"))
-        {
-            dwSkipSignature = 1;
-            break;
-        }
-        pSetOpt = pSetOpt->pNext;
-    }
-    *pdwSkipSignature = dwSkipSignature;
-cleanup:
-    return dwError;
-
-error:
-    if(pdwSkipSignature)
-    {
-       *pdwSkipSignature = 0;
-    }
-    goto cleanup;
-}
-
-uint32_t
-TDNFGetSkipDigestOption(
-    PTDNF pTdnf,
-    uint32_t *pdwSkipDigest
-    )
-{
-    uint32_t dwError = 0;
-    PTDNF_CMD_OPT pSetOpt = NULL;
-    uint32_t dwSkipDigest = 0;
-
-    if(!pTdnf || !pTdnf->pArgs)
-    {
-        dwError = ERROR_TDNF_INVALID_PARAMETER;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    pSetOpt = pTdnf->pArgs->pSetOpt;
-
-    while(pSetOpt)
-    {
-        if(!strcasecmp(pSetOpt->pszOptName, "skipdigest"))
-        {
-            dwSkipDigest = 1;
-            break;
-        }
-        pSetOpt = pSetOpt->pNext;
-    }
-    *pdwSkipDigest = dwSkipDigest;
-cleanup:
-    return dwError;
-
-error:
-    if(pdwSkipDigest)
-    {
-       *pdwSkipDigest = 0;
-    }
-    goto cleanup;
-}
-
-uint32_t
-TDNFGetGPGSignatureCheck(
+TDNFGetGPGKeys(
     PTDNF pTdnf,
     PTDNF_REPO_DATA pRepo,
-    int* pnGPGSigCheck,
     char*** pppszUrlGPGKeys
     )
 {
     uint32_t dwError = 0;
-    int nGPGSigCheck = 0;
-    uint32_t dwSkipSignature = 0;
     char** ppszUrlGPGKeys = NULL;
 
-    if(!pTdnf || !pRepo || !pnGPGSigCheck)
+    if(!pTdnf || !pRepo)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = TDNFGetSkipSignatureOption(pTdnf, &dwSkipSignature);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    if(!(pTdnf->pArgs->nNoGPGCheck || dwSkipSignature))
+    if (pppszUrlGPGKeys != NULL)
     {
-        if(pRepo->nGPGCheck)
+        if (pRepo->ppszUrlGPGKeys == NULL ||
+            IsNullOrEmptyString(pRepo->ppszUrlGPGKeys[0]))
         {
-            nGPGSigCheck = 1;
-            if (pppszUrlGPGKeys != NULL)
-            {
-                if (pRepo->ppszUrlGPGKeys == NULL ||
-                    IsNullOrEmptyString(pRepo->ppszUrlGPGKeys[0]))
-                {
-                    dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
-                    BAIL_ON_TDNF_ERROR(dwError);
-                }
-                dwError = TDNFAllocateStringArray(
-                    pRepo->ppszUrlGPGKeys,
-                    &ppszUrlGPGKeys);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
+            dwError = ERROR_TDNF_NO_GPGKEY_CONF_ENTRY;
+            BAIL_ON_TDNF_ERROR(dwError);
         }
+        dwError = TDNFAllocateStringArray(
+            pRepo->ppszUrlGPGKeys,
+            &ppszUrlGPGKeys);
+        BAIL_ON_TDNF_ERROR(dwError);
     }
-
-    *pnGPGSigCheck = nGPGSigCheck;
     if (pppszUrlGPGKeys)
     {
         *pppszUrlGPGKeys = ppszUrlGPGKeys;

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -364,7 +364,7 @@ TDNFCreateRepo(
     uint32_t dwError = 0;
     PTDNF_REPO_DATA pRepo = NULL;
 
-    if(!ppRepo || !pszId)
+    if(!pTdnf || !pTdnf->pArgs || !ppRepo || !pszId)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -382,7 +382,7 @@ TDNFCreateRepo(
     pRepo->nEnabled = TDNF_REPO_DEFAULT_ENABLED;
     pRepo->nHasMetaData = 1;
     pRepo->nSkipIfUnavailable = TDNF_REPO_DEFAULT_SKIP;
-    pRepo->nGPGCheck = TDNF_REPO_DEFAULT_GPGCHECK;
+    pRepo->nGPGCheck = pTdnf->pConf->nGPGCheck;
     pRepo->nSSLVerify = pTdnf->pConf->nSSLVerify;
     pRepo->lMetadataExpire = TDNF_REPO_DEFAULT_METADATA_EXPIRE;
     pRepo->nPriority = TDNF_REPO_DEFAULT_PRIORITY;
@@ -640,6 +640,11 @@ TDNFLoadReposFromFile(
         /* default to repo id if name isn't set */
         if (pRepo->pszName == NULL)
             pRepo->pszName = strdup(pRepo->pszId);
+
+        /* override from cmd line */
+        if (pTdnf->pArgs->nNoGPGCheck) {
+            pRepo->nGPGCheck = 0;
+        }
 
         pRepo->pNext = pRepos;
         pRepos = pRepo;

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -659,9 +659,6 @@ TDNFRunTransaction(
     )
 {
     uint32_t dwError = 0;
-    int rpmVfyLevelMask = 0;
-    uint32_t dwSkipSignature = 0;
-    uint32_t dwSkipDigest = 0;
     int rc;
     FD_t fdScript = NULL;
 
@@ -678,12 +675,8 @@ TDNFRunTransaction(
     BAIL_ON_TDNF_ERROR(dwError);
 
     rpmtsClean(pTS->pTS);
-
-    dwError = TDNFGetSkipSignatureOption(pTdnf, &dwSkipSignature);
-    BAIL_ON_TDNF_ERROR(dwError);
-
-    dwError = TDNFGetSkipDigestOption(pTdnf, &dwSkipDigest);
-    BAIL_ON_TDNF_ERROR(dwError);
+    /* we checked already for the signature during TDNFTransAddInstallPkgs() */
+    rpmtsSetVfyLevel(pTS->pTS, rpmtsVfyLevel(pTS->pTS) & ~RPMSIG_VERIFIABLE_TYPE);
 
     /* When json output is enabled redirect stdout from scripts to stderr
        to not mess with the json syntax ("json decode failed at ...") */
@@ -700,26 +693,6 @@ TDNFRunTransaction(
     //TODO do callbacks for output
     pr_info("Testing transaction\n");
 
-    if (pTdnf->pArgs->nNoGPGCheck)
-    {
-        rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NODIGESTS | RPMVSF_MASK_NOSIGNATURES);
-        rpmtsSetVfyLevel(pTS->pTS, ~RPMSIG_VERIFIABLE_TYPE);
-    }
-
-    else if (dwSkipSignature || dwSkipDigest)
-    {
-         if (dwSkipSignature)
-         {
-             rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NOSIGNATURES);
-             rpmVfyLevelMask |= RPMSIG_SIGNATURE_TYPE;
-         }
-         if (dwSkipDigest)
-         {
-             rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NODIGESTS);
-             rpmVfyLevelMask |= RPMSIG_DIGEST_TYPE;
-         }
-         rpmtsSetVfyLevel(pTS->pTS, ~rpmVfyLevelMask);
-    }
     rpmtsSetFlags(pTS->pTS, RPMTRANS_FLAG_TEST);
     rc = rpmtsRun(pTS->pTS, NULL, pTS->nProbFilterFlags);
     if (rc != 0)
@@ -818,7 +791,6 @@ TDNFTransAddInstallPkg(
     )
 {
     uint32_t dwError = 0;
-    int nGPGCheck = 0;
     char* pszFilePath = NULL;
     Header rpmHeader = NULL;
     PTDNF_CACHED_RPM_ENTRY pRpmCache = NULL;
@@ -930,9 +902,7 @@ TDNFTransAddInstallPkg(
     dwError = TDNFGPGCheckPackage(pTS, pTdnf, pRepo, pszFilePath, &rpmHeader);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    dwError = TDNFGetGPGCheck(pTdnf, pRepo->pszId, &nGPGCheck);
-    BAIL_ON_TDNF_ERROR(dwError);
-    if (!nGPGCheck)
+    if (!pRepo->nGPGCheck)
     {
         rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NODIGESTS | RPMVSF_MASK_NOSIGNATURES);
         rpmtsSetVfyLevel(pTS->pTS, ~RPMSIG_VERIFIABLE_TYPE);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -220,6 +220,8 @@ typedef struct _TDNF_CMD_ARGS
     int nShowVersion;      //show version and exit
     int nNoDeps;           //download no dependencies
     int nNoGPGCheck;       //skip gpg check
+    int nSkipSignature;
+    int nSkipDigest;
     int nNoOutput;         //if quiet and assumeyes are provided
     int nQuiet;            //quiet option
     int nVerbose;          //print debug info
@@ -258,6 +260,8 @@ typedef struct _TDNF_CONF
     int nCheckUpdateCompat;
     int nDistroSyncReinstallChanged;
     int nPluginsEnabled;
+    int nSkipDigest;
+    int nSkipSignature;
     char* pszRepoDir;
     char* pszCacheDir;
     char* pszPersistDir;

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -46,6 +46,7 @@ BUILD_PATH=${TEST_REPO_DIR}/build
 PUBLISH_PATH=${TEST_REPO_DIR}/photon-test
 PUBLISH_SRC_PATH=${TEST_REPO_DIR}/photon-test-src
 PUBLISH_SHA512_PATH=${TEST_REPO_DIR}/photon-test-sha512
+PUBLISH_UNSIGNED_PATH=${TEST_REPO_DIR}/photon-test-unsigned
 
 ARCH=$(uname -m)
 
@@ -58,6 +59,7 @@ mkdir -p -m 755 ${BUILD_PATH}/BUILD \
     ${PUBLISH_PATH} \
     ${PUBLISH_SRC_PATH} \
     ${PUBLISH_SHA512_PATH} \
+    ${PUBLISH_UNSIGNED_PATH} \
     ${GNUPGHOME}
 
 #gpgkey data for unattended key generation
@@ -95,6 +97,7 @@ for spec in ${REPO_SRC_DIR}/*.spec ${BUILD_PATH}/SOURCES/*.spec ; do
     rpmbuild -D "_topdir ${BUILD_PATH}" -ba ${spec} 2>&1
     check_err "ERROR: failed to build ${spec}"
 done
+cp -r ${BUILD_PATH}/RPMS ${PUBLISH_UNSIGNED_PATH}
 rpmsign --addsign ${BUILD_PATH}/RPMS/*/*.rpm
 check_err "Failed to sign built packages."
 cp -r ${BUILD_PATH}/RPMS ${PUBLISH_PATH}
@@ -108,6 +111,7 @@ gpg --armor --export tdnftest@tdnf.test > ${PUBLISH_PATH}/keys/pubkey.asc
 createrepo ${PUBLISH_PATH}
 createrepo ${PUBLISH_SRC_PATH}
 createrepo -s sha512 ${PUBLISH_SHA512_PATH}
+createrepo ${PUBLISH_UNSIGNED_PATH}
 
 modifyrepo ${REPO_SRC_DIR}/updateinfo-1.xml ${PUBLISH_PATH}/repodata
 check_err "Failed to modify repo with updateinfo-1.xml."
@@ -139,6 +143,14 @@ gpgcheck=0
 enabled=0
 username=cassian
 password=andor
+EOF
+
+cat << EOF > ${TEST_REPO_DIR}/yum.repos.d/photon-test-unsigned.repo
+[photon-test-unsigned]
+name=basic
+baseurl=http://localhost:8080/photon-test-unsigned
+gpgcheck=0
+enabled=0
 EOF
 
 cat << EOF > ${TEST_REPO_DIR}/yum.repos.d/photon-test-sha512.repo

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -26,17 +26,69 @@ def setup_test_function(utils):
 
 def teardown_test(utils):
     set_gpgcheck(utils, False)
+    set_gpgcheck(utils, False, None)
     utils.run(['rpm', '-e', '--allmatches', 'gpg-pubkey'])
     pkgname = utils.config["sglversion_pkgname"]
     utils.run(['tdnf', 'erase', '-y', pkgname])
 
 
-def set_gpgcheck(utils, enabled):
-    utils.edit_config({'gpgcheck': '1' if enabled else '0'}, repo='photon-test')
+def set_gpgcheck(utils, enabled, repo='photon-test'):
+    if enabled is not None:
+        utils.edit_config({'gpgcheck': '1' if enabled else '0'}, repo)
+    else:
+        utils.edit_config({'gpgcheck': None}, repo)
 
 
 def set_repo_key(utils, url):
     utils.edit_config({'gpgkey': url}, repo='photon-test')
+
+
+# install unsigned package with gpgcheck enabled in repo,
+# expect failure
+def test_install_unsigned(utils):
+    set_gpgcheck(utils, None, repo=None)
+    set_gpgcheck(utils, True, repo='photon-test-unsigned')
+    set_repo_key(utils, DEFAULT_KEY)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', '--repoid', 'photon-test-unsigned', 'install', '-y', pkgname])
+    assert ret['retval'] == 1515
+    assert not utils.check_package(pkgname)
+
+
+# install unsigned package with gpgcheck enabled in global config,
+# expect failure
+def test_install_unsigned_global_gpgcheck(utils):
+    set_gpgcheck(utils, True, repo=None)
+    set_gpgcheck(utils, None, repo='photon-test-unsigned')
+    set_repo_key(utils, DEFAULT_KEY)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', '--repoid', 'photon-test-unsigned', 'install', '-y', pkgname])
+    assert ret['retval'] == 1515
+    assert not utils.check_package(pkgname)
+
+
+# install unsigned package with gpgcheck enabled in repo,
+# but disabled on command line,
+# expect success
+def test_install_unsigned_nogpgcheck(utils):
+    set_gpgcheck(utils, True, repo='photon-test-unsigned')
+    set_repo_key(utils, DEFAULT_KEY)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', '--nogpgcheck', '--repoid', 'photon-test-unsigned', 'install', '-y', pkgname])
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+
+
+# install unsigned package with gpgcheck enabled in repo,
+# but skipsignature on command line,
+# expect success
+def test_install_unsigned_skipsignature(utils):
+    set_gpgcheck(utils, True, repo='photon-test-unsigned')
+    set_repo_key(utils, DEFAULT_KEY)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', '--skipsignature', '--repoid', 'photon-test-unsigned', 'install', '-y', pkgname])
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
 
 
 # 'wrong' key in repo config, but skip signature, expect success
@@ -45,6 +97,17 @@ def test_install_skipsignature(utils):
     set_repo_key(utils, DEFAULT_KEY)
     pkgname = utils.config["sglversion_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', '--skipsignature', pkgname])
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+
+
+def test_install_skipdigest(utils):
+    set_gpgcheck(utils, True)
+    keypath = os.path.join(utils.config['repo_path'], 'photon-test', 'keys', 'pubkey.asc')
+    utils.run(['rpm', '--import', keypath])
+    set_repo_key(utils, DEFAULT_KEY)
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'install', '-y', '--skipdigest', pkgname])
     assert ret['retval'] == 0
     assert utils.check_package(pkgname)
 

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -54,9 +54,9 @@ static struct option pstOptions[] =
     {"setopt",        required_argument, 0, 0},            //--set or override options
     {"skip-broken",   no_argument, &_opt.nSkipBroken, 1},
     {"skipconflicts", no_argument, 0, 0},                  //--skipconflicts to skip conflict problems
-    {"skipdigest",    no_argument, 0, 0},                  //--skipdigest to skip verifying RPM digest
+    {"skipdigest",    no_argument, &_opt.nSkipDigest, 1},  //--skipdigest to skip verifying RPM digest
     {"skipobsoletes", no_argument, 0, 0},                  //--skipobsoletes to skip obsolete problems
-    {"skipsignature", no_argument, 0, 0},                  //--skipsignature to skip verifying RPM signatures
+    {"skipsignature", no_argument, &_opt.nSkipSignature, 1}, //--skipsignature to skip verifying RPM signatures
     {"source",        no_argument, &_opt.nSource, 1},
     {"testonly",      no_argument, &_opt.nTestOnly, 1},
     {"verbose",       no_argument, &_opt.nVerbose, 1},     //-v --verbose
@@ -332,6 +332,8 @@ TDNFCopyOptions(
     pArgs->nDebugSolver   = pOptionArgs->nDebugSolver;
     pArgs->nNoDeps        = pOptionArgs->nNoDeps;
     pArgs->nNoGPGCheck    = pOptionArgs->nNoGPGCheck;
+    pArgs->nSkipSignature = pOptionArgs->nSkipSignature;
+    pArgs->nSkipDigest    = pOptionArgs->nSkipDigest;
     pArgs->nNoOutput      = pOptionArgs->nQuiet && pOptionArgs->nAssumeYes;
     pArgs->nQuiet         = pOptionArgs->nQuiet;
     pArgs->nRefresh       = pOptionArgs->nRefresh;


### PR DESCRIPTION
This started with addressing the issue in https://github.com/vmware/tdnf/pull/522 (unsigned packages were installed even when `gpgcheck` is enabled), and developed into a major overhaul of the signature checking code.

Changes made:
* make sure `gpgcheck` can be consistently enabled globally in `tdnf.conf` which sets the default, and on a per repo basis. Repo config inherits from the global config if unset in the repo config.
* make the `--nogpgcheck` disable the check globally
* refactor setting the rpm verify flags and level
* move signature check to the `TDNFGPGCheckPackage()` function used by `TDNFTransAddInstallPkg()` and away from `TDNFRunTransaction()` to ensure settings on per repo basis are used.
* move internally the `--skipdigest` and `--skipsignature` options to settings in the global config, to make code simpler
* add more tests


