### PR TITLE
add option `--urls` print package URLs instead of downloading

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -2402,6 +2402,84 @@ error:
 }
 
 uint32_t
+TDNFGetPackageUrls(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    char ***pppszUrls,
+    int *pnCount)
+{
+    uint32_t dwError = 0;
+    PTDNF_PKG_INFO pInfo = NULL;
+    PTDNF_REPO_DATA pRepo = NULL;
+    char **ppszUrls = NULL;
+    char *pszUrl = NULL;
+    int nCount = 0;
+    int nIndex = 0;
+
+    /* lists that require downloading RPMs */
+    PTDNF_PKG_INFO *apLists[] = {
+        &pSolvedPkgInfo->pPkgsToInstall,
+        &pSolvedPkgInfo->pPkgsToUpgrade,
+        &pSolvedPkgInfo->pPkgsToDowngrade,
+        &pSolvedPkgInfo->pPkgsToReinstall,
+    };
+
+    if (!pTdnf || !pSolvedPkgInfo || !pppszUrls || !pnCount)
+    {
+        dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    for (int i = 0; i < (int)(sizeof(apLists)/sizeof(apLists[0])); i++)
+    {
+        for (pInfo = *apLists[i]; pInfo; pInfo = pInfo->pNext)
+        {
+            /* skip local packages (absolute path) */
+            if (!IsNullOrEmptyString(pInfo->pszLocation) &&
+                pInfo->pszLocation[0] != '/')
+            {
+                nCount++;
+            }
+        }
+    }
+
+    dwError = TDNFAllocateMemory(nCount + 1, sizeof(char *), (void **)&ppszUrls);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    for (int i = 0; i < (int)(sizeof(apLists)/sizeof(apLists[0])); i++)
+    {
+        for (pInfo = *apLists[i]; pInfo; pInfo = pInfo->pNext)
+        {
+            if (IsNullOrEmptyString(pInfo->pszLocation) ||
+                pInfo->pszLocation[0] == '/')
+            {
+                continue;
+            }
+
+            dwError = TDNFFindRepoById(pTdnf, pInfo->pszRepoName, &pRepo);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            dwError = TDNFCreatePackageUrl(pRepo, pInfo->pszLocation, &pszUrl);
+            BAIL_ON_TDNF_ERROR(dwError);
+
+            ppszUrls[nIndex++] = pszUrl;
+            pszUrl = NULL;
+        }
+    }
+
+    *pppszUrls = ppszUrls;
+    *pnCount = nCount;
+
+cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszUrl);
+    return dwError;
+
+error:
+    TDNFFreeStringArray(ppszUrls);
+    goto cleanup;
+}
+
+uint32_t
 TDNFMark(
     PTDNF pTdnf,
     char** ppszPackageNameSpecs,

--- a/common/utils.c
+++ b/common/utils.c
@@ -541,7 +541,7 @@ TDNFPathFromUri(
     uint32_t dwError = 0;
     const char* pszPath = NULL;
     char *pszPathTmp = NULL;
-    size_t nOffset;
+    size_t nOffset = 0;
     const char *szProtocols[] = {"http://", "https://", "ftp://",
                                 "ftps://", "file://", NULL};
     int i = 0;

--- a/include/tdnf.h
+++ b/include/tdnf.h
@@ -151,7 +151,12 @@ TDNFHistoryList(
     PTDNF_HISTORY_ARGS pHistoryArgs,
     PTDNF_HISTORY_INFO *ppHistoryInfo);
 
-
+uint32_t
+TDNFGetPackageUrls(
+    PTDNF pTdnf,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    char ***pppszUrls,
+    int *pnCount);
 
 //confidence check. displays current installed count.
 //should be same as rpm -qa | wc -l

--- a/include/tdnfclitypes.h
+++ b/include/tdnfclitypes.h
@@ -170,6 +170,13 @@ typedef uint32_t
     char **ppszPkgNameSpecs,
     uint32_t nValue);
 
+typedef uint32_t
+(*PFN_TDNF_GET_PKG_URLS)(
+    PTDNF_CLI_CONTEXT,
+    PTDNF_SOLVED_PKG_INFO,
+    char ***,
+    int *);
+
 typedef struct _TDNF_CLI_CONTEXT_
 {
     HTDNF hTdnf;
@@ -195,6 +202,7 @@ typedef struct _TDNF_CLI_CONTEXT_
     PFN_TDNF_HISTORY_RESOLVE_CMD  pFnHistoryResolve;
     PFN_TDNF_ALTER_HISTORY        pFnAlterHistory;
     PFN_TDNF_MARK_COMMAND         pFnMark;
+    PFN_TDNF_GET_PKG_URLS         pFnGetPackageUrls;
 } TDNF_CLI_CONTEXT;
 
 #ifdef __cplusplus

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -231,6 +231,7 @@ typedef struct _TDNF_CMD_ARGS
     int nIPv6;             //resolve to IPv6 addresses only
     int nDisableExcludes;  //disable excludes from tdnf.conf
     int nDownloadOnly;     //download packages only, no install
+    int nUrlsOnly;         //print package URLs only, no download or install
     int nNoAutoRemove;     //overide clean_requirements_on_remove config option
     int nJsonOutput;       //output in json format
     int nTestOnly;         //run test transaction only

--- a/pytests/tests/test_urls.py
+++ b/pytests/tests/test_urls.py
@@ -1,0 +1,114 @@
+#
+# Copyright (C) 2026 Broadcom, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+
+import pytest
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgs = [
+        utils.config['sglversion_pkgname'],
+        'tdnf-test-cleanreq-leaf1',
+        'tdnf-test-cleanreq-required',
+    ]
+    utils.run('tdnf remove -y ' + ' '.join(pkgs))
+
+
+# --urls must print a URL and not install the package
+def test_urls_basic(utils):
+    pkgname = utils.config['sglversion_pkgname']
+    utils.erase_package(pkgname)
+
+    ret = utils.run(['tdnf', 'install', '-y', '--urls', pkgname])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+
+    output = '\n'.join(ret['stdout'])
+    assert pkgname in output
+    assert output.strip().endswith('.rpm')
+
+
+# each printed line must be a valid URL (starts with a known scheme or '/')
+def test_urls_format(utils):
+    pkgname = utils.config['sglversion_pkgname']
+    utils.erase_package(pkgname)
+
+    ret = utils.run(['tdnf', 'install', '-y', '--urls', pkgname])
+    assert ret['retval'] == 0
+
+    for line in ret['stdout']:
+        if line.strip():
+            assert (line.startswith('http://') or line.startswith('https://') or line.startswith('ftp://') or line.startswith('file://') or line.startswith('/')), \
+                f"unexpected URL format: {line}"
+
+
+# an uninstalled requirement must also appear in the URL list (default deps)
+def test_urls_includes_requires(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.erase_package(pkgname_req)
+    assert not utils.check_package(pkgname_req)
+
+    ret = utils.run(['tdnf', 'install', '-y', '--urls', pkgname])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+    assert not utils.check_package(pkgname_req)
+
+    output = '\n'.join(ret['stdout'])
+    assert pkgname_req in output
+
+
+# --alldeps: an already-installed requirement must still appear in the URL list
+def test_urls_alldeps(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.install_package(pkgname_req)
+    assert utils.check_package(pkgname_req)
+
+    ret = utils.run(['tdnf', 'install', '-y', '--urls', '--alldeps', pkgname])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+
+    output = '\n'.join(ret['stdout'])
+    assert pkgname_req in output
+
+
+# --nodeps: the requirement must NOT appear in the URL list
+def test_urls_nodeps(utils):
+    pkgname = 'tdnf-test-cleanreq-leaf1'
+    pkgname_req = 'tdnf-test-cleanreq-required'
+
+    utils.erase_package(pkgname_req)
+    assert not utils.check_package(pkgname_req)
+
+    ret = utils.run(['tdnf', 'install', '-y', '--urls', '--nodeps', pkgname])
+    assert ret['retval'] == 0
+    assert not utils.check_package(pkgname)
+
+    output = '\n'.join(ret['stdout'])
+    assert pkgname_req not in output
+
+
+# --alldeps without --urls or --downloadonly must fail
+def test_urls_alldeps_requires_urls_or_downloadonly(utils):
+    pkgname = utils.config['sglversion_pkgname']
+    ret = utils.run(['tdnf', 'install', '-y', '--alldeps', pkgname])
+    assert ret['retval'] != 0
+
+
+# --nodeps without --urls or --downloadonly must fail
+def test_urls_nodeps_requires_urls_or_downloadonly(utils):
+    pkgname = utils.config['sglversion_pkgname']
+    ret = utils.run(['tdnf', 'install', '-y', '--nodeps', pkgname])
+    assert ret['retval'] != 0

--- a/tools/cli/lib/help.c
+++ b/tools/cli/lib/help.c
@@ -17,7 +17,7 @@ static const char *help_msg =
  "--6, -6                    Resolve to IPv6 addresses only\n"
  "                           Example: tdnf -6 install package\n"
 
- "--alldeps                  Download all dependencies (requires --downloadonly)\n"
+ "--alldeps                  Download all dependencies (requires --downloadonly or --urls)\n"
  "                           Example: tdnf --downloadonly --alldeps install package\n"
 
  "--allowerasing             Allow erasing of installed packages to resolve dependencies\n"
@@ -61,6 +61,9 @@ static const char *help_msg =
 
  "--downloadonly             Download packages only, do not install\n"
  "                           Example: tdnf --downloadonly install pkg\n"
+ "\n"
+ "--urls                     Print package URLs only, do not download or install\n"
+ "                           Example: tdnf --urls install pkg\n"
 
  "--enablerepo <repoid>      Enable repositories by id\n"
  "                           Example: tdnf --enablerepo=updates install\n"
@@ -86,7 +89,7 @@ static const char *help_msg =
  "--noautoremove             Do not remove automatically installed dependencies\n"
  "                           Example: tdnf --noautoremove remove pkg\n"
 
- "--nodeps                   Skip dependency checks(requires --downloadonly)\n"
+ "--nodeps                   Skip dependency checks (requires --downloadonly or --urls)\n"
  "                           Example: tdnf --downloadonly --nodeps install package\n"
 
  "--nogpgcheck               Skip GPG signature checks\n"

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -333,6 +333,26 @@ TDNFCliAlterCommand(
                   &pSolvedPkgInfo);
     BAIL_ON_CLI_ERROR(dwError);
 
+    if (pCmdArgs->nUrlsOnly)
+    {
+        char **ppszUrls = NULL;
+        int nCount = 0;
+
+        dwError = pContext->pFnGetPackageUrls(
+                      pContext,
+                      pSolvedPkgInfo,
+                      &ppszUrls,
+                      &nCount);
+        BAIL_ON_CLI_ERROR(dwError);
+
+        for (int i = 0; i < nCount; i++)
+        {
+            pr_crit("%s\n", ppszUrls[i]);
+        }
+        TDNFFreeStringArray(ppszUrls);
+        goto cleanup;
+    }
+
     dwError = TDNFCliAskAndAlter(pContext, pCmdArgs, pSolvedPkgInfo);
     BAIL_ON_CLI_ERROR(dwError);
 

--- a/tools/cli/lib/parseargs.c
+++ b/tools/cli/lib/parseargs.c
@@ -11,6 +11,7 @@
 
 static TDNF_CMD_ARGS _opt = {0};
 
+/* options must be grouped if specific for sub commands, and sorted alphabetically */
 static struct option pstOptions[] =
 {
     {"4",             no_argument, 0, '4'},                //-4 resolve to IPv4 addresses only
@@ -62,6 +63,7 @@ static struct option pstOptions[] =
     {"skipsignature", no_argument, &_opt.nSkipSignature, 1}, //--skipsignature to skip verifying RPM signatures
     {"source",        no_argument, &_opt.nSource, 1},
     {"testonly",      no_argument, &_opt.nTestOnly, 1},
+    {"urls",          no_argument, &_opt.nUrlsOnly, 1},    //--urls
     {"verbose",       no_argument, &_opt.nVerbose, 1},     //-v --verbose
     {"version",       no_argument, &_opt.nShowVersion, 1}, //--version
     // reposync options
@@ -73,7 +75,6 @@ static struct option pstOptions[] =
     {"metadata-path", required_argument, 0, 0},
     {"newest-only",   no_argument, 0, 0},
     {"norepopath",    no_argument, 0, 0},
-    {"urls",          no_argument, 0, 0},
     // repoquery option
     // repoquery select options
     {"available",     no_argument, 0, 0},
@@ -289,12 +290,12 @@ TDNFCliParseArgs(
         BAIL_ON_CLI_ERROR(dwError);
     }
 
-    if (pCmdArgs->nAllDeps && !pCmdArgs->nDownloadOnly) {
+    if (pCmdArgs->nAllDeps && !pCmdArgs->nDownloadOnly && !pCmdArgs->nUrlsOnly) {
         dwError = ERROR_TDNF_CLI_ALLDEPS_REQUIRES_DOWNLOADONLY;
         BAIL_ON_CLI_ERROR(dwError);
     }
 
-    if (pCmdArgs->nNoDeps && !pCmdArgs->nDownloadOnly) {
+    if (pCmdArgs->nNoDeps && !pCmdArgs->nDownloadOnly && !pCmdArgs->nUrlsOnly) {
         dwError = ERROR_TDNF_CLI_NODEPS_REQUIRES_DOWNLOADONLY;
         BAIL_ON_CLI_ERROR(dwError);
     }
@@ -353,6 +354,7 @@ TDNFCopyOptions(
     pArgs->nIPv6          = pOptionArgs->nIPv6;
     pArgs->nDisableExcludes = pOptionArgs->nDisableExcludes;
     pArgs->nDownloadOnly  = pOptionArgs->nDownloadOnly;
+    pArgs->nUrlsOnly      = pOptionArgs->nUrlsOnly;
     pArgs->nNoAutoRemove  = pOptionArgs->nNoAutoRemove;
     pArgs->nJsonOutput    = pOptionArgs->nJsonOutput;
     pArgs->nTestOnly      = pOptionArgs->nTestOnly;

--- a/tools/cli/main.c
+++ b/tools/cli/main.c
@@ -92,6 +92,7 @@ int main(int argc, char **argv)
         _context.pFnHistoryResolve = TDNFCliInvokeHistoryResolve;
         _context.pFnAlterHistory = TDNFCliInvokeAlterHistory;
         _context.pFnMark = TDNFCliInvokeMark;
+        _context.pFnGetPackageUrls = TDNFCliInvokeGetPackageUrls;
 
         pszCmd = pCmdArgs->ppszCmds[0];
 
@@ -484,6 +485,17 @@ TDNFCliInvokeHistoryResolve(
         pContext->hTdnf,
         pHistoryArgs,
         ppSolvedPkgInfo);
+}
+
+uint32_t
+TDNFCliInvokeGetPackageUrls(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    char ***pppszUrls,
+    int *pnCount
+)
+{
+    return TDNFGetPackageUrls(pContext->hTdnf, pSolvedPkgInfo, pppszUrls, pnCount);
 }
 
 uint32_t

--- a/tools/cli/prototypes.h
+++ b/tools/cli/prototypes.h
@@ -126,6 +126,14 @@ TDNFCliInvokeAlterHistory(
     PTDNF_HISTORY_ARGS pHistoryArgs
     );
 
+uint32_t
+TDNFCliInvokeGetPackageUrls(
+    PTDNF_CLI_CONTEXT pContext,
+    PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo,
+    char ***pppszUrls,
+    int *pnCount
+);
+
 void
 TDNFCliShowNoSuchOption(
     const char* pszOption


### PR DESCRIPTION
The functionality is similar to `--downloadonly`, but just prints the URLs. This can be used for scripts that download the packages in another way.

Example:
```
$ sudo ./bin/tdnf --urls install --alldeps -q lsof | tee test.out
https://packages.broadcom.com/photon/5.0/photon_updates_5.0_x86_64/x86_64/pcre-libs-8.45-8.ph5.x86_64.rpm
https://packages.broadcom.com/photon/5.0/photon_updates_5.0_x86_64/x86_64/grep-3.7-6.ph5.x86_64.rpm
https://packages.broadcom.com/photon/5.0/photon_updates_5.0_x86_64/x86_64/pcre2-libs-10.40-10.ph5.x86_64.rpm
https://packages.broadcom.com/photon/5.0/photon_updates_5.0_x86_64/x86_64/libselinux-3.4-6.ph5.x86_64.rpm
https://packages.broadcom.com/photon/5.0/photon_updates_5.0_x86_64/x86_64/gmp-6.2.1-5.ph5.x86_64.rpm
...
```

It's a good idea to use the `-q` option along with it, to suppress eventual "Refreshing metadata" messages.