### PR TITLE
glob packages uninstall fix when all repos disabled.

### DIFF
--- a/pytests/tests/test_downgrade.py
+++ b/pytests/tests/test_downgrade.py
@@ -21,8 +21,10 @@ def teardown_test(utils):
 
 
 def test_downgrade_no_arg(utils):
-    ret = utils.run(['tdnf', 'downgrade'])
-    assert ret['retval'] == 1011
+    cmd = "tdnf downgrade -y --disablerepo=* --enablerepo=photon-test".split()
+    ret = utils.run(cmd)
+    assert ret['retval'] == 0
+    assert "Downgrading: tdnf-test-multiversion" in " ".join(ret["stdout"])
 
 
 def test_downgrade_install(utils):

--- a/pytests/tests/test_glob.py
+++ b/pytests/tests/test_glob.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pass
+
+
+def test_glob_install(utils):
+    cmd = "tdnf remove -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -qa 'tdnf*multi*'".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "tdnf install -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+
+def test_glob_uninstall(utils):
+    cmd = "tdnf remove -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+
+def test_glob_uninstall_with_all_repos_disabled(utils):
+    cmd = "tdnf install -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "tdnf remove -y tdnf*multi* --disablerepo=*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"]

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -249,7 +249,7 @@ SolvApplySinglePackageFilter(
 {
     uint32_t dwError = 0;
     char** ppCopyOfpkgNames = NULL;
-    if(!pQuery || !pszPackageName || IsNullOrEmptyString(pszPackageName))
+    if(!pQuery || IsNullOrEmptyString(pszPackageName))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -399,13 +399,10 @@ SolvAddAvailableRepoFilter(
     pool = pQuery->pSack->pPool;
     FOR_REPOS(i, pRepo)
     {
-        if (strcasecmp(SYSTEM_REPO_NAME, pRepo->name))
-        {
-            queue_push2(
-                &pQuery->queueRepoFilter,
-                SOLVER_SOLVABLE_REPO | SOLVER_SETREPO | SOLVER_SETVENDOR,
-                pRepo->repoid);
-        }
+        queue_push2(
+            &pQuery->queueRepoFilter,
+            SOLVER_SOLVABLE_REPO | SOLVER_SETREPO | SOLVER_SETVENDOR,
+            pRepo->repoid);
     }
 
 cleanup:


### PR DESCRIPTION
    Do not exclude @System repo while applying repo filter

    Excluding @System repo will break package removals with globs with all
    repos disabled.

    Steps to reproduce:
    ```
    tdnf install -y openjdk11
    tdnf remove -y openjdk\* --disablerepo=*
    ```
    The second command errors out.