### PR TITLE
make snapshot files fetchable by URL

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -393,6 +393,8 @@ TDNFClean(
             BAIL_ON_TDNF_ERROR(dwError);
             dwError = TDNFRemoveMirrorList(pTdnf, pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
+            dwError = TDNFRemoveSnapshot(pTdnf, pRepo);
+            BAIL_ON_TDNF_ERROR(dwError);
         }
 
         /* remove the top level repo cache dir if it's not empty */

--- a/client/init.c
+++ b/client/init.c
@@ -132,7 +132,7 @@ TDNFRefreshSack(
     for (i = 0; i < nCount; i++) {
         pRepo = ppRepoArray[i];
 
-        if (pRepo->nEnabled && pRepo->pszSnapshotUrl) {
+        if (pRepo->nEnabled && pRepo->pszSnapshotFile) {
             dwError = TDNFApplySnapshot(pRepo, pSack, pRepo->pRepo);
             BAIL_ON_TDNF_ERROR(dwError);
         }

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -111,6 +111,12 @@ TDNFRemoveMirrorList(
     );
 
 uint32_t
+TDNFRemoveSnapshot(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    );
+
+uint32_t
 TDNFRemoveTmpRepodata(
     const char* pszTmpRepodataDir
     );

--- a/client/repo.c
+++ b/client/repo.c
@@ -23,7 +23,7 @@ TDNFApplySnapshot(
     int i;
     Queue qResult = {0};
 
-    if(!pRepoData || !pRepoData->pszSnapshotUrl || !pSack || !pSack->pPool)
+    if(!pRepoData || !pRepoData->pszSnapshotFile || !pSack || !pSack->pPool)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -32,7 +32,7 @@ TDNFApplySnapshot(
 
     queue_init(&qResult);
 
-    dwError = TDNFReadFileToStringArray(pRepoData->pszSnapshotUrl, &ppszSnapshotPackages);
+    dwError = TDNFReadFileToStringArray(pRepoData->pszSnapshotFile, &ppszSnapshotPackages);
     BAIL_ON_TDNF_ERROR(dwError);
 
     for(i = 0; ppszSnapshotPackages[i]; i++) {
@@ -475,6 +475,7 @@ TDNFGetRepoMD(
     char *pszTmpRepoDataDir = NULL;
     char *pszTmpRepoMDFile = NULL;
     char *pszMirrorFile = NULL;
+    char *pszSnapshotFile = NULL;
     char *pszTempBaseUrlFile = NULL;
     char* pszLastRefreshMarker = NULL;
     PTDNF_REPO_METADATA pRepoMDRel = NULL;
@@ -691,6 +692,60 @@ TDNFGetRepoMD(
                   pRepoMDRel,
                   &pRepoMD);
     BAIL_ON_TDNF_ERROR(dwError);
+
+    if (pRepoData->pszSnapshotUrl) {
+        time_t now = time(NULL);
+        int needDownload = 0, nIsRemote = 0;
+        struct stat st = {0};
+
+        if (pRepoData->pszSnapshotUrl[0] == '/') {
+            SET_STRING(pRepoData->pszSnapshotFile, pRepoData->pszSnapshotUrl);
+        } else {
+            dwError = TDNFUriIsRemote(pRepoData->pszSnapshotUrl, &nIsRemote);
+            if (dwError) {
+                /* should be a relative path, relative to repo dir */
+                dwError = TDNFJoinPath(
+                              &pRepoData->pszSnapshotFile,
+                              pTdnf->pConf->pszRepoDir,
+                              pRepoData->pszSnapshotUrl,
+                              NULL);
+                BAIL_ON_TDNF_ERROR(dwError);
+            } else {
+                if (nIsRemote) {
+                    /* we need a unique name based on URL locally, so we automatically refresh on config changes
+                       "snapshot" % URL => "snapshot-12345678" */
+                    dwError = SolvCreateRepoCacheName(TDNF_REPO_METADATA_SNAPSHOT, pRepoData->pszSnapshotUrl, &pszSnapshotFile);
+                    BAIL_ON_TDNF_ERROR(dwError);
+
+                    dwError = TDNFGetCachePath(pTdnf, pRepoData,
+                                               pszSnapshotFile, NULL,
+                                               &pRepoData->pszSnapshotFile);
+                    BAIL_ON_TDNF_ERROR(dwError);
+
+                    if (stat(pRepoData->pszSnapshotFile, &st) < 0) {
+                        if (errno == ENOENT)
+                            needDownload = 1;
+                        else {
+                            dwError = errno;
+                            BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+                        }
+                    } else if ((now - st.st_ctime) > pRepoData->lMetadataExpire)
+                        needDownload = 1;
+
+                    if (needDownload) {
+                        dwError = TDNFDownloadFile(pTdnf, pRepoData, pRepoData->pszSnapshotUrl, pRepoData->pszSnapshotFile, pRepoData->pszId);
+                        BAIL_ON_TDNF_ERROR(dwError);
+                    }
+                } else if (strncmp(pRepoData->pszSnapshotUrl, "file://", 7) == 0) {
+                    SET_STRING(pRepoData->pszSnapshotFile, &pRepoData->pszSnapshotUrl[7]);
+                } else {
+                    /* we should never get here if TDNFUriIsRemote() behaves correctly */
+                    dwError = ERROR_TDNF_URL_INVALID;
+                    BAIL_ON_TDNF_ERROR(dwError);
+                }
+            }
+        }
+    }
     *ppRepoMD = pRepoMD;
 
 cleanup:
@@ -712,6 +767,7 @@ cleanup:
     TDNF_SAFE_FREE_MEMORY(pszTempBaseUrlFile);
     TDNF_SAFE_FREE_MEMORY(pszError);
     TDNF_SAFE_FREE_MEMORY(pszLastRefreshMarker);
+    TDNF_SAFE_FREE_MEMORY(pszSnapshotFile);
     return dwError;
 
 error:

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -56,6 +56,8 @@ TDNFRepoConfigFromCnfTree(PTDNF pTdnf,
     uint32_t dwError = 0;
     struct cnfnode *cn;
 
+    UNUSED(pTdnf);
+
     for(cn = cn_top->first_child; cn; cn = cn->next)
     {
         if ((cn->name[0] == '.') || (cn->value == NULL))
@@ -84,18 +86,7 @@ TDNFRepoConfigFromCnfTree(PTDNF pTdnf,
         }
         else if (strcmp(cn->name, TDNF_REPO_KEY_SNAPSHOT_URL) == 0)
         {
-            /* we do not support URLs yet, just filenames */
-            if (cn->value[0] == '/') {
-                SET_STRING(pRepo->pszSnapshotUrl, cn->value);
-            } else {
-                /* path should be relative to repo dir */
-                dwError = TDNFJoinPath(
-                              &pRepo->pszSnapshotUrl,
-                              pTdnf->pConf->pszRepoDir,
-                              cn->value,
-                              NULL);
-                BAIL_ON_TDNF_ERROR(dwError);
-            }
+            SET_STRING(pRepo->pszSnapshotUrl, cn->value);
         }
         else if (strcmp(cn->name, TDNF_REPO_KEY_SKIP) == 0)
         {

--- a/client/repoutils.c
+++ b/client/repoutils.c
@@ -7,6 +7,8 @@
  */
 
 #include "includes.h"
+#include <glob.h>
+
 
 uint32_t
 TDNFRepoGetUserPass(
@@ -276,6 +278,49 @@ TDNFRemoveMirrorList(
     )
 {
     return _TDNFRemoveRepoCacheFile(pTdnf, pRepo, TDNF_REPO_METADATA_MIRRORLIST);
+}
+
+uint32_t
+TDNFRemoveSnapshot(
+    PTDNF pTdnf,
+    PTDNF_REPO_DATA pRepo
+    )
+{
+    uint32_t dwError = 0;
+    int i, ret = 0;
+    char *pszPathPattern = NULL;
+    glob_t globbuf =  {0};
+
+    if(!pTdnf || !pRepo || !pTdnf->pConf)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    /* glob for all files matching TDNF_REPO_METADATA_MIRRORLIST"-*" ("snapshot*")
+       and remove them */
+    dwError = TDNFGetCachePath(pTdnf, pRepo,
+                               TDNF_REPO_METADATA_SNAPSHOT"-*", NULL,
+                               &pszPathPattern);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    ret = glob(pszPathPattern, 0, NULL, &globbuf);
+    if (ret == 0) {
+        for (i = 0; globbuf.gl_pathv[i]; i++) {
+            if(unlink(globbuf.gl_pathv[i]) && errno != ENOENT)
+            {
+               dwError = errno;
+               BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
+            }
+        }
+    }
+
+cleanup:
+    globfree(&globbuf);
+    TDNF_SAFE_FREE_MEMORY(pszPathPattern);
+    return dwError;
+error:
+    goto cleanup;
 }
 
 uint32_t

--- a/common/config.h
+++ b/common/config.h
@@ -87,6 +87,7 @@
 //file names
 #define TDNF_REPO_METADATA_MARKER         "lastrefresh"
 #define TDNF_REPO_METADATA_MIRRORLIST     "mirrorlist"
+#define TDNF_REPO_METADATA_SNAPSHOT       "snapshot"
 #define TDNF_REPO_METADATA_FILE_PATH      "repodata/repomd.xml"
 #define TDNF_REPO_METADATA_FILE_NAME      "repomd.xml"
 #define TDNF_REPO_METALINK_FILE_NAME      "metalink"

--- a/common/utils.c
+++ b/common/utils.c
@@ -439,6 +439,8 @@ TDNFFreeRepos(
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszBaseUrls);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMetaLink);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotUrl);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotFile);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
 
         pRepos = pRepo->pNext;

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -303,6 +303,7 @@ typedef struct _TDNF_REPO_DATA
     char* pszMetaLink;
     char* pszMirrorList;
     char* pszSnapshotUrl;
+    char* pszSnapshotFile;
     char** ppszUrlGPGKeys;
     int nSSLVerify;
     char* pszSSLCaCert;

--- a/pytests/tests/test_snapshots.py
+++ b/pytests/tests/test_snapshots.py
@@ -102,6 +102,56 @@ def test_list(utils):
         assert nevr not in EXCLUDED_PKGS
 
 
+def test_list_file_absolute(utils):
+    snapshot_file = os.path.join(utils.config['repo_path'], "yum.repos.d", f"{REPONAME}.list")
+
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", f"--setopt=snapshot.{REPONAME}={snapshot_file}", "list"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS
+
+
+def test_list_file_notfound(utils):
+    snapshot_file = os.path.join(utils.config['repo_path'], "yum.repos.d", f"{REPONAME}.list.invalid")
+
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", f"--setopt=snapshot.{REPONAME}={snapshot_file}", "list"])
+    assert ret['retval'] != 0
+
+
+def test_list_file_url(utils):
+    snapshot_file = os.path.join(utils.config['repo_path'], "yum.repos.d", f"{REPONAME}.list")
+
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", f"--setopt=snapshot.{REPONAME}=file://{snapshot_file}", "list"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS
+
+
+def test_list_http(utils):
+    snapshot_url = f"http://localhost:8080/yum.repos.d/{REPONAME}.list"
+
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", f"--setopt=snapshot.{REPONAME}={snapshot_url}", "list"])
+    infolist = json.loads("\n".join(ret['stdout']))
+
+    # excluded packages should not be listed
+    for info in infolist:
+        nevr = f"{info['Name']}={info['Evr']}"
+        assert nevr not in EXCLUDED_PKGS
+
+
+def test_list_http_404(utils):
+    snapshot_url = f"http://localhost:8080/yum.repos.d/{REPONAME}.list.invalid"
+
+    ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", f"--setopt=snapshot.{REPONAME}={snapshot_url}", "list"])
+    assert ret['retval'] != 0
+
+
 def test_info(utils):
     ret = utils.run(["tdnf", "-j", "--repoid", REPONAME, "--available", "info"])
     infolist = json.loads("\n".join(ret['stdout']))


### PR DESCRIPTION
Make snapshot files fetchable by URL.

If the snapshot file is not local, it will be downloaded to the cache, unless it already exists and is not expired, with the same expiry time as the whole repo. The file will be downloaded as `snapshot-<hash>`, where the hash is calculated from the URL - this is to make sure that the file will be downloaded even if a previous version exists but the URL has changed. On cleanup all snapshot files will be removed, by matching the pattern.

The behavior for local snapshot files has not changed. It will be read directly, and not copied to cache.