### PR TITLE
Enhance enablerepo, disablerepo

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -726,33 +726,34 @@ TDNFRepoListFinalize(
     /* There could be overrides to enable/disable
        repo such as cmdline args, api overrides */
     for (cn = pTdnf->pArgs->cn_setopts->first_child; cn; cn = cn->next) {
-        if(strcmp(cn->name, "enablerepo") == 0) {
-            dwError = TDNFAlterRepoState(
-                          pTdnf->pRepos,
-                          1,
-                          cn->value);
-        }
-        else if(strcmp(cn->name, "disablerepo") == 0) {
-            dwError = TDNFAlterRepoState(
-                          pTdnf->pRepos,
-                          0,
-                          cn->value);
-        }
-        else if((strcmp(cn->name, "repo") == 0) ||
-                (strcmp(cn->name, "repoid") == 0)) {
-            if (!nRepoidSeen)
-            {
-                dwError = TDNFAlterRepoState(
-                              pTdnf->pRepos, 0, "*");
-                BAIL_ON_TDNF_ERROR(dwError);
-                nRepoidSeen = 1;
+        int isEnabled = -1;
+        char **ppszRepos = NULL;
+
+        if (!strcmp(cn->name, "enablerepo"))
+            isEnabled = 1;
+        else if (!strcmp(cn->name, "disablerepo"))
+            isEnabled = 0;
+
+        if (isEnabled != -1) {
+            dwError = TDNFSplitStringToArray(cn->value, ",", &ppszRepos);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            for (int i = 0; ppszRepos[i]; ++i) {
+              dwError = TDNFAlterRepoState(pTdnf->pRepos, isEnabled, ppszRepos[i]);
+              BAIL_ON_TDNF_ERROR(dwError);
             }
-            dwError = TDNFAlterRepoState(
-                          pTdnf->pRepos,
-                          1,
-                          cn->value);
+
+            TDNF_SAFE_FREE_STRINGARRAY(ppszRepos);
+        } else if (!strcmp(cn->name, "repo") || !strcmp(cn->name, "repoid")) {
+            if (!nRepoidSeen) {
+              dwError = TDNFAlterRepoState(pTdnf->pRepos, 0, "*");
+              BAIL_ON_TDNF_ERROR(dwError);
+              nRepoidSeen = 1;
+            }
+
+            dwError = TDNFAlterRepoState(pTdnf->pRepos, 1, cn->value);
+            BAIL_ON_TDNF_ERROR(dwError);
         }
-        BAIL_ON_TDNF_ERROR(dwError);
     }
 
     /* Now that the overrides are applied, replace config vars

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -849,18 +849,20 @@ TDNFAlterRepoState(
 
     nIsGlob = TDNFIsGlob(pszId);
 
-    for (int nMatch = 0; pRepos; pRepos = pRepos->pNext)
+    for (; pRepos; pRepos = pRepos->pNext)
     {
+        bool nMatch = false;
+
         if(nIsGlob)
         {
             if(!fnmatch(pszId, pRepos->pszId, 0))
             {
-                nMatch = 1;
+                nMatch = true;
             }
         }
         else if(!strcmp(pRepos->pszId, pszId))
         {
-            nMatch = 1;
+            nMatch = true;
         }
         if(nMatch)
         {

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -751,8 +751,16 @@ TDNFRepoListFinalize(
               nRepoidSeen = 1;
             }
 
-            dwError = TDNFAlterRepoState(pTdnf->pRepos, 1, cn->value);
+            ppszRepos = NULL;
+            dwError = TDNFSplitStringToArray(cn->value, ",", &ppszRepos);
             BAIL_ON_TDNF_ERROR(dwError);
+
+            for (int i = 0; ppszRepos[i]; ++i) {
+              dwError = TDNFAlterRepoState(pTdnf->pRepos, 1, ppszRepos[i]);
+              BAIL_ON_TDNF_ERROR(dwError);
+            }
+
+            TDNF_SAFE_FREE_STRINGARRAY(ppszRepos);
         }
     }
 

--- a/pytests/tests/test_repoid.py
+++ b/pytests/tests/test_repoid.py
@@ -8,6 +8,7 @@
 
 import os
 import shutil
+import json
 import pytest
 
 REPODIR = '/root/repoid/yum.repos.d'
@@ -94,3 +95,86 @@ def test_repoid_created_repo(utils):
     assert ret['retval'] == 0
     assert utils.check_package(pkgname)
     utils.erase_package(pkgname)
+
+
+def find_repo(repolist, id):
+    for repo in repolist:
+        if repo['Repo'] == id:
+            return True
+    return False
+
+
+# Test comma-separated repoid
+def test_repoid_comma_separated(utils):
+    os.makedirs(REPODIR, exist_ok=True)
+
+    # Create first repo
+    REPONAME1 = "repoid-test1"
+    utils.create_repoconf(os.path.join(REPODIR, 'repoid1.repo'),
+                          "http://foo.bar.com/packages1",
+                          REPONAME1)
+
+    # Create second repo
+    REPONAME2 = "repoid-test2"
+    utils.create_repoconf(os.path.join(REPODIR, 'repoid2.repo'),
+                          "http://foo.bar.com/packages2",
+                          REPONAME2)
+
+    # Create third repo (should be disabled when using --repoid)
+    REPONAME3 = "repoid-test3"
+    utils.create_repoconf(os.path.join(REPODIR, 'repoid3.repo'),
+                          "http://foo.bar.com/packages3",
+                          REPONAME3)
+
+    # Test with comma-separated repoid - should only enable the specified repos
+    ret = utils.run(['tdnf',
+                     '--setopt=reposdir={}'.format(REPODIR),
+                     '--repoid={},{}'.format(REPONAME1, REPONAME2),
+                     'repolist', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+
+    # Verify that the specified repos are enabled
+    assert find_repo(repolist, REPONAME1)
+    assert find_repo(repolist, REPONAME2)
+
+    # Verify that the third repo is NOT enabled (repoid disables all others)
+    assert not find_repo(repolist, REPONAME3)
+
+
+# Test comma-separated repo (alias for repoid)
+def test_repo_comma_separated(utils):
+    os.makedirs(REPODIR, exist_ok=True)
+
+    # Create first repo
+    REPONAME1 = "repo-test1"
+    utils.create_repoconf(os.path.join(REPODIR, 'repo1.repo'),
+                          "http://foo.bar.com/packages1",
+                          REPONAME1)
+
+    # Create second repo
+    REPONAME2 = "repo-test2"
+    utils.create_repoconf(os.path.join(REPODIR, 'repo2.repo'),
+                          "http://foo.bar.com/packages2",
+                          REPONAME2)
+
+    # Create third repo (should be disabled when using --repo)
+    REPONAME3 = "repo-test3"
+    utils.create_repoconf(os.path.join(REPODIR, 'repo3.repo'),
+                          "http://foo.bar.com/packages3",
+                          REPONAME3)
+
+    # Test with comma-separated repo - should only enable the specified repos
+    ret = utils.run(['tdnf',
+                     '--setopt=reposdir={}'.format(REPODIR),
+                     '--repo={},{}'.format(REPONAME1, REPONAME2),
+                     'repolist', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+
+    # Verify that the specified repos are enabled
+    assert find_repo(repolist, REPONAME1)
+    assert find_repo(repolist, REPONAME2)
+
+    # Verify that the third repo is NOT enabled (repo disables all others)
+    assert not find_repo(repolist, REPONAME3)

--- a/pytests/tests/test_repolist.py
+++ b/pytests/tests/test_repolist.py
@@ -43,15 +43,44 @@ def setup_test(utils):
         section='bar',
         filename=repofile_bar
     )
+    # Add repos for glob testing
+    repofile_example = os.path.join(utils.config['repo_path'], 'yum.repos.d', 'example.repo')
+    utils.edit_config(
+        {
+            'name': 'Example Repo',
+            'enabled': '1',
+            'baseurl': 'http://pkgs.example.org/example'
+        },
+        section='example-test',
+        filename=repofile_example
+    )
+    utils.edit_config(
+        {
+            'name': 'Example Debug Repo',
+            'enabled': '0',
+            'baseurl': 'http://pkgs.example.org/example-debug'
+        },
+        section='example-debug',
+        filename=repofile_example
+    )
+    utils.edit_config(
+        {
+            'name': 'Example Updates Repo',
+            'enabled': '0',
+            'baseurl': 'http://pkgs.example.org/example-updates'
+        },
+        section='example-updates',
+        filename=repofile_example
+    )
     yield
     teardown_test(utils)
 
 
 def teardown_test(utils):
-    os.remove(os.path.join(utils.config['repo_path'], 'yum.repos.d', 'foo.repo'))
-    os.remove(os.path.join(utils.config['repo_path'], 'yum.repos.d', 'bar.repo'))
-    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", 'test.repo'))
-    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", 'test1.repo'))
+    for fn in ["foo", "bar", "test", "example"]:
+        fn = os.path.join(utils.config["repo_path"], "yum.repos.d", f"{fn}.repo")
+        if os.path.isfile(fn):
+            os.remove(fn)
 
 
 def find_repo(repolist, id):
@@ -160,3 +189,93 @@ def test_multiple_repoid(utils):
                      '--disablerepo=*', '--enablerepo={}'.format(reponame),
                      'makecache'])
     assert ret['retval'] == 1037
+    os.remove(os.path.join(utils.config['repo_path'], "yum.repos.d", 'test1.repo'))
+
+
+# Test comma-separated repo names for enablerepo
+def test_repolist_enable_comma_separated(utils):
+    ret = utils.run(['tdnf', 'repolist', '--enablerepo=foo-debug,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert find_repo(repolist, 'foo')
+    assert find_repo(repolist, 'foo-debug')
+    assert find_repo(repolist, 'bar')
+
+
+# Test comma-separated repo names for disablerepo
+def test_repolist_disable_comma_separated(utils):
+    ret = utils.run(['tdnf', 'repolist', '--disablerepo=foo,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert not find_repo(repolist, 'foo')
+    assert not find_repo(repolist, 'bar')
+    # foo-debug should still be disabled (not enabled by default)
+    assert not find_repo(repolist, 'foo-debug')
+
+
+# Test glob pattern for enablerepo
+def test_repolist_enable_glob(utils):
+    ret = utils.run(['tdnf', 'repolist', '--enablerepo=example*', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert find_repo(repolist, 'example-test')
+    assert find_repo(repolist, 'example-debug')
+    assert find_repo(repolist, 'example-updates')
+
+
+# Test glob pattern for disablerepo
+def test_repolist_disable_glob(utils):
+    ret = utils.run(['tdnf', 'repolist', '--disablerepo=foo*', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert not find_repo(repolist, 'foo')
+    assert not find_repo(repolist, 'foo-debug')
+    # bar should still be enabled
+    assert find_repo(repolist, 'bar')
+
+
+# Test comma-separated globs for enablerepo
+def test_repolist_enable_comma_separated_globs(utils):
+    ret = utils.run(['tdnf', 'repolist', '--enablerepo=example*,foo*', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert find_repo(repolist, 'example-test')
+    assert find_repo(repolist, 'example-debug')
+    assert find_repo(repolist, 'example-updates')
+    assert find_repo(repolist, 'foo')
+    assert find_repo(repolist, 'foo-debug')
+
+
+# Test comma-separated globs for disablerepo
+def test_repolist_disable_comma_separated_globs(utils):
+    ret = utils.run(['tdnf', 'repolist', '--disablerepo=example*,foo*', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert not find_repo(repolist, 'example-test')
+    assert not find_repo(repolist, 'example-debug')
+    assert not find_repo(repolist, 'example-updates')
+    assert not find_repo(repolist, 'foo')
+    assert not find_repo(repolist, 'foo-debug')
+    # bar should still be enabled
+    assert find_repo(repolist, 'bar')
+
+
+# Test mixed comma-separated (globs and non-globs) for enablerepo
+def test_repolist_enable_mixed(utils):
+    ret = utils.run(['tdnf', 'repolist', '--enablerepo=example*,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert find_repo(repolist, 'example-test')
+    assert find_repo(repolist, 'example-debug')
+    assert find_repo(repolist, 'example-updates')
+    assert find_repo(repolist, 'bar')
+
+
+# Test mixed comma-separated (globs and non-globs) for disablerepo
+def test_repolist_disable_mixed(utils):
+    ret = utils.run(['tdnf', 'repolist', '--disablerepo=foo*,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    assert not find_repo(repolist, 'foo')
+    assert not find_repo(repolist, 'foo-debug')
+    assert not find_repo(repolist, 'bar')

--- a/pytests/tests/test_repolist.py
+++ b/pytests/tests/test_repolist.py
@@ -213,6 +213,36 @@ def test_repolist_disable_comma_separated(utils):
     assert not find_repo(repolist, 'foo-debug')
 
 
+# Test comma-separated repo names for repoid
+def test_repolist_repoid_comma_separated(utils):
+    ret = utils.run(['tdnf', 'repolist', '--repoid=foo-debug,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    # repoid disables all repos first, then enables only the specified ones
+    assert find_repo(repolist, 'foo-debug')
+    assert find_repo(repolist, 'bar')
+    # foo should be disabled (repoid disables all others)
+    assert not find_repo(repolist, 'foo')
+    # example repos should be disabled
+    assert not find_repo(repolist, 'example-test')
+    assert not find_repo(repolist, 'example-debug')
+
+
+# Test comma-separated repo names for repo (alias for repoid)
+def test_repolist_repo_comma_separated(utils):
+    ret = utils.run(['tdnf', 'repolist', '--repo=foo-debug,bar', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads("\n".join(ret['stdout']))
+    # repo disables all repos first, then enables only the specified ones
+    assert find_repo(repolist, 'foo-debug')
+    assert find_repo(repolist, 'bar')
+    # foo should be disabled (repo disables all others)
+    assert not find_repo(repolist, 'foo')
+    # example repos should be disabled
+    assert not find_repo(repolist, 'example-test')
+    assert not find_repo(repolist, 'example-debug')
+
+
 # Test glob pattern for enablerepo
 def test_repolist_enable_glob(utils):
     ret = utils.run(['tdnf', 'repolist', '--enablerepo=example*', '-j'])


### PR DESCRIPTION
Accept comma-separated repository names and globs as well.

Currently, enabling or disabling specific repositories requires multiple flags, for example:
```
tdnf ...  --disablerepo=repo1 --disablerepo=repo2 --enablerepo=repo3 --enablerepo=repo4
```

This PR extends the behavior so that each flag can take a comma-separated list, allowing the same operation with:
```
tdnf ...  --disablerepo=repo1,repo2 --enablerepo=repo3,repo4
```

Globs are also supported.