### PR TITLE
Fix tdnf list and tdnf search commands while multiple keys are given at a time

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -550,6 +550,10 @@ TDNFListInternal(
     *pdwCount = dwCount;
 
 cleanup:
+    if (!dwError && pQuery && pQuery->queryError)
+    {
+        dwError = pQuery->queryError;
+    }
     if(pQuery)
     {
         SolvFreeQuery(pQuery);
@@ -558,6 +562,7 @@ cleanup:
     {
         SolvFreePackageList(pPkgList);
     }
+
     return dwError;
 error:
     if(ppPkgInfo)
@@ -869,7 +874,6 @@ TDNFProvides(
 
     dwError = SolvCreateQuery(pTdnf->pSack, &pQuery);
     BAIL_ON_TDNF_ERROR(dwError);
-
     dwError = SolvApplySinglePackageFilter(pQuery, pszSpec);
     BAIL_ON_TDNF_ERROR(dwError);
 
@@ -883,6 +887,7 @@ TDNFProvides(
     BAIL_ON_TDNF_ERROR(dwError);
 
     *ppPkgInfo = pPkgInfo;
+
 cleanup:
     if(pQuery)
     {
@@ -893,16 +898,13 @@ cleanup:
         SolvFreePackageList(pPkgList);
     }
     return dwError;
+
 error:
     if(ppPkgInfo)
     {
       *ppPkgInfo = NULL;
     }
     TDNFFreePackageInfo(pPkgInfo);
-    if(dwError == ERROR_TDNF_NO_MATCH)
-    {
-        dwError = ERROR_TDNF_NO_DATA;
-    }
     goto cleanup;
 }
 
@@ -1817,6 +1819,10 @@ TDNFSearchCommand(
                   pCmdArgs->ppszCmds,
                   nStartArgIndex,
                   pCmdArgs->nCmdCount);
+    if (dwError == ERROR_TDNF_NO_MATCH)
+    {
+        dwError = 0;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = SolvGetQueryResult(pQuery, &pPkgList);
@@ -1858,6 +1864,11 @@ TDNFSearchCommand(
     *punCount = unCount;
 
 cleanup:
+    if (!dwError && pQuery && pQuery->queryError)
+    {
+        dwError = pQuery->queryError;
+    }
+
     if(pQuery)
     {
         SolvFreeQuery(pQuery);
@@ -1867,6 +1878,7 @@ cleanup:
         SolvFreePackageList(pPkgList);
     }
     return dwError;
+
 error:
     if(ppPkgInfo)
     {
@@ -1877,11 +1889,6 @@ error:
         *punCount = 0;
     }
     TDNFFreePackageInfoArray(pPkgInfo, unCount);
-
-    if(dwError == ERROR_TDNF_NO_MATCH)
-    {
-        dwError = ERROR_TDNF_NO_SEARCH_RESULTS;
-    }
 
     goto cleanup;
 }

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -205,6 +205,8 @@ class TestUtils(object):
     def check_package(self, package, version=None):
         ''' Check if a package exists '''
         ret = self.run(["tdnf", "--disablerepo=*", "list", "-j", "--installed", package])
+        if ret['retval']:
+            return False
         pkglist = json.loads('\n'.join(ret['stdout']))
         assert type(pkglist) is list, f"unexpected json type from 'tdnf list': pkglist={pkglist}"
         for p in pkglist:

--- a/pytests/tests/test_install.py
+++ b/pytests/tests/test_install.py
@@ -72,7 +72,7 @@ def test_install_package_verbose(utils):
 def test_dummy_requires(utils):
     pkg = utils.config["dummy_requires_pkgname"]
     ret = utils.run(['tdnf', 'install', '-y', pkg])
-    assert ' nothing provides ' in ret['stderr'][0]
+    assert "nothing provides" in "\n".join(ret['stderr'])
 
 
 def test_install_testonly(utils):

--- a/pytests/tests/test_json.py
+++ b/pytests/tests/test_json.py
@@ -140,8 +140,8 @@ def test_erase_verbose(utils):
 
 def test_check_update(utils):
     ret = utils.run(['tdnf', '-j', 'check-update'])
-    d = json.loads("\n".join(ret['stdout']))
-    assert type(d) is list
+    assert not ret['retval']
+    assert not ret['stdout']
 
 
 def test_repolist(utils):

--- a/pytests/tests/test_list.py
+++ b/pytests/tests/test_list.py
@@ -88,3 +88,18 @@ def test_list_notinstalled(utils):
         # spkg is not installed, expect error
         ret = utils.run(['tdnf', 'list', cmd, spkg])
         assert ret['retval'] == 1011
+
+
+def test_list_invalid_with_valid(utils):
+    spkg = utils.config["sglversion_pkgname"]
+
+    ret = utils.run(f"tdnf list {spkg} invalid1")
+    assert ret['retval'] == 1011
+    assert "No match found for 'invalid1'" in "\n".join(ret['stderr'])
+    assert "tdnf-test-one" in "\n".join(ret['stdout'])
+
+    ret = utils.run(f"tdnf list invalid1 {spkg} invalid2")
+    assert ret['retval'] == 1011
+    assert "No match found for 'invalid1'" in "\n".join(ret['stderr'])
+    assert "No match found for 'invalid2'" in "\n".join(ret['stderr'])
+    assert "tdnf-test-one" in "\n".join(ret['stdout'])

--- a/pytests/tests/test_provides.py
+++ b/pytests/tests/test_provides.py
@@ -31,4 +31,5 @@ def test_provides_valid_pkg_name(utils):
 
 def test_provides_invalid_pkg_name(utils):
     ret = utils.run(['tdnf', 'provides', 'invalid_pkg_name'])
-    assert ret['stderr'][0] == 'No data available'
+    assert "No match found for 'invalid_pkg_name'" in "\n".join(ret['stderr'])
+    assert ret['retval'] == 1011

--- a/pytests/tests/test_search.py
+++ b/pytests/tests/test_search.py
@@ -21,19 +21,38 @@ def teardown_test(utils):
 
 def test_search_no_arg(utils):
     ret = utils.run(['tdnf', 'search'])
-    assert ret['retval'] == 1599
+    assert ret['retval'] == 1011
 
 
 def test_search_invalid_arg(utils):
     ret = utils.run(['tdnf', 'search', 'invalid_arg'])
-    assert ret['retval'] == 1599
+    assert "No search results found for 'invalid_arg'" in "\n".join(ret['stderr'])
+    assert ret['retval'] == 1011
 
 
 def test_search_single(utils):
-    ret = utils.run(['tdnf', 'search', 'tdnf'])
+    pkgname = utils.config["sglversion_pkgname"]
+    ret = utils.run(['tdnf', 'search', pkgname])
     assert ret['retval'] == 0
 
 
 def test_search_multiple(utils):
-    ret = utils.run(['tdnf', 'search', 'tdnf', 'wget', 'gzip'])
+    sglpkgname = utils.config["sglversion_pkgname"]
+    mulpkgname = utils.config["mulversion_pkgname"]
+    ret = utils.run(['tdnf', 'search', sglpkgname, mulpkgname])
     assert ret['retval'] == 0
+
+
+def test_search_valid_with_invalid(utils):
+    sglpkgname = utils.config["sglversion_pkgname"]
+
+    ret = utils.run(f"tdnf search {sglpkgname} invalid1")
+    assert ret['retval'] == 1599
+    assert "No search results found for 'invalid1'" in "\n".join(ret['stderr'])
+    assert "tdnf-test-one : basic install test file" in "\n".join(ret['stdout'])
+
+    ret = utils.run(f"tdnf search {sglpkgname} invalid1 invalid2")
+    assert ret['retval'] == 1599
+    assert "No search results found for 'invalid1'" in "\n".join(ret['stderr'])
+    assert "No search results found for 'invalid2'" in "\n".join(ret['stderr'])
+    assert "tdnf-test-one : basic install test file" in "\n".join(ret['stdout'])

--- a/pytests/tests/test_whatprovides.py
+++ b/pytests/tests/test_whatprovides.py
@@ -27,8 +27,8 @@ def test_whatprovides_no_arg(utils):
 
 def test_whatprovides_invalid_arg(utils):
     ret = utils.run(['tdnf', 'whatprovides', 'invalid_arg'])
-    assert ret['retval'] == 0
-    assert ret['stderr'][0] == 'No data available'
+    assert ret['retval'] == 1011
+    assert "No match found for 'invalid_arg'" in "\n".join(ret['stderr'])
 
 
 def test_whatprovides_valid_file_notinstalled(utils):

--- a/solv/prototypes.h
+++ b/solv/prototypes.h
@@ -34,6 +34,7 @@ typedef struct _SolvQuery
     Queue       queueResult;
     uint32_t    dwNewPackages;
     TDNF_SCOPE  nScope;
+    uint32_t    queryError;
 } SolvQuery, *PSolvQuery;
 
 typedef struct _SolvPackageList
@@ -404,12 +405,6 @@ SolvApplySearch(
     char** ppszSearchStrings,
     int dwStartIndex,
     int dwCount
-    );
-
-uint32_t
-SolvGenerateCommonJob(
-    PSolvQuery pQuery,
-    uint32_t dwSelectFlags
     );
 
 uint32_t

--- a/solv/tdnfquery.c
+++ b/solv/tdnfquery.c
@@ -415,7 +415,7 @@ error:
     goto cleanup;
 }
 
-uint32_t
+static uint32_t
 SolvGenerateCommonJob(
     PSolvQuery pQuery,
     uint32_t dwSelectFlags
@@ -497,6 +497,11 @@ SolvGenerateCommonJob(
                               pQuery->queueJob.count,
                               queueJob.count,
                               queueJob.elements);
+            }
+            else
+            {
+                pr_err("No match found for '%s'\n", *ppszPkgNames);
+                pQuery->queryError = ERROR_TDNF_NO_MATCH;
             }
             ppszPkgNames++;
         }
@@ -611,6 +616,10 @@ SolvApplyListQuery(
     }
 
     dwError = SolvGenerateCommonJob(pQuery, nFlags);
+    if (dwError == ERROR_TDNF_NO_MATCH)
+    {
+        dwError = 0;
+    }
     BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
 
     if(pQuery->nScope == SCOPE_UPGRADES)
@@ -728,6 +737,8 @@ SolvApplySearch(
 
     for(nIndex = dwStartIndex; nIndex < dwEndIndex; nIndex++)
     {
+        int countBeforeInsert = 0;
+
         queue_empty(&queueSel);
         queue_empty(&queueResult);
         dataiterator_init(&di, pPool, 0, 0, 0, ppszSearchStrings[nIndex],
@@ -747,10 +758,16 @@ SolvApplySearch(
         dataiterator_free(&di);
 
         selection_solvables(pPool, &queueSel, &queueResult);
+        countBeforeInsert = pQuery->queueResult.count;
         queue_insertn(&pQuery->queueResult,
                       pQuery->queueResult.count,
                       queueResult.count,
                       queueResult.elements);
+
+        if (pQuery->queueResult.count == countBeforeInsert) {
+            pr_err("No search results found for '%s'\n", ppszSearchStrings[nIndex]);
+            pQuery->queryError = ERROR_TDNF_NO_SEARCH_RESULTS;
+        }
     }
 
 cleanup:
@@ -768,6 +785,7 @@ SolvApplyProvidesQuery(
     )
 {
     uint32_t dwError = 0;
+    uint32_t retVal = 0;
     int nIndex = 0;
     Queue queueTmp = {0};
     uint32_t nFlags = 0;
@@ -783,6 +801,11 @@ SolvApplyProvidesQuery(
     nFlags |= SELECTION_CANON| SELECTION_FILELIST|SELECTION_REL;
 
     dwError = SolvGenerateCommonJob(pQuery, nFlags);
+    if (dwError == ERROR_TDNF_NO_MATCH)
+    {
+        retVal = dwError;
+        dwError = 0;
+    }
     BAIL_ON_TDNF_LIBSOLV_ERROR(dwError);
 
     if(pQuery->queueJob.count > 0)
@@ -810,6 +833,10 @@ SolvApplyProvidesQuery(
 
 cleanup:
     queue_free(&queueTmp);
+    if (retVal && !dwError)
+    {
+        dwError = retVal;
+    }
     return dwError;
 
 error:

--- a/tools/cli/lib/api.c
+++ b/tools/cli/lib/api.c
@@ -177,7 +177,10 @@ TDNFCliListPackagesPrint(
             CHECK_JD_RC(jd_list_add_child(jd, jd_pkg));
             JD_SAFE_DESTROY(jd_pkg);
         }
-        pr_json(jd->buf);
+        if (dwCount)
+        {
+            pr_json(jd->buf);
+        }
         JD_SAFE_DESTROY(jd);
     }
     else
@@ -235,6 +238,7 @@ TDNFCliListCommand(
     )
 {
     uint32_t dwError = 0;
+    uint32_t retVal = 0;
     PTDNF_PKG_INFO pPkgInfo = NULL;
     uint32_t dwCount = 0;
     PTDNF_LIST_ARGS pListArgs = NULL;
@@ -249,8 +253,9 @@ TDNFCliListCommand(
     BAIL_ON_CLI_ERROR(dwError);
 
     dwError = pContext->pFnList(pContext, pListArgs, &pPkgInfo, &dwCount);
-    if (pCmdArgs->nJsonOutput && dwError == ERROR_TDNF_NO_MATCH)
+    if (dwError == ERROR_TDNF_NO_MATCH)
     {
+        retVal = dwError;
         dwError = 0;
     }
     BAIL_ON_CLI_ERROR(dwError);
@@ -266,6 +271,10 @@ cleanup:
     if(pPkgInfo)
     {
         TDNFFreePackageInfoArray(pPkgInfo, dwCount);
+    }
+    if (!dwError && retVal)
+    {
+        dwError = retVal;
     }
     return dwError;
 
@@ -480,6 +489,7 @@ TDNFCliSearchCommand(
     )
 {
     uint32_t dwError = 0;
+    uint32_t retVal = 0;
     uint32_t dwCount = 0;
     uint32_t dwIndex = 0;
     PTDNF_PKG_INFO pPkgInfo = NULL;
@@ -494,8 +504,9 @@ TDNFCliSearchCommand(
     }
 
     dwError = pContext->pFnSearch(pContext, pCmdArgs, &pPkgInfo, &dwCount);
-    if (pCmdArgs->nJsonOutput && dwError == ERROR_TDNF_NO_SEARCH_RESULTS)
+    if (dwError == ERROR_TDNF_NO_SEARCH_RESULTS)
     {
+        retVal = dwError;
         dwError = 0;
     }
     BAIL_ON_CLI_ERROR(dwError);
@@ -536,6 +547,10 @@ TDNFCliSearchCommand(
 
 cleanup:
     TDNFFreePackageInfoArray(pPkgInfo, dwCount);
+    if (!dwError && retVal)
+    {
+        dwError = retVal;
+    }
     return dwError;
 
 error:


### PR DESCRIPTION
Currently tdnf returns with zero exit status when a command like `tdnf search tdnf invalid linux` or `tdnf search linux invalid123 tdnf` is invoked, if we are passing args in bulk, and if there are multiple keys with no results tdnf doesn't show any errors. This patch is an attempt to address this issue. Corresponding tests are added.