### PR TITLE
remove redundant rpmtsOpenDB() call in history utility

### DIFF
--- a/.github/workflows/vcf.yml
+++ b/.github/workflows/vcf.yml
@@ -44,3 +44,145 @@ jobs:
                   if [[ "${{ github.ref_name }}" == "dev" ]] ; then
                       cd ${HOME}/artifacts/tdnf/ && rm -f dev && ln -fs ${GITHUB_SHA::7} ./dev
                   fi
+
+    cayman_poi:
+        runs-on: self-hosted
+        steps:
+            - name: Checkout Cayman POI
+              uses: actions/checkout@master
+              with:
+                  repository: vcf/cayman-poi
+                  ref: vmware-master
+                  path: ./cayman-poi
+                  submodules: "true"
+                  fetch-depth: 0
+                  ssh-key: ${{ secrets.POI_CICD_SSH_KEY }}
+                  ssh-strict: "false"
+
+            - name: create branch and push
+              run: |
+                  cd ./cayman-poi
+                  BRANCH_NAME="test/tdnf-submodule/${GITHUB_SHA::7}"
+
+                  if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+                      echo "Branch $BRANCH_NAME already exists locally, switching to it"
+                      git checkout "$BRANCH_NAME"
+                  elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH_NAME"; then
+                      echo "Branch $BRANCH_NAME exists remotely, checking it out"
+                      git checkout -b "$BRANCH_NAME" "origin/$BRANCH_NAME"
+                  else
+                      echo "Branch $BRANCH_NAME does not exist, creating it"
+                      git checkout -b "$BRANCH_NAME"
+                  fi
+
+                  pushd poi/tdnf
+
+                  # sometimes the sha is not available yet
+                  git fetch
+
+                  git checkout ${GITHUB_SHA::7}
+                  popd
+
+                  # Enable tdnf submodule
+                  sed -i 's/USE_TDNF_SUBMODULE = False/USE_TDNF_SUBMODULE = True/' poi/poi_defs.py
+
+                  git add poi/tdnf poi/poi_defs.py
+                  git config --global user.email "poi-cicd@broadcom.com"
+                  git config --global user.name "POI CI/CD"
+
+                  # Only commit if there are changes
+                  if git diff --cached --quiet; then
+                      echo "No changes to commit, skipping commit step"
+                  else
+                      git commit -m "update poi/tdnf to ${GITHUB_SHA::7} for testing branch ${{ github.ref_name }}"
+                  fi
+
+                  git push origin "$BRANCH_NAME"
+
+            - name: Wait for and monitor cayman-poi workflow
+              env:
+                  GITHUB_TOKEN: ${{ secrets.PAT_POI_CICD_RO }}
+              run: |
+                  BRANCH_NAME="test/tdnf-submodule/${GITHUB_SHA::7}"
+                  echo "Monitoring branch: $BRANCH_NAME"
+
+                  # Function to get workflow runs for the branch
+                  get_workflow_runs() {
+                      curl -s \
+                          -H "Accept: application/vnd.github+json" \
+                          -H "Authorization: Bearer $GITHUB_TOKEN" \
+                          -H "X-GitHub-Api-Version: 2022-11-28" \
+                          "https://github-vcf.devops.broadcom.net/api/v3/repos/vcf/cayman-poi/actions/runs?branch=$BRANCH_NAME" \
+                          | jq -r '.workflow_runs[] | select(.head_branch == "'$BRANCH_NAME'") | "\(.id) \(.status) \(.conclusion // "null") \(.created_at)"'
+                  }
+
+                  # Wait for workflow to start (up to 5 minutes)
+                  echo "Waiting for workflow to start on branch $BRANCH_NAME..."
+                  timeout=300
+                  interval=30
+                  elapsed=0
+
+                  while [ $elapsed -lt $timeout ]; do
+                      runs=$(get_workflow_runs)
+                      if [ -n "$runs" ]; then
+                          echo "Workflow detected:"
+                          echo "$runs"
+                          break
+                      fi
+                      echo "No workflow found yet, waiting ${interval}s..."
+                      sleep $interval
+                      elapsed=$((elapsed + interval))
+                  done
+
+                  if [ $elapsed -ge $timeout ]; then
+                      echo "ERROR: No workflow was triggered within $timeout seconds"
+                      exit 1
+                  fi
+
+                  # Get the workflow run ID (first field from the output)
+                  run_id=$(echo "$runs" | head -1 | cut -d' ' -f1)
+                  echo "Monitoring workflow run ID: $run_id"
+
+                  # Monitor workflow status (up to 1 hour)
+                  timeout=3600
+                  interval=60
+                  elapsed=0
+
+                  while [ $elapsed -lt $timeout ]; do
+                      run_info=$(curl -s \
+                          -H "Accept: application/vnd.github+json" \
+                          -H "Authorization: Bearer $GITHUB_TOKEN" \
+                          -H "X-GitHub-Api-Version: 2022-11-28" \
+                          "https://github-vcf.devops.broadcom.net/api/v3/repos/vcf/cayman-poi/actions/runs/$run_id")
+
+                      status=$(echo "$run_info" | jq -r '.status')
+                      conclusion=$(echo "$run_info" | jq -r '.conclusion // "null"')
+                      url=$(echo "$run_info" | jq -r '.html_url')
+
+                      echo "Workflow status: $status, conclusion: $conclusion"
+
+                      if [ "$status" = "completed" ]; then
+                          echo "Workflow completed with conclusion: $conclusion"
+                          echo "Workflow URL: $url"
+
+                          if [ "$conclusion" = "success" ]; then
+                              echo "✅ Cayman POI workflow succeeded!"
+                              exit 0
+                          elif [ "$conclusion" = "null" ]; then
+                              echo "❌ Cayman POI workflow completed but conclusion is null"
+                              echo "Check the workflow at: $url"
+                              exit 1
+                          else
+                              echo "❌ Cayman POI workflow failed with conclusion: $conclusion"
+                              echo "Check the workflow at: $url"
+                              exit 1
+                          fi
+                      fi
+
+                      sleep $interval
+                      elapsed=$((elapsed + interval))
+                  done
+
+                  echo "ERROR: Workflow did not complete within $timeout seconds"
+                  echo "Workflow URL: $url"
+                  exit 1

--- a/ci/prep.sh
+++ b/ci/prep.sh
@@ -55,6 +55,25 @@ elif grep -qw "Photon" ${rel_file}; then
     shadow
     zlib-devel
   )
+
+  tdnf-config edit photon-updates enabled=0
+  if [ -f /etc/yum.repos.d/photon-snapshot.repo ] ; then
+    tdnf-config edit photon-snapshot enabled=1
+  else
+     mkdir -p  /etc/tdnf/vars && echo latest > /etc/tdnf/vars/updatenumber && echo 92 > /etc/tdnf/vars/subrelease
+     cat << 'EOF' > /etc/yum.repos.d/photon-snapshot.repo
+[photon-snapshot]
+name=VMware Photon Linux $releasever ($basearch) Snapshot for Updates
+baseurl=https://packages.broadcom.com/photon/$releasever/photon_$releasever_$basearch
+snapshot=https://packages.broadcom.com/photon/$releasever/photon_snapshots_$releasever_$basearch/$subrelease/snapshot-$subrelease-$updatenumber.$basearch.list
+gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096
+gpgcheck=1
+enabled=1
+skip_if_unavailable=1
+skip_md_filelists=1
+EOF
+  fi
+
   tdnf -y upgrade --refresh
   tdnf remove -y toybox
   tdnf -y install --enablerepo=photon-debuginfo ${photon_packages[@]}

--- a/history/main.c
+++ b/history/main.c
@@ -123,10 +123,6 @@ int main(int argc, char *argv[])
         fail(ERR_RPMTS, "could not set rpm root dir\n");
     }
 
-    if(rpmtsOpenDB(ts, O_RDONLY)) {
-        fail(ERR_RPMTS, "could not open rpmdb\n");
-    }
-
     ctx = create_history_ctx(db_file);
     check_ptr(ctx);
 

--- a/tdnf.spec.in
+++ b/tdnf.spec.in
@@ -1,6 +1,4 @@
 %define hist_db_dir     %{_libdir}/sysimage/%{name}
-%define history_db_fn   %{hist_db_dir}/history.db
-%define history_util    %{_libexecdir}/%{name}/%{name}-history-util
 %define _tdnfpluginsdir %{_libdir}/%{name}-plugins
 
 %global automatic_services %{name}-automatic.timer %{name}-automatic-notifyonly.timer %{name}-automatic-install.timer
@@ -155,16 +153,10 @@ pip3 install flake8
 
 %post
 /sbin/ldconfig
+[ -d %{hist_db_dir} ] || mkdir -p %{hist_db_dir}
 
 %postun
 /sbin/ldconfig
-
-%posttrans
-# must be postrans because we read the rpm db
-# cannot use tdnf because that is still running even in postrans
-[ -d %{hist_db_dir} ] || mkdir -p %{hist_db_dir}
-[ -f %{history_db_fn} ] || %{history_util} init
-exit 0
 
 %triggerin -- motd
 [ $2 -eq 1 ] || exit 0


### PR DESCRIPTION
`rpmtsOpenDB` is not needed in `main.c`. Not all sub comands need it,  operations like `init` and `update` will still work perfectly, because the underlying function they call—`history_sync()` in `history/history.c `(line 1502)—already contains its own correct internal call to `rpmtsOpenDB(ts, O_RDONLY)` exactly when it needs it.