### PR TITLE
ensure history db directory exists

### DIFF
--- a/ci/prep.sh
+++ b/ci/prep.sh
@@ -56,25 +56,8 @@ elif grep -qw "Photon" ${rel_file}; then
     zlib-devel
   )
 
-  tdnf-config edit photon-updates enabled=0
-  if [ -f /etc/yum.repos.d/photon-snapshot.repo ] ; then
-    tdnf-config edit photon-snapshot enabled=1
-  else
-     mkdir -p  /etc/tdnf/vars && echo latest > /etc/tdnf/vars/updatenumber && echo 92 > /etc/tdnf/vars/subrelease
-     cat << 'EOF' > /etc/yum.repos.d/photon-snapshot.repo
-[photon-snapshot]
-name=VMware Photon Linux $releasever ($basearch) Snapshot for Updates
-baseurl=https://packages.broadcom.com/photon/$releasever/photon_$releasever_$basearch
-snapshot=https://packages.broadcom.com/photon/$releasever/photon_snapshots_$releasever_$basearch/$subrelease/snapshot-$subrelease-$updatenumber.$basearch.list
-gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY-4096
-gpgcheck=1
-enabled=1
-skip_if_unavailable=1
-skip_md_filelists=1
-EOF
-  fi
-
   tdnf -y upgrade --refresh
   tdnf remove -y toybox
   tdnf -y install --enablerepo=photon-debuginfo ${photon_packages[@]}
 fi
+

--- a/client/rpmtrans.c
+++ b/client/rpmtrans.c
@@ -138,10 +138,23 @@ TDNFRunTransactionWithHistory(
 {
     uint32_t dwError = 0;
     int rc;
+    char *pszDataDir = NULL;
 
     if(!pTdnf || !pTS || !pHistoryCtx)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    dwError = TDNFJoinPath(&pszDataDir,
+                           pTdnf->pArgs->pszInstallRoot,
+                           pTdnf->pConf->pszPersistDir,
+                           NULL);
+    if (dwError == 0 && pszDataDir)
+    {
+        dwError = TDNFUtilsMakeDirs(pszDataDir);
+        if (dwError == ERROR_TDNF_ALREADY_EXISTS)
+            dwError = 0;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
@@ -162,6 +175,7 @@ TDNFRunTransactionWithHistory(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 cleanup:
+    TDNF_SAFE_FREE_MEMORY(pszDataDir);
     return dwError;
 error:
     goto cleanup;

--- a/history/history.c
+++ b/history/history.c
@@ -211,6 +211,9 @@ sqlite3 *init_db(const char *filename)
     sqlite3 *db = NULL;
 
     int rc = sqlite3_open(filename, &db);
+    if (rc == SQLITE_OK) {
+        sqlite3_busy_timeout(db, 5000); // Wait up to 5 seconds
+    }
     check_db_rc(db, rc);
 
 error:
@@ -235,6 +238,7 @@ int db_table_exists(sqlite3 *db, const char *name)
     check_db_rc(db, rc);
 
     rc = sqlite3_step(res);
+    check_db_step(db, rc);
     sqlite3_finalize(res); res = NULL;
 
 error:
@@ -257,6 +261,7 @@ int db_rpms_count(sqlite3 *db, int *pcount)
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
+    check_db_step(db, step);
     if (step == SQLITE_ROW) {
         *pcount = sqlite3_column_int(res, 0);
     }
@@ -282,7 +287,7 @@ int db_maxid(sqlite3 *db, const char *table_name, int *pmaxid)
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
-    check_cond(step == SQLITE_ROW || step == SQLITE_DONE);
+    check_db_step(db, step);
     if (step == SQLITE_ROW) {
         *pmaxid = sqlite3_column_int(res, COLUMN_RPMS_ID);
     } else if (step == SQLITE_DONE) {
@@ -323,6 +328,7 @@ static
 struct history_nevra_map *db_string_map(sqlite3 *db, const char *table_name)
 {
     int rc = 0;
+    int step = 0;
     struct history_nevra_map *hnm = NULL;
     sqlite3_stmt *res = NULL;
     char sql_find[256];
@@ -344,7 +350,7 @@ struct history_nevra_map *db_string_map(sqlite3 *db, const char *table_name)
 
     rc = sqlite3_prepare_v2(db, sql_find, -1, &res, 0);
     check_db_rc(db, rc);
-    for(int step = sqlite3_step(res); step == SQLITE_ROW; step = sqlite3_step(res)) {
+    while ((step = sqlite3_step(res)) == SQLITE_ROW) {
         int id = sqlite3_column_int(res, COLUMN_RPMS_ID);
         nevra = strdup((const char *)sqlite3_column_text(res, COLUMN_RPMS_NEVRA));
         check_ptr(nevra);
@@ -352,6 +358,7 @@ struct history_nevra_map *db_string_map(sqlite3 *db, const char *table_name)
         /* map is zero based, rpm ids start with 1 */
         hnm->idmap[id - 1] = nevra;
     }
+    check_db_step(db, step);
 error:
     if (res)
         sqlite3_finalize(res);
@@ -375,6 +382,7 @@ int db_get_dict_entry(sqlite3 *db,
                       int create)
 {
     int rc = 0, step;
+    int id = 0;
     sqlite3_stmt *res = NULL;
     char sql[256];
 
@@ -387,8 +395,9 @@ int db_get_dict_entry(sqlite3 *db,
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
+    check_db_step(db, step);
     if (step == SQLITE_ROW) {
-        int id = sqlite3_column_int(res, COLUMN_RPMS_ID);
+        id = sqlite3_column_int(res, COLUMN_RPMS_ID);
         if (pid)
             *pid = id;
         sqlite3_finalize(res);
@@ -411,11 +420,12 @@ int db_get_dict_entry(sqlite3 *db,
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
-    if (step == SQLITE_DONE) {
-        int id = sqlite3_last_insert_rowid(db);
-        if (pid)
-            *pid = id;
-    }
+    check_db_step(db, step);
+    check_cond(step == SQLITE_DONE);
+
+    id = sqlite3_last_insert_rowid(db);
+    if (pid)
+        *pid = id;
 
 error:
     if (res)
@@ -437,7 +447,7 @@ int db_add_nevra(sqlite3 *db, const char *nevra, int *pid)
 static
 int history_delta_read(sqlite3 *db, struct history_delta *hd, int id)
 {
-    int rc = 0;
+    int rc = 0, step = 0;
     sqlite3_stmt *res = NULL;
     const char *sql = "SELECT * FROM trans_items WHERE trans_id = ? ORDER BY rpm_id;";
     int max_count = 0;
@@ -460,7 +470,7 @@ int history_delta_read(sqlite3 *db, struct history_delta *hd, int id)
     rc = sqlite3_bind_int(res, 1, id);
     check_db_rc(db, rc);
 
-    for(int step = sqlite3_step(res); step == SQLITE_ROW; step = sqlite3_step(res)) {
+    while ((step = sqlite3_step(res)) == SQLITE_ROW) {
         int type = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_TYPE);
         int rpm_id = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_RPM_ID);
         if (type == HISTORY_ITEM_TYPE_ADD || type == HISTORY_ITEM_TYPE_SET) {
@@ -472,6 +482,7 @@ int history_delta_read(sqlite3 *db, struct history_delta *hd, int id)
             hd->removed_ids[hd->removed_count++] = rpm_id;
         }
     }
+    check_db_step(db, step);
 
 error:
     if (res)
@@ -484,7 +495,7 @@ static
 int db_play_delta(sqlite3 *db, int trans_id,
                   char *installed_map, int map_size)
 {
-    int rc = 0;
+    int rc = 0, step = 0;
     sqlite3_stmt *res = NULL;
     const char *sql = "SELECT * FROM trans_items WHERE trans_id = ? ORDER BY rpm_id;";
 
@@ -494,10 +505,12 @@ int db_play_delta(sqlite3 *db, int trans_id,
     rc = sqlite3_bind_int(res, 1, trans_id);
     check_db_rc(db, rc);
 
-    for(int step = sqlite3_step(res); step == SQLITE_ROW; step = sqlite3_step(res)) {
+    while ((step = sqlite3_step(res)) == SQLITE_ROW) {
         int type = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_TYPE);
         int rpm_id = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_RPM_ID);
-        check_cond(rpm_id > 0 && rpm_id <= map_size);
+        if (rpm_id <= 0 || rpm_id > map_size) {
+            continue;
+        }
         check_cond(type == HISTORY_ITEM_TYPE_ADD || type == HISTORY_ITEM_TYPE_REMOVE);
         if (type == HISTORY_ITEM_TYPE_ADD) {
             map_set(installed_map, rpm_id);
@@ -506,6 +519,7 @@ int db_play_delta(sqlite3 *db, int trans_id,
             map_unset(installed_map, rpm_id);
         }
     }
+    check_db_step(db, step);
 
 error:
     if (res)
@@ -518,7 +532,7 @@ static
 int db_play_set(sqlite3 *db, int trans_id,
                 char *installed_map, int map_size)
 {
-    int rc = 0;
+    int rc = 0, step = 0;
     sqlite3_stmt *res = NULL;
     const char *sql = "SELECT * FROM trans_items "
         "WHERE trans_id = ? ORDER BY rpm_id;";
@@ -529,13 +543,16 @@ int db_play_set(sqlite3 *db, int trans_id,
     rc = sqlite3_bind_int(res, 1, trans_id);
     check_db_rc(db, rc);
 
-    for(int step = sqlite3_step(res); step == SQLITE_ROW; step = sqlite3_step(res)) {
+    while ((step = sqlite3_step(res)) == SQLITE_ROW) {
         int type = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_TYPE);
         int rpm_id = sqlite3_column_int(res, COLUMN_TRANS_ITEMS_RPM_ID);
-        check_cond(rpm_id > 0 && rpm_id <= map_size);
+        if (rpm_id <= 0 || rpm_id > map_size) {
+            continue;
+        }
         check_cond(type == HISTORY_ITEM_TYPE_SET);
         map_set(installed_map, rpm_id);
     }
+    check_db_step(db, step);
 
 error:
     if (res)
@@ -790,6 +807,7 @@ int db_get_auto_flag_byid(sqlite3 *db, int trans_id, int name_id, int *pvalue)
     check_db_rc(db, rc);
 
     step = sqlite3_step(res);
+    check_db_step(db, step);
 
     if (step == SQLITE_ROW) { /* found */
         *pvalue = sqlite3_column_int(res, COLUMN_FLAG_SET_VALUE);
@@ -1358,9 +1376,8 @@ int history_get_transactions(struct history_ctx *ctx,
     tas = (struct history_transaction *)calloc(count, sizeof(struct history_transaction));
     check_ptr(tas);
 
-    for (i = 0, step = sqlite3_step(res);
-         step == SQLITE_ROW;
-         step = sqlite3_step(res), i++) {
+    i = 0;
+    while ((step = sqlite3_step(res)) == SQLITE_ROW) {
         const char *cookie;
         const char *cmdline;
         check_cond(i >= 0 && i < count);
@@ -1375,7 +1392,9 @@ int history_get_transactions(struct history_ctx *ctx,
 
         tas[i].timestamp = sqlite3_column_int(res, COLUMN_TRANSACTIONS_TIMESTAMP);
         tas[i].type = sqlite3_column_int(res, COLUMN_TRANSACTIONS_TYPE);
+        i++;
     }
+    check_db_step(ctx->db, step);
     count = i;
 
     for (i = 0; i < count; i++) {
@@ -1513,6 +1532,7 @@ int history_sync(struct history_ctx *ctx, rpmts ts)
         check_db_rc(ctx->db, rc);
 
         step = sqlite3_step(res);
+        check_db_step(ctx->db, step);
         if (step == SQLITE_ROW) {
             int id = sqlite3_column_int(res, COLUMN_TRANSACTIONS_ID);
             const char *cookie_db = (char *)sqlite3_column_text(res, 1);
@@ -1591,6 +1611,7 @@ struct history_ctx *create_history_ctx(const char *db_filename)
         check_db_rc(ctx->db, rc);
 
         step = sqlite3_step(res);
+        check_db_step(ctx->db, step);
         if (step == SQLITE_ROW) {
             const char *cookie = (char *)sqlite3_column_text(res, COLUMN_TRANSACTIONS_COOKIE);
             if (cookie)

--- a/llconf/nodes.c
+++ b/llconf/nodes.c
@@ -53,7 +53,7 @@ struct cnfnode *
 create_cnfnode_keyval(const char *keyval)
 {
     struct cnfnode *cn = NULL;
-    char *psep;
+    const char *psep;
 
     psep = strstr(keyval, "=");
     if (psep) {

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -401,9 +401,9 @@ def check_packages_consistency(utils, request):
     Automatically runs before and after every test.
     Verifies that the set of installed packages remains unchanged.
     """
-    baseline = utils.list_installed_packages()
+    baseline = [p for p in utils.list_installed_packages() if not p.startswith('gpg-pubkey')]
     yield
-    final = utils.list_installed_packages()
+    final = [p for p in utils.list_installed_packages() if not p.startswith('gpg-pubkey')]
     if set(final) != set(baseline):
         __tracebackhide__ = True
         added = sorted(set(final) - set(baseline))

--- a/pytests/repo/setup-repo.sh
+++ b/pytests/repo/setup-repo.sh
@@ -84,6 +84,7 @@ check_err "Failed to generate gpg key."
 cat << EOF > ~/.rpmmacros
 %_gpg_name tdnftest@tdnf.test
 %__gpg /usr/bin/gpg
+%__transaction_unshare %{nil}
 EOF
 
 

--- a/pytests/tests/test_signature.py
+++ b/pytests/tests/test_signature.py
@@ -33,7 +33,9 @@ def setup_test_function(utils):
         original_gpg_keys = get_host_gpg_keys(utils)
 
     new_gpg_key = get_host_gpg_keys(utils)
-    new_gpg_key = list(set(new_gpg_key) - set(original_gpg_keys))
+    new_gpg_key = [k for k in set(new_gpg_key) - set(original_gpg_keys) if not any(
+        k.split('-')[2].endswith(orig.split('-')[2]) or orig.split('-')[2].endswith(k.split('-')[2])
+        for orig in original_gpg_keys)]
     for key in new_gpg_key:
         ret = utils._run(f"rpm -ev {key}")
         assert ret['retval'] == 0
@@ -49,7 +51,9 @@ def teardown_test(utils):
     set_gpgcheck(utils, False, None)
 
     new_gpg_key = get_host_gpg_keys(utils)
-    new_gpg_key = list(set(new_gpg_key) - set(original_gpg_keys))
+    new_gpg_key = [k for k in set(new_gpg_key) - set(original_gpg_keys) if not any(
+        k.split('-')[2].endswith(orig.split('-')[2]) or orig.split('-')[2].endswith(k.split('-')[2])
+        for orig in original_gpg_keys)]
     for key in new_gpg_key:
         ret = utils._run(f"rpm -ev {key}")
         assert ret['retval'] == 0

--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1856,7 +1856,7 @@ check_for_providers(
     char *prv_pkgname
     )
 {
-    char *beg;
+    const char *beg;
     const char *end = NULL;
     uint32_t dwError = 0;
     char pkgname[256] = {0};


### PR DESCRIPTION
* ensure that the history db directory exists, to avoid failures
* Check for history db errors: the db may have been busy, and the error SQLITE_BUSY wasn't checked.
This lead to invalid entries written to the db, and this caused errors leter when read back.
This change also skips over these invalid entries, and adds a busy timeout (500 seconds),
to wait when busy instead of exting with SQLITE_BUSY immediately.
* fix a few test issues
* Fedora gcc showed a few warnings, also fixed.
