### PR TITLE
fix globbing to match installed packages for erase/upgrade/downgrade/reinstall ops

### DIFF
--- a/client/packageutils.c
+++ b/client/packageutils.c
@@ -643,6 +643,7 @@ uint32_t
 TDNFGetGlobPackages(
     PSolvSack pSack,
     char* pszPkgGlob,
+    int nIsInstalled,
     Queue* pQueueGoal
     )
 {
@@ -655,10 +656,17 @@ TDNFGetGlobPackages(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    dwError = SolvFindAvailablePkgByName(
-                  pSack,
-                  pszPkgGlob,
-                  &pSolvPkgList);
+    if (nIsInstalled) {
+        dwError = SolvFindInstalledPkgByName(
+                      pSack,
+                      pszPkgGlob,
+                      &pSolvPkgList);
+    } else {
+        dwError = SolvFindAvailablePkgByName(
+                      pSack,
+                      pszPkgGlob,
+                      &pSolvPkgList);
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     if(pSolvPkgList->queuePackages.count > 0)

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -291,6 +291,7 @@ uint32_t
 TDNFGetGlobPackages(
     PSolvSack pSack,
     char* pszPkgGlob,
+    int nIsInstalled,
     Queue* pQueueGlob
     );
 

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -123,10 +123,17 @@ TDNFPrepareAllPackages(
 
            if(TDNFIsGlob(pszPkgName))
            {
+               int nIsInstalled = (nAlterType == ALTER_ERASE ||
+                                   nAlterType == ALTER_AUTOERASE ||
+                                   nAlterType == ALTER_UPGRADE ||
+                                   nAlterType == ALTER_DOWNGRADE ||
+                                   nAlterType == ALTER_REINSTALL);
+
                queue_empty(&queueLocal);
                dwError = TDNFGetGlobPackages(
                              pTdnf->pSack,
                              pszPkgName,
+                             nIsInstalled,
                              &queueLocal);
                BAIL_ON_TDNF_ERROR(dwError);
                if(queueLocal.count == 0)

--- a/pytests/tests/test_glob.py
+++ b/pytests/tests/test_glob.py
@@ -22,13 +22,6 @@ def teardown_test(utils):
 
 
 def test_glob_install(utils):
-    cmd = "tdnf remove -y tdnf*multi*".split()
-    ret = utils.run(cmd)
-    assert ret["retval"] == 0
-    cmd = "rpm -qa 'tdnf*multi*'".split()
-    ret = utils.run(cmd)
-    assert ret["retval"] == 0
-
     cmd = "tdnf install -y tdnf*multi*".split()
     ret = utils.run(cmd)
     assert ret["retval"] == 0
@@ -38,6 +31,10 @@ def test_glob_install(utils):
 
 
 def test_glob_uninstall(utils):
+    mpkg = utils.config['mulversion_pkgname']
+    ret = utils.run(['tdnf', 'install', '-y', mpkg])
+    assert ret['retval'] == 0
+
     cmd = "tdnf remove -y tdnf*multi*".split()
     ret = utils.run(cmd)
     assert ret["retval"] == 0

--- a/pytests/tests/test_glob.py
+++ b/pytests/tests/test_glob.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2019-2022 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import pytest
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pass
+
+
+def test_glob_install(utils):
+    cmd = "tdnf remove -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -qa 'tdnf*multi*'".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "tdnf install -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+
+def test_glob_uninstall(utils):
+    cmd = "tdnf remove -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+
+def test_glob_uninstall_with_all_repos_disabled(utils):
+    cmd = "tdnf install -y tdnf*multi*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+
+    cmd = "tdnf remove -y tdnf*multi* --disablerepo=*".split()
+    ret = utils.run(cmd)
+    assert ret["retval"] == 0
+    cmd = "rpm -q tdnf-multi tdnf-test-multiversion".split()
+    ret = utils.run(cmd)
+    assert ret["retval"]

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -249,7 +249,7 @@ SolvApplySinglePackageFilter(
 {
     uint32_t dwError = 0;
     char** ppCopyOfpkgNames = NULL;
-    if(!pQuery || !pszPackageName || IsNullOrEmptyString(pszPackageName))
+    if(!pQuery || IsNullOrEmptyString(pszPackageName))
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);


### PR DESCRIPTION
This should supersede https://github.com/vmware/tdnf/pull/535 . I cherry-picked two commits from there for proper credits.

When using globs for packages, we should search installed packages for  erase, upgrade, downgrade and reinstall operations, not available packages.