### PR TITLE
use vars for username and password, with test

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -758,6 +758,16 @@ TDNFRepoListFinalize(
                 BAIL_ON_TDNF_ERROR(dwError);
             }
         }
+        if(pRepo->pszUser)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszUser);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+        if(pRepo->pszPass)
+        {
+            dwError = TDNFConfigReplaceVars(pTdnf, &pRepo->pszPass);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
 
         if (pRepo->pszMetaLink)
         {

--- a/pytests/tests/test_auth.py
+++ b/pytests/tests/test_auth.py
@@ -61,8 +61,32 @@ def setup_test_function(utils):
     utils.erase_package(pkgname)
 
 
-def test_install_package(utils):
+def test_install_package_authed(utils):
     pkgname = utils.config["sglversion_pkgname"]
+
+    utils.edit_config({'password': PASSWORD}, repo='photon-test-auth')
+    utils.edit_config({'username': USERNAME}, repo='photon-test-auth')
+
+    ret = utils.run(['tdnf', 'install', '--repoid=photon-test-auth', '-y', '--nogpgcheck', pkgname])
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+
+
+def test_install_package_authed_vars(utils):
+    pkgname = utils.config["sglversion_pkgname"]
+
+    vars_path = os.path.join(utils.config['repo_path'], "vars")
+    os.makedirs(vars_path, exist_ok=True)
+
+    with open(os.path.join(vars_path, "user"), "wt") as f:
+        f.write(USERNAME)
+    with open(os.path.join(vars_path, "pass"), "wt") as f:
+        f.write(PASSWORD)
+
+    utils.edit_config({'varsdir': vars_path})
+
+    utils.edit_config({'password': "$pass"}, repo='photon-test-auth')
+    utils.edit_config({'username': "$user"}, repo='photon-test-auth')
 
     ret = utils.run(['tdnf', 'install', '--repoid=photon-test-auth', '-y', '--nogpgcheck', pkgname])
     assert ret['retval'] == 0


### PR DESCRIPTION
Expand variables in the `username` and `password` settings for repo configurations. This makes it possible to set the credentrials using the `vars` mechanism, that is by setting them with:

`echo secret < /etc/tdnf/vars/extra_password`

and using them in a repo file with:

```
[extra]
baseurl = http://...
password = $extra_password
```

This serves two purposes:
* the password can be set once and used in multiple repositories
* the file that stores the password can be made readable by root only
