### PR TITLE
ignore history absent error if a package is already installed

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -2022,7 +2022,6 @@ TDNFHistoryResolve(
     PTDNF_SOLVED_PKG_INFO *ppSolvedPkgInfo)
 {
     uint32_t dwError = 0;
-    int rc = 0;
     char **ppszPkgsNotResolved = NULL;
     Queue queueGoal = {0};
     PTDNF_SOLVED_PKG_INFO pSolvedPkgInfo = NULL;
@@ -2030,7 +2029,6 @@ TDNFHistoryResolve(
     struct history_delta *hd = NULL;
     struct history_flags_delta *hfd = NULL;
     struct history_nevra_map *hnm = NULL;
-    rpmts ts = NULL;
     Queue qInstall = {0};
     Queue qErase = {0};
 
@@ -2071,35 +2069,12 @@ TDNFHistoryResolve(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    ts = rpmtsCreate();
-    if(!ts)
-    {
-        dwError = ERROR_TDNF_RPMTS_CREATE_FAILED;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    if (rpmtsOpenDB(ts, O_RDONLY))
-    {
-        dwError = ERROR_TDNF_RPMTS_OPENDB_FAILED;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
-    if(rpmtsSetRootDir(ts, pTdnf->pArgs->pszInstallRoot))
-    {
-        dwError = ERROR_TDNF_RPMTS_BAD_ROOT_DIR;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
-
     dwError = TDNFGetHistoryCtx(pTdnf, &ctx,
                                 pHistoryArgs->nCommand != HISTORY_CMD_INIT);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    rc = history_sync(ctx, ts);
-    if (rc != 0)
-    {
-        dwError = ERROR_TDNF_HISTORY_ERROR;
-        BAIL_ON_TDNF_ERROR(dwError);
-    }
+    dwError = TDNFHistorySyncState(pTdnf, ctx);
+    BAIL_ON_TDNF_ERROR(dwError);
 
     switch (pHistoryArgs->nCommand)
     {
@@ -2255,10 +2230,6 @@ cleanup:
     queue_free(&queueGoal);
     queue_free(&qInstall);
     queue_free(&qErase);
-    if (ts) {
-        rpmtsCloseDB(ts);
-        rpmtsFree(ts);
-    }
     return dwError;
 
 error:

--- a/client/goal.c
+++ b/client/goal.c
@@ -262,6 +262,11 @@ TDNFAddUserInstalledToJobs(
     }
 
     dwError = TDNFGetHistoryCtx(pTdnf, &pHistoryCtx, 1);
+    if (dwError == ERROR_TDNF_HISTORY_NODB)
+    {
+        dwError = 0;
+        goto cleanup;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = SolvAddUserInstalledToJobs(pQueueJobs,
@@ -541,9 +546,8 @@ TDNFGoal(
         nAlterType == ALTER_AUTOERASEALL;
     if(nAllowErasing)
     {
-        TDNFAddUserInstalledToJobs(pTdnf, &queueJobs);
+        dwError = TDNFAddUserInstalledToJobs(pTdnf, &queueJobs);
         BAIL_ON_TDNF_ERROR(dwError);
-        /* TODO: deal with no db error? */
     }
 
     dwError = TDNFSolv(pTdnf, &queueJobs, ppszExcludes, dwExcludeCount,
@@ -686,6 +690,11 @@ TDNFMarkAutoInstalledSinglePkg(
     }
 
     dwError = TDNFGetHistoryCtx(pTdnf, &pHistoryCtx, 1);
+    if (dwError == ERROR_TDNF_HISTORY_NODB)
+    {
+        dwError = 0;
+        goto cleanup;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     rc = history_set_auto_flag(pHistoryCtx, pszPkgName, 0);

--- a/client/history.c
+++ b/client/history.c
@@ -9,6 +9,54 @@
 #include "includes.h"
 
 uint32_t
+TDNFHistorySyncState(
+    PTDNF pTdnf,
+    struct history_ctx *ctx
+)
+{
+    uint32_t dwError = 0;
+    rpmts ts = NULL;
+    int rc = 0;
+
+    ts = rpmtsCreate();
+    if(!ts)
+    {
+        dwError = ERROR_TDNF_RPMTS_CREATE_FAILED;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if (rpmtsOpenDB(ts, O_RDONLY))
+    {
+        dwError = ERROR_TDNF_RPMTS_OPENDB_FAILED;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    if(rpmtsSetRootDir(ts, pTdnf->pArgs->pszInstallRoot))
+    {
+        dwError = ERROR_TDNF_RPMTS_BAD_ROOT_DIR;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+    rc = history_sync(ctx, ts);
+    if (rc != 0)
+    {
+        dwError = ERROR_TDNF_HISTORY_ERROR;
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+
+cleanup:
+    if (ts)
+    {
+        rpmtsCloseDB(ts);
+        rpmtsFree(ts);
+    }
+    return dwError;
+
+error:
+    goto cleanup;
+}
+
+uint32_t
 TDNFGetHistoryCtx(
     PTDNF pTdnf,
     struct history_ctx **ppCtx,
@@ -19,6 +67,7 @@ TDNFGetHistoryCtx(
     char *pszDataDir = NULL;
     char *pszHistoryDb = NULL;
     struct history_ctx *ctx = NULL;
+    int nExists = 0;
 
     if(!pTdnf || !ppCtx)
     {
@@ -38,16 +87,14 @@ TDNFGetHistoryCtx(
             NULL);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    if (nMustExist)
+    nExists = 0;
+    dwError = TDNFIsFileOrSymlink(pszHistoryDb, &nExists);
+    BAIL_ON_TDNF_ERROR(dwError);
+
+    if (nMustExist && !nExists)
     {
-        int nExists = 0;
-        dwError = TDNFIsFileOrSymlink(pszHistoryDb, &nExists);
+        dwError = ERROR_TDNF_HISTORY_NODB;
         BAIL_ON_TDNF_ERROR(dwError);
-        if (!nExists)
-        {
-            dwError = ERROR_TDNF_HISTORY_NODB;
-            BAIL_ON_TDNF_ERROR(dwError);
-        }
     }
 
     dwError = TDNFUtilsMakeDirs(pszDataDir);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -1019,6 +1019,12 @@ TDNFListInternal(
     );
 
 uint32_t
+TDNFHistorySyncState(
+    PTDNF pTdnf,
+    struct history_ctx *ctx
+);
+
+uint32_t
 TDNFGetHistoryCtx(
     PTDNF pTdnf,
     struct history_ctx **ppCtx,

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -276,6 +276,11 @@ TDNFGetAutoInstalledOrphans(
     pSack = pTdnf->pSack;
 
     dwError = TDNFGetHistoryCtx(pTdnf, &pHistoryCtx, 1);
+    if (dwError == ERROR_TDNF_HISTORY_NODB)
+    {
+        dwError = 0;
+        goto cleanup;
+    }
     BAIL_ON_TDNF_ERROR(dwError);
 
     dwError = SolvGetAutoInstalledOrphans(pSack, pHistoryCtx, pQueueGoal);

--- a/pytests/tests/test_installroot.py
+++ b/pytests/tests/test_installroot.py
@@ -104,6 +104,38 @@ def test_install(utils):
     shutil.rmtree(INSTALLROOT)
 
 
+def test_install_already_installed_no_history_db(utils):
+    install_root(utils)
+    pkgname = utils.config["mulversion_pkgname"]
+    erase_package(utils, pkgname)
+
+    # 1. Install the package
+    ret = utils.run(['tdnf', 'install',
+                     '-y', '--nogpgcheck',
+                     '--installroot', INSTALLROOT,
+                     '--releasever=4.0', pkgname], noconfig=True)
+    assert ret['retval'] == 0
+    assert check_package(utils, pkgname)
+
+    # 2. Delete the history database
+    hist_db = os.path.join(INSTALLROOT, 'var/lib/tdnf/history.db')
+    if os.path.exists(hist_db):
+        os.remove(hist_db)
+
+    # 3. Try to install the same package again
+    ret = utils.run(['tdnf', 'install',
+                     '-y', '--nogpgcheck',
+                     '--installroot', INSTALLROOT,
+                     '--releasever=4.0', pkgname], noconfig=True)
+
+    # 4. It should succeed and say "already installed"
+    assert ret['retval'] == 0
+    output_str = "\n".join(ret['stdout'] + ret['stderr']).lower()
+    assert "already installed" in output_str
+
+    shutil.rmtree(INSTALLROOT)
+
+
 def test_makecache(utils):
     install_root(utils)
     ret = utils.run(['tdnf', 'makecache',


### PR DESCRIPTION
## Summary
Fixes an issue where package operations fail with `Error(1802) : History database does not exist` in fresh environments (like Docker containers) where the history database hasn't been created yet.

## Details
When running commands like `tdnf install <pkg>` where the package is already installed, `tdnf` attempts to mark the package as user-installed. Previously, this would fail if the history database was missing. 

This change gracefully handles a missing history database by catching and ignoring `ERROR_TDNF_HISTORY_NODB` in non-critical paths where it is acceptable for the database to be absent:
* `TDNFMarkAutoInstalledSinglePkg`
* `TDNFAddUserInstalledToJobs`
* `TDNFGetAutoInstalledOrphans`

Since packages are considered user-installed by default, a missing history database shouldn't block these operations.