### PR TITLE
global SSL configuration inheritance and SSL_CERT_FILE environment variable

### DIFF
--- a/ci/prep.sh
+++ b/ci/prep.sh
@@ -37,6 +37,7 @@ if grep -qw "Fedora" ${rel_file}; then
     glib2-devel
     libcurl-devel
     make
+    openssl
     python3-flake8
     rpm-devel
     rpm-sign

--- a/client/api.c
+++ b/client/api.c
@@ -2579,7 +2579,7 @@ TDNFCloseHandle(
     {
         if(pTdnf->pRepos)
         {
-            TDNFFreeReposInternal(pTdnf->pRepos);
+            TDNFFreeRepos(pTdnf->pRepos);
         }
         if(pTdnf->pConf)
         {

--- a/client/config.c
+++ b/client/config.c
@@ -177,6 +177,18 @@ TDNFConfigFromCnfTree(PTDNF_CONF pConf, struct cnfnode *cn_top)
         {
             pConf->nSSLVerify = isTrue(cn->value);
         }
+        else if (strcmp(cn->name, TDNF_CONF_KEY_SSL_CA_CERT) == 0)
+        {
+            SET_STRING(pConf->pszSSLCaCert, cn->value);
+        }
+        else if (strcmp(cn->name, TDNF_CONF_KEY_SSL_CLI_CERT) == 0)
+        {
+            SET_STRING(pConf->pszSSLClientCert, cn->value);
+        }
+        else if (strcmp(cn->name, TDNF_CONF_KEY_SSL_CLI_KEY) == 0)
+        {
+            SET_STRING(pConf->pszSSLClientKey, cn->value);
+        }
         else if (strcmp(cn->name, TDNF_CONF_KEY_KEEP_CACHE) == 0)
         {
             pConf->nKeepCache = isTrue(cn->value);
@@ -604,6 +616,9 @@ TDNFFreeConfig(
         TDNF_SAFE_FREE_MEMORY(pConf->pszRepoDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszCacheDir);
         TDNF_SAFE_FREE_MEMORY(pConf->pszPersistDir);
+        TDNF_SAFE_FREE_MEMORY(pConf->pszSSLCaCert);
+        TDNF_SAFE_FREE_MEMORY(pConf->pszSSLClientCert);
+        TDNF_SAFE_FREE_MEMORY(pConf->pszSSLClientKey);
         TDNF_SAFE_FREE_STRINGARRAY(pConf->ppszDistroVerPkgs);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarReleaseVer);
         TDNF_SAFE_FREE_MEMORY(pConf->pszVarBaseArch);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -713,11 +713,6 @@ TDNFCloneRepo(
     PTDNF_REPO_DATA* ppRepo
     );
 
-void
-TDNFFreeReposInternal(
-    PTDNF_REPO_DATA pRepos
-    );
-
 //resolve.c
 uint32_t
 TDNFPrepareAllPackages(

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -316,7 +316,7 @@ error:
     }
     if(pReposAll)
     {
-        TDNFFreeReposInternal(pReposAll);
+        TDNFFreeRepos(pReposAll);
     }
     goto cleanup;
 }
@@ -352,7 +352,7 @@ cleanup:
 error:
     if(pRepo)
     {
-        TDNFFreeReposInternal(pRepo);
+        TDNFFreeRepos(pRepo);
     }
     goto cleanup;
 }
@@ -416,7 +416,7 @@ error:
     }
     if(pRepo)
     {
-        TDNFFreeReposInternal(pRepo);
+        TDNFFreeRepos(pRepo);
     }
     goto cleanup;
 }
@@ -488,7 +488,7 @@ error:
     }
     if(pRepo)
     {
-        TDNFFreeReposInternal(pRepo);
+        TDNFFreeRepos(pRepo);
     }
     goto cleanup;
 }
@@ -559,7 +559,7 @@ error:
     }
     if(pRepo)
     {
-        TDNFFreeReposInternal(pRepo);
+        TDNFFreeRepos(pRepo);
     }
     goto cleanup;
 }
@@ -719,7 +719,7 @@ error:
     TDNF_SAFE_FREE_MEMORY(pRepo);
     if(pRepos)
     {
-        TDNFFreeReposInternal(pRepos);
+        TDNFFreeRepos(pRepos);
     }
     goto cleanup;
 }
@@ -961,30 +961,3 @@ error:
     goto cleanup;
 }
 
-void
-TDNFFreeReposInternal(
-    PTDNF_REPO_DATA pRepos
-    )
-{
-    PTDNF_REPO_DATA pRepo = NULL;
-    while(pRepos)
-    {
-        pRepo = pRepos;
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszId);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszName);
-        TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszBaseUrls);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszMetaLink);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotUrl);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotFile);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLCaCert);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientCert);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientKey);
-        TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszUser);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszPass);
-        TDNF_SAFE_FREE_MEMORY(pRepo->pszCacheName);
-        pRepos = pRepo->pNext;
-        TDNF_SAFE_FREE_MEMORY(pRepo);
-    }
-}

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -504,7 +504,7 @@ TDNFCreateRepo(
     uint32_t dwError = 0;
     PTDNF_REPO_DATA pRepo = NULL;
 
-    if(!pTdnf || !pTdnf->pArgs || !ppRepo || !pszId)
+    if(!pTdnf || !pTdnf->pArgs || !pTdnf->pConf || !ppRepo || !pszId)
     {
         dwError = ERROR_TDNF_INVALID_PARAMETER;
         BAIL_ON_TDNF_ERROR(dwError);
@@ -524,6 +524,21 @@ TDNFCreateRepo(
     pRepo->nSkipIfUnavailable = TDNF_REPO_DEFAULT_SKIP;
     pRepo->nGPGCheck = pTdnf->pConf->nGPGCheck;
     pRepo->nSSLVerify = pTdnf->pConf->nSSLVerify;
+    if (pTdnf->pConf->pszSSLCaCert)
+    {
+        dwError = TDNFSafeAllocateString(pTdnf->pConf->pszSSLCaCert, &pRepo->pszSSLCaCert);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    if (pTdnf->pConf->pszSSLClientCert)
+    {
+        dwError = TDNFSafeAllocateString(pTdnf->pConf->pszSSLClientCert, &pRepo->pszSSLClientCert);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
+    if (pTdnf->pConf->pszSSLClientKey)
+    {
+        dwError = TDNFSafeAllocateString(pTdnf->pConf->pszSSLClientKey, &pRepo->pszSSLClientKey);
+        BAIL_ON_TDNF_ERROR(dwError);
+    }
     pRepo->lMetadataExpire = TDNF_REPO_DEFAULT_METADATA_EXPIRE;
     pRepo->nPriority = TDNF_REPO_DEFAULT_PRIORITY;
     pRepo->nTimeout = TDNF_REPO_DEFAULT_TIMEOUT;
@@ -960,6 +975,11 @@ TDNFFreeReposInternal(
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszBaseUrls);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMetaLink);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotUrl);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotFile);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLCaCert);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientCert);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientKey);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszUser);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszPass);

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -289,6 +289,16 @@ TDNFLoadRepoData(
         }
     }
 
+    /* Apply SSL_CERT_FILE environment variable, unless overridden by global setopt */
+    if (getenv("SSL_CERT_FILE") &&
+        (!pTdnf->pArgs->cn_setopts || !find_child(pTdnf->pArgs->cn_setopts, TDNF_CONF_KEY_SSL_CA_CERT))) {
+        for (pRepo = pReposAll; pRepo; pRepo = pRepo->pNext) {
+            TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLCaCert);
+            dwError = TDNFSafeAllocateString(getenv("SSL_CERT_FILE"), &pRepo->pszSSLCaCert);
+            BAIL_ON_TDNF_ERROR(dwError);
+        }
+    }
+
     /* look for setopt settings */
     if (pTdnf->pArgs->cn_repoopts != NULL) {
         for (pRepo = pReposAll; pRepo; pRepo = pRepo->pNext) {

--- a/common/config.h
+++ b/common/config.h
@@ -48,6 +48,9 @@
 #define TDNF_CONF_KEY_PLUGIN_PATH         "pluginpath"
 #define TDNF_CONF_KEY_PLUGIN_CONF_PATH    "pluginconfpath"
 #define TDNF_CONF_KEY_SSL_VERIFY          "sslverify"
+#define TDNF_CONF_KEY_SSL_CA_CERT         "sslcacert"
+#define TDNF_CONF_KEY_SSL_CLI_CERT        "sslclientcert"
+#define TDNF_CONF_KEY_SSL_CLI_KEY         "sslclientkey"
 #define TDNF_PLUGIN_CONF_KEY_ENABLED      "enabled"
 #define TDNF_CONF_KEY_TSFLAGS             "tsflags"
 #define TDNF_CONF_KEY_EXCLUDE             "excludepkgs"
@@ -78,9 +81,9 @@
 #define TDNF_REPO_KEY_MINRATE             "minrate"
 #define TDNF_REPO_KEY_THROTTLE            "throttle"
 #define TDNF_REPO_KEY_SSL_VERIFY          TDNF_CONF_KEY_SSL_VERIFY
-#define TDNF_REPO_KEY_SSL_CA_CERT         "sslcacert"
-#define TDNF_REPO_KEY_SSL_CLI_CERT        "sslclientcert"
-#define TDNF_REPO_KEY_SSL_CLI_KEY         "sslclientkey"
+#define TDNF_REPO_KEY_SSL_CA_CERT         TDNF_CONF_KEY_SSL_CA_CERT
+#define TDNF_REPO_KEY_SSL_CLI_CERT        TDNF_CONF_KEY_SSL_CLI_CERT
+#define TDNF_REPO_KEY_SSL_CLI_KEY         TDNF_CONF_KEY_SSL_CLI_KEY
 #define TDNF_REPO_KEY_SKIP_MD_FILELISTS   "skip_md_filelists"
 #define TDNF_REPO_KEY_SKIP_MD_UPDATEINFO  "skip_md_updateinfo"
 #define TDNF_REPO_KEY_SKIP_MD_OTHER       "skip_md_other"

--- a/common/utils.c
+++ b/common/utils.c
@@ -441,7 +441,13 @@ TDNFFreeRepos(
         TDNF_SAFE_FREE_MEMORY(pRepo->pszMirrorList);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotUrl);
         TDNF_SAFE_FREE_MEMORY(pRepo->pszSnapshotFile);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLCaCert);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientCert);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszSSLClientKey);
         TDNF_SAFE_FREE_STRINGARRAY(pRepo->ppszUrlGPGKeys);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszUser);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszPass);
+        TDNF_SAFE_FREE_MEMORY(pRepo->pszCacheName);
 
         pRepos = pRepo->pNext;
         TDNF_SAFE_FREE_MEMORY(pRepo);

--- a/include/tdnftypes.h
+++ b/include/tdnftypes.h
@@ -259,6 +259,9 @@ typedef struct _TDNF_CONF
     int nGPGCheck;
     int nCliGPGCheck;
     int nSSLVerify;
+    char* pszSSLCaCert;
+    char* pszSSLClientCert;
+    char* pszSSLClientKey;
     int nInstallOnlyLimit;
     int nCleanRequirementsOnRemove;
     int nKeepCache;

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -295,20 +295,21 @@ class TestUtils(object):
                         '--error-exitcode=1']
         return self._run(memcheck_cmd + cmd, retvalonly=True)
 
-    def run(self, cmd, cwd=None, noconfig=False):
+    def run(self, cmd, cwd=None, noconfig=False, env=None):
         if isinstance(cmd, str):
             cmd = cmd.split()
         self._decorate_tdnf_cmd_for_test(cmd, noconfig)
-        return self._run(cmd, cwd=cwd)
+        return self._run(cmd, cwd=cwd, env=env)
 
-    def _run(self, cmd, retvalonly=False, cwd=None):
+    def _run(self, cmd, retvalonly=False, cwd=None, env=None):
         use_shell = not isinstance(cmd, list)
         print(cmd)
         process = subprocess.Popen(cmd, shell=use_shell,
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE,
                                    stdin=subprocess.DEVNULL,
-                                   cwd=cwd)
+                                   cwd=cwd,
+                                   env=env)
         out, err = process.communicate()
         if retvalonly:
             return {'retval': process.returncode}

--- a/pytests/tests/test_ssl_config.py
+++ b/pytests/tests/test_ssl_config.py
@@ -1,0 +1,130 @@
+import os
+import pytest
+import shutil
+import threading
+import time
+import http.server
+import ssl
+
+WORKDIR = '/root/test_ssl_config'
+TEST_CONF_FILE = 'tdnf.conf'
+TEST_REPO = 'test-ssl'
+TEST_REPO_FILE = TEST_REPO + '.repo'
+TEST_CONF_PATH = os.path.join(WORKDIR, TEST_CONF_FILE)
+TEST_REPO_PATH = os.path.join(WORKDIR, TEST_REPO_FILE)
+
+GOOD_CERT_PATH = os.path.join(WORKDIR, 'server.crt')
+GOOD_KEY_PATH = os.path.join(WORKDIR, 'server.key')
+BAD_CERT_PATH = os.path.join(WORKDIR, 'bad.crt')
+BAD_KEY_PATH = os.path.join(WORKDIR, 'bad.key')
+
+
+class QuietHandler(http.server.SimpleHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass
+
+
+def run_server():
+    server_address = ('localhost', 8443)
+    httpd = http.server.HTTPServer(server_address, QuietHandler)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.minimum_version = ssl.TLSVersion.TLSv1_2
+    context.load_cert_chain(certfile=GOOD_CERT_PATH, keyfile=GOOD_KEY_PATH)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+    httpd.serve_forever()
+
+
+@pytest.fixture(scope='module', autouse=True)
+def setup_test(utils):
+    os.makedirs(WORKDIR, exist_ok=True)
+
+    # Generate certificates
+    utils.run(["openssl", "genrsa", "-out", GOOD_KEY_PATH, "2048"])
+    utils.run(["openssl", "req", "-new", "-x509", "-key", GOOD_KEY_PATH, "-out", GOOD_CERT_PATH, "-days", "365", "-subj", "/CN=localhost"])
+
+    utils.run(["openssl", "genrsa", "-out", BAD_KEY_PATH, "2048"])
+    utils.run(["openssl", "req", "-new", "-x509", "-key", BAD_KEY_PATH, "-out", BAD_CERT_PATH, "-days", "365", "-subj", "/CN=badhost"])
+
+    # Start HTTPS server
+    server_thread = threading.Thread(target=run_server, daemon=True)
+    server_thread.start()
+    time.sleep(1)
+
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    if os.path.isdir(WORKDIR):
+        shutil.rmtree(WORKDIR)
+
+
+def run_tdnf_test(utils, global_cert=None, repo_cert=None, env_cert=None, setopt_cert=None):
+    # Setup config
+    with open(TEST_CONF_PATH, "w") as f:
+        f.write("[main]\n")
+        f.write("gpgcheck=0\n")
+        f.write(f"reposdir={WORKDIR}\n")
+        f.write(f"cachedir={WORKDIR}/cache\n")
+        if global_cert:
+            f.write(f"sslcacert={global_cert}\n")
+
+    with open(TEST_REPO_PATH, "w") as f:
+        f.write(f"[{TEST_REPO}]\n")
+        f.write("name=Test Repo\n")
+        f.write("baseurl=https://localhost:8443\n")
+        f.write("sslverify=1\n")
+        f.write("skip_if_unavailable=0\n")
+        f.write("enabled=1\n")
+        if repo_cert:
+            f.write(f"sslcacert={repo_cert}\n")
+
+    cmd = ['tdnf', '--config', TEST_CONF_PATH, '--refresh']
+    if setopt_cert:
+        cmd.append(f'--setopt=sslcacert={setopt_cert}')
+    cmd.append('makecache')
+
+    env = os.environ.copy()
+    if env_cert:
+        env['SSL_CERT_FILE'] = env_cert
+    elif 'SSL_CERT_FILE' in env:
+        del env['SSL_CERT_FILE']
+
+    return utils.run(cmd, env=env)
+
+
+def test_ssl_inherit_global(utils):
+    ret = run_tdnf_test(utils, global_cert=GOOD_CERT_PATH)
+    # Should get 404 because repo is empty, but SSL succeeds
+    assert ret['retval'] != 0
+    assert '404' in ''.join(ret['stderr'])
+
+
+def test_ssl_override_global_with_good(utils):
+    ret = run_tdnf_test(utils, global_cert=BAD_CERT_PATH, repo_cert=GOOD_CERT_PATH)
+    assert ret['retval'] != 0
+    assert '404' in ''.join(ret['stderr'])
+
+
+def test_ssl_override_global_with_bad(utils):
+    ret = run_tdnf_test(utils, global_cert=GOOD_CERT_PATH, repo_cert=BAD_CERT_PATH)
+    assert ret['retval'] != 0
+    assert 'SSL peer certificate' in ''.join(ret['stderr']) or 'curl error' in ''.join(ret['stderr'])
+
+
+def test_ssl_env_only(utils):
+    ret = run_tdnf_test(utils, env_cert=GOOD_CERT_PATH)
+    assert ret['retval'] != 0
+    assert '404' in ''.join(ret['stderr'])
+
+
+def test_ssl_override_repo_with_env(utils):
+    ret = run_tdnf_test(utils, repo_cert=BAD_CERT_PATH, env_cert=GOOD_CERT_PATH)
+    assert ret['retval'] != 0
+    assert '404' in ''.join(ret['stderr'])
+
+
+def test_ssl_override_env_with_bad_setopt(utils):
+    ret = run_tdnf_test(utils, env_cert=GOOD_CERT_PATH, setopt_cert=BAD_CERT_PATH)
+    assert ret['retval'] != 0
+    assert 'SSL peer certificate' in ''.join(ret['stderr']) or 'curl error' in ''.join(ret['stderr'])


### PR DESCRIPTION
## Summary

This PR introduces global SSL configuration inheritance and `SSL_CERT_FILE` environment variable support to `tdnf`, ensuring that SSL settings follow a canonical precedence hierarchy.

Previously, `sslcacert` had to be explicitly defined in every single `.repo` file, which was problematic for transparent MITM proxies. Additionally, `tdnf` did not respect the standard `SSL_CERT_FILE` environment variable.

### Changes Made

- **Global SSL Configuration**: Added support for parsing `sslcacert`, `sslclientcert`, and `sslclientkey` in the `[main]` section of `tdnf.conf`. These settings are now inherited by all repositories unless explicitly overridden.
- **Environment Variable Support**: Added support for the `SSL_CERT_FILE` environment variable to override configuration files.
- **Canonical Precedence Hierarchy**: Enforced the standard configuration precedence (from highest to lowest priority):
  1. Command-line arguments (`--setopt=sslcacert=...` or `--setopt=repoid.sslcacert=...`)
  2. Environment variable (`SSL_CERT_FILE`)
  3. Per-repository configuration (`.repo` files)
  4. Global configuration (`tdnf.conf`)
- **Memory Leak Fix**: Fixed a pre-existing memory leak where `pszSnapshotUrl` and `pszSnapshotFile` were not being freed when destroying repository data structures. Consolidated `TDNFFreeReposInternal` and `TDNFFreeRepos` to prevent future drift.
- **Test Suite Updates**: Added a new pytest module (`test_ssl_config.py`) that spins up a local HTTPS server with self-signed certificates to verify the new inheritance and precedence logic. Updated `TestUtils.run()` in `conftest.py` to accept custom environment variables for testing.