### PR TITLE
Improve error message while failing an operation

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -255,6 +255,10 @@ TDNFCreateRepoFromDirectory(
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = TDNFIsDir(pszPath, &nIsDir);
+    if (dwError) {
+        pr_err("CreateRepoFromDir: Error while operating on '%s', '%s'\n",
+                pszPath, strerror(errno));
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     if (!nIsDir)
@@ -321,6 +325,10 @@ TDNFCreateRepoFromPath(
     if (pszPath[0] == '/')
     {
         dwError = TDNFIsDir(pszPath, &nIsDir);
+        if (dwError) {
+            pr_err("CreateRepoFromPath: Error while operating on '%s', '%s'\n",
+                    pszPath, strerror(errno));
+        }
         BAIL_ON_TDNF_ERROR(dwError);
 
         if (nIsDir)

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -414,14 +414,19 @@ TDNFPrepareSinglePkg(
     }
 
 cleanup:
-    if(pInstalledPkgList)
+    if (dwError)
+    {
+        pr_err("Error while processing package: '%s'\n", pszPkgName);
+    }
+
+    if (pInstalledPkgList)
     {
         SolvFreePackageList(pInstalledPkgList);
     }
     return dwError;
 
 error:
-    if(dwError == ERROR_TDNF_ALREADY_INSTALLED)
+    if (dwError == ERROR_TDNF_ALREADY_INSTALLED)
     {
         int nShowAlreadyInstalled = 1;
         //dont show already installed errors in the check path
@@ -438,28 +443,32 @@ error:
             pr_err("Package %s is already installed.\n", pszPkgName);
         }
     }
-    if(dwError == ERROR_TDNF_NO_UPGRADE_PATH)
+    else if (dwError == ERROR_TDNF_NO_UPGRADE_PATH)
     {
         dwError = 0;
         pr_err("There is no upgrade path for %s.\n", pszPkgName);
     }
-    if(dwError == ERROR_TDNF_NO_DOWNGRADE_PATH)
+    else if (dwError == ERROR_TDNF_NO_DOWNGRADE_PATH)
     {
         dwError = 0;
         pr_err("There is no downgrade path for %s.\n", pszPkgName);
     }
-    if(dwError == ERROR_TDNF_NO_SEARCH_RESULTS)
+    else if (dwError == ERROR_TDNF_NO_SEARCH_RESULTS)
     {
-        dwError = 0;
-        if(TDNFAddNotResolved(ppszPkgsNotResolved, pszPkgName))
+        dwError = TDNFAddNotResolved(ppszPkgsNotResolved, pszPkgName);
+        if (dwError)
         {
-            pr_err("Error while adding not resolved packages\n");
+            pr_err("Error while adding not resolved packages: '%s'\n", pszPkgName);
         }
     }
-    if(dwError == ERROR_TDNF_ERASE_NEEDS_INSTALL)
+    else if (dwError == ERROR_TDNF_ERASE_NEEDS_INSTALL)
     {
         dwError = 0;
-//TODO: maybe restore solvedinfo based processing here.
+        //TODO: maybe restore solvedinfo based processing here.
+    }
+    else if (dwError == ERROR_TDNF_NO_MATCH)
+    {
+        pr_err("Package '%s' not found\n", pszPkgName);
     }
     goto cleanup;
 }

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -300,6 +300,10 @@ readRpmsFromDir(
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFIsDir(pszPath, &isDir);
+        if (dwError) {
+            pr_err("ReadRpms: Error while operating on '%s', '%s'\n",
+                    pszPath, strerror(errno));
+        }
         BAIL_ON_TDNF_ERROR(dwError);
 
         if (isDir) {


### PR DESCRIPTION
Currently if a third party rpm is installed in Photon and if we do: `tdnf downgrade` it fails and error we see is:
'Error(1011) : No matching packages'
And we will not know which package caused the failure.