### PR TITLE
print url on error

### DIFF
--- a/client/remoterepo.c
+++ b/client/remoterepo.c
@@ -130,6 +130,9 @@ TDNFDownloadFileFromRepo(
             if (dwError == 0) {
                 break;
             }
+            if (pRepo->ppszBaseUrls[i + 1]) {
+                pr_err("Warning: failed to download %s, trying next base URL\n", pszUrl);
+            }
             TDNF_SAFE_FREE_MEMORY(pszUrl);
         }
     } else {
@@ -265,6 +268,8 @@ TDNFDownloadFile(
         }
         if (i == pRepo->nRetries || TDNFCurlErrorIsFatal(dwError))
         {
+            pr_err("Error: failed to download %s: %s\n",
+                   pszFileUrl, curl_easy_strerror(dwError));
             BAIL_ON_TDNF_CURL_ERROR(dwError);
         }
         fclose(fp);
@@ -285,7 +290,7 @@ TDNFDownloadFile(
     if(lStatus >= 400)
     {
         pr_err(
-                "Error: %ld when downloading %s\n. Please check repo url "
+                "Error: %ld when downloading %s. Please check repo url "
                 "or refresh metadata with 'tdnf makecache'.\n",
                 lStatus,
                 pszFileUrl);

--- a/common/utils.c
+++ b/common/utils.c
@@ -541,7 +541,7 @@ TDNFPathFromUri(
     uint32_t dwError = 0;
     const char* pszPath = NULL;
     char *pszPathTmp = NULL;
-    size_t nOffset;
+    size_t nOffset = 0;
     const char *szProtocols[] = {"http://", "https://", "ftp://",
                                 "ftps://", "file://", NULL};
     int i = 0;

--- a/pytests/tests/test_download_errors.py
+++ b/pytests/tests/test_download_errors.py
@@ -1,0 +1,123 @@
+#
+# Copyright (C) 2026 Broadcom, Inc. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v2 (the "License");
+# you may not use this file except in compliance with the License. The terms
+# of the License are located in the COPYING file of this distribution.
+#
+
+import os
+import shutil
+import pytest
+
+WORKDIR = '/tmp/test_download_errors/workdir'
+BASEDIR = os.path.dirname(WORKDIR)
+REPOFILENAME = 'download_errors.repo'
+REPONAME = 'download-errors-repo'
+
+# A URL that resolves but points to a non-existent path -> HTTP 404
+BAD_HTTP_URL = 'http://localhost:8080/doesntexist'
+# A URL that does not resolve at all -> curl connection error
+BAD_CURL_URL = 'http://localhost:19999/doesntexist'
+# The working test repo URL
+GOOD_HTTP_URL = 'http://localhost:8080/photon-test'
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    os.makedirs(WORKDIR, exist_ok=True)
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    pkgname = utils.config['mulversion_pkgname']
+    utils.erase_package(pkgname)
+    if os.path.isdir(BASEDIR):
+        shutil.rmtree(BASEDIR)
+    repofile = os.path.join(utils.config['repo_path'], 'yum.repos.d', REPOFILENAME)
+    if os.path.isfile(repofile):
+        os.remove(repofile)
+
+
+def repofile_path(utils):
+    return os.path.join(utils.config['repo_path'], 'yum.repos.d', REPOFILENAME)
+
+
+# HTTP 404: error message must contain the full URL and the HTTP status code
+def test_http_error_contains_url(utils):
+    utils.create_repoconf(repofile_path(utils), BAD_HTTP_URL, REPONAME)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', f'--enablerepo={REPONAME}',
+                     'makecache'],
+                    cwd=WORKDIR)
+    assert ret['retval'] != 0
+    stderr = '\n'.join(ret['stderr'])
+    assert BAD_HTTP_URL in stderr
+    assert f'Error: 404 when downloading {BAD_HTTP_URL}' in stderr
+
+
+# curl connection failure: error message must contain the full URL and curl error
+def test_curl_error_contains_url(utils):
+    utils.create_repoconf(repofile_path(utils), BAD_CURL_URL, REPONAME)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', f'--enablerepo={REPONAME}',
+                     'makecache'],
+                    cwd=WORKDIR)
+    assert ret['retval'] != 0
+    stderr = '\n'.join(ret['stderr'])
+    assert BAD_CURL_URL in stderr
+    assert f'Error: failed to download {BAD_CURL_URL}' in stderr
+
+
+# Multi-URL fallback: the failed URL must appear in the warning, and the
+# operation must ultimately succeed using the second (good) URL
+def test_multi_baseurl_fallback_warning_contains_url(utils):
+    baseurls = f'{BAD_HTTP_URL} {GOOD_HTTP_URL}'
+    utils.create_repoconf(repofile_path(utils), baseurls, REPONAME)
+
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', f'--enablerepo={REPONAME}',
+                     'makecache'],
+                    cwd=WORKDIR)
+    assert ret['retval'] == 0
+    stderr = '\n'.join(ret['stderr'])
+    assert BAD_HTTP_URL in stderr
+    assert any(
+        line.startswith(f'Warning: failed to download {BAD_HTTP_URL}') and
+        line.endswith(', trying next base URL')
+        for line in ret['stderr']
+    )
+
+
+# Multi-URL fallback for package download: the failed URL must appear in
+# the warning, and the install must succeed using the second (good) URL
+def test_multi_baseurl_pkg_download_warning_contains_url(utils):
+    pkgname = utils.config['mulversion_pkgname']
+    utils.erase_package(pkgname)
+
+    baseurls = f'{BAD_HTTP_URL} {GOOD_HTTP_URL}'
+    utils.create_repoconf(repofile_path(utils), baseurls, REPONAME)
+
+    # prime the cache with a working URL first
+    ret = utils.run(['tdnf',
+                     '--disablerepo=*', f'--enablerepo={REPONAME}',
+                     '--setopt={}.baseurl={}'.format(REPONAME, GOOD_HTTP_URL),
+                     'makecache'],
+                    cwd=WORKDIR)
+    assert ret['retval'] == 0
+
+    ret = utils.run(['tdnf', '-y', '--nogpgcheck',
+                     '--disablerepo=*', f'--enablerepo={REPONAME}',
+                     'install', pkgname],
+                    cwd=WORKDIR)
+    assert ret['retval'] == 0
+    assert utils.check_package(pkgname)
+    assert BAD_HTTP_URL in '\n'.join(ret['stderr'])
+    assert any(
+        line.startswith(f'Warning: failed to download {BAD_HTTP_URL}') and
+        line.endswith(', trying next base URL')
+        for line in ret['stderr']
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,3 @@
 [flake8]
 exclude=._*
-ignore=E501
+ignore=E501,W504


### PR DESCRIPTION
To better find an issue if downloading fails, print out the complete URL on error.