### PR TITLE
Check for RPMTAG_OPENPGP when detecting unsigned packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-### External dependency: rpm-devel
+# External dependency: rpm-devel
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(RPM REQUIRED rpm)
 find_package(OpenSSL REQUIRED)
@@ -57,15 +57,25 @@ pkg_check_modules(SQLITE3 sqlite3)
 include_directories(${RPM_INCLUDE_DIRS})
 include_directories(${EXPAT_INCLUDE_DIRS})
 
-### External dependency: libsolv
+# External dependency: libsolv
 find_package(LibSolv REQUIRED ext)
 
-### External dependency: libcurl
+# External dependency: libcurl
 find_package(CURL REQUIRED)
 
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/tdnf")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/pytests/tests/" DESTINATION "${CMAKE_INSTALL_DATADIR}/tdnf/pytests/tests")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/pytests/repo/" DESTINATION "${CMAKE_INSTALL_DATADIR}/tdnf/pytests/repo")
+
+pkg_check_modules(RPM REQUIRED rpm)
+
+if(RPM_VERSION VERSION_GREATER_EQUAL "6.0")
+  message(STATUS "rpm ${RPM_VERSION} >= 6.0")
+  message(STATUS "Enabling BUILD_WITH_RPM_6X macro")
+  add_compile_definitions(BUILD_WITH_RPM_6X)
+else()
+  message(STATUS "rpm ${RPM_VERSION} < 6.0")
+endif()
 
 set(LIB_TDNF "tdnf")
 set(LIB_TDNF_SOLV "tdnfsolv")

--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -266,6 +266,9 @@ TDNFGPGCheckPackage(
         if (((pszTmp = headerGetAsString(rpmHeader, RPMTAG_SIGPGP)) == NULL) &&
             ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_SIGGPG)) == NULL) &&
             ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_DSAHEADER)) == NULL) &&
+#ifdef BUILD_WITH_RPM_6X
+            ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_OPENPGP)) == NULL) &&
+#endif
             ((pszTmp = headerGetAsString(rpmHeader, RPMTAG_RSAHEADER)) == NULL))
         {
             dwError = ERROR_TDNF_RPM_UNSIGNED;

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -108,6 +108,19 @@ cp -r ${BUILD_PATH}/RPMS ${PUBLISH_SHA512_PATH}
 mkdir -p ${PUBLISH_PATH}/keys
 gpg --armor --export tdnftest@tdnf.test > ${PUBLISH_PATH}/keys/pubkey.asc
 
+gpg --batch --generate-key <<EOF
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: tdnf test wrong
+Name-Email: tdnftest@tdnf.wrong
+Expire-Date: 0
+%no-protection
+%commit
+EOF
+
+WRONG_FPR=$(gpg --list-keys --with-colons tdnftest@tdnf.wrong | awk -F: '/^fpr:/ {print $10; exit}')
+gpg --armor --export "${WRONG_FPR}" > ${PUBLISH_PATH}/keys/pubkey.wrong.asc
+
 createrepo ${PUBLISH_PATH}
 createrepo ${PUBLISH_SRC_PATH}
 createrepo -s sha512 ${PUBLISH_SHA512_PATH}

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -212,8 +212,10 @@ def test_install_nokey(utils):
 # 'wrong' key in repo config, expect fail
 def test_install_nokey1(utils):
     set_gpgcheck(utils, True)
-    set_repo_key(utils, DEFAULT_KEY)
+    keypath = os.path.join(utils.config['repo_path'], 'photon-test', 'keys', 'pubkey.wrong.asc')
+    set_repo_key(utils, f"file://{keypath}")
     pkgname = utils.config["sglversion_pkgname"]
+    utils.run(['rpm', '--import', keypath])
     ret = utils.run(['tdnf', 'install', '-y', pkgname])
     assert ret['retval'] == 1514
     assert not utils.check_package(pkgname)


### PR DESCRIPTION
This is needed if underlying RPM version used is 6.x