### PR TITLE
Add configurable connect timeout for downloads

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -86,6 +86,7 @@ TDNFReadConfig(
     pConf->nCleanRequirementsOnRemove = 0;
     pConf->nKeepCache = 0;
     pConf->nOpenMax = TDNF_DEFAULT_OPENMAX;
+    pConf->nConnectTimeout = TDNF_CONF_DEFAULT_CONNECT_TIMEOUT;
 
     register_ini(NULL);
     mod_ini = find_cnfmodule("ini");
@@ -170,6 +171,10 @@ TDNFReadConfig(
         else if (strcmp(cn->name, TDNF_CONF_KEY_OPENMAX) == 0)
         {
             pConf->nOpenMax = atoi(cn->value);
+        }
+        else if (strcmp(cn->name, TDNF_CONF_KEY_CONNECT_TIMEOUT) == 0)
+        {
+            pConf->nConnectTimeout = strtoi(cn->value);
         }
         else if (strcmp(cn->name, TDNF_CONF_KEY_CHECK_UPDATE_COMPAT) == 0)
         {

--- a/client/defines.h
+++ b/client/defines.h
@@ -145,6 +145,7 @@ typedef enum
 #define TDNF_REPO_METADATA_EXPIRE_NEVER   "never"
 
 #define TDNF_DEFAULT_OPENMAX              1024
+#define TDNF_CONF_DEFAULT_CONNECT_TIMEOUT 0  // seconds (unlimited)
 
 // repo default settings
 #define TDNF_REPO_DEFAULT_ENABLED            0

--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -209,6 +209,12 @@ TDNFDownloadFile(
     dwError = curl_easy_setopt(pCurl, CURLOPT_FOLLOWLOCATION, 1L);
     BAIL_ON_TDNF_CURL_ERROR(dwError);
 
+    if (pTdnf->pConf->nConnectTimeout > 0)
+    {
+        curl_easy_setopt(pCurl, CURLOPT_CONNECTTIMEOUT,
+                          (long)pTdnf->pConf->nConnectTimeout);
+    }
+
     if (!pTdnf->pArgs->nQuiet && pszProgressData != NULL)
     {
         //print progress only if tty or verbose is specified.

--- a/common/config.h
+++ b/common/config.h
@@ -52,6 +52,7 @@
 #define TDNF_CONF_KEY_VARS_DIRS           "varsdir"
 #define TDNF_CONF_KEY_CHECK_UPDATE_COMPAT "dnf_check_update_compat"
 #define TDNF_CONF_KEY_DISTROSYNC_REINSTALL_CHANGED "distrosync_reinstall_changed"
+#define TDNF_CONF_KEY_CONNECT_TIMEOUT     "connect_timeout"
 
 //Repo file key names
 #define TDNF_REPO_KEY_BASEURL             "baseurl"

--- a/etc/tdnf/tdnf.conf
+++ b/etc/tdnf/tdnf.conf
@@ -4,3 +4,4 @@ installonly_limit=3
 clean_requirements_on_remove=0
 repodir=/etc/yum.repos.d
 cachedir=/var/cache/tdnf
+connect_timeout=10

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -264,6 +264,7 @@ typedef struct _TDNF_CONF
     int nPluginsEnabled;
     int nSkipDigest;
     int nSkipSignature;
+    int nConnectTimeout;
     char* pszRepoDir;
     char* pszCacheDir;
     char* pszPersistDir;


### PR DESCRIPTION
Introduce connect_timeout config option and apply it via CURLOPT_CONNECTTIMEOUT in remote downloads to avoid long hangs when DNS resolution succeeds but TCP connection does not establish.