### PR TITLE
fix segfault when -c /dev/null (empty config file) is used

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -143,6 +143,11 @@ TDNFConfigFromCnfTree(PTDNF_CONF pConf, struct cnfnode *cn_top)
     const char *pszProxyUser = NULL;
     const char *pszProxyPass = NULL;
 
+    if (!cn_top)
+    {
+        goto cleanup;
+    }
+
     for(cn = cn_top->first_child; cn; cn = cn->next)
     {
         if ((cn->name[0] == '.') || (cn->value == NULL))

--- a/pytests/tests/test_config.py
+++ b/pytests/tests/test_config.py
@@ -79,3 +79,10 @@ def test_config_reposdir(utils):
     utils.edit_config({'reposdir': WORKDIR, 'repodir': None}, section='main', filename=TEST_CONF_PATH)
     ret = utils.run(['tdnf', '--config', TEST_CONF_PATH, 'list', pkg])
     assert ret['retval'] == 0
+
+
+def test_config_empty_file(utils):
+    # Using /dev/null simulates an empty config file.
+    # Prior to the fix, this would segfault and return 139.
+    ret = utils.run(['tdnf', '--config', '/dev/null', 'list'])
+    assert ret['retval'] != 139


### PR DESCRIPTION
`tdnf -c /dev/null` would crash with a segmentation fault. Fixing this.