### PR TITLE
fix potential overflow when adding to unresolved packages

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1691,7 +1691,7 @@ TDNFResolve(
         dwError = TDNFResolveBuildDependencies(
                         pTdnf,
                         ppszPkgNames,
-                        ppszPkgsNotResolved,
+                        &ppszPkgsNotResolved,
                         &queueGoal);
     }
     BAIL_ON_TDNF_ERROR(dwError);

--- a/client/prototypes.h
+++ b/client/prototypes.h
@@ -741,7 +741,7 @@ uint32_t
 TDNFResolveBuildDependencies(
     PTDNF pTdnf,
     char **ppszPackageNameSpecs,
-    char **ppszPkgsNotResolved,
+    char ***pppszPkgsNotResolved,
     Queue* queueGoal
     );
 

--- a/client/resolve.c
+++ b/client/resolve.c
@@ -482,7 +482,7 @@ uint32_t
 TDNFResolveBuildDependencies(
     PTDNF pTdnf,
     char **ppszPackageNameSpecs,
-    char **ppszPkgsNotResolved,
+    char ***pppszPkgsNotResolved,
     Queue* queueGoal
     )
 {
@@ -530,6 +530,14 @@ TDNFResolveBuildDependencies(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
+    if (qDeps.count > 0) {
+        dwError = TDNFReAllocateMemory(
+                      (pTdnf->pArgs->nCmdCount + qDeps.count + 1) * sizeof(char*),
+                      (void**)pppszPkgsNotResolved);
+        BAIL_ON_TDNF_ERROR(dwError);
+        memset(*pppszPkgsNotResolved + pTdnf->pArgs->nCmdCount, 0, (qDeps.count + 1) * sizeof(char*));
+    }
+
     for (i = 0; i < qDeps.count; i++) {
         pszDep = pool_dep2str(pTdnf->pSack->pPool, qDeps.elements[i]);
         if (!pszDep) {
@@ -545,7 +553,7 @@ TDNFResolveBuildDependencies(
                       pTdnf,
                       pszDep,
                       ALTER_INSTALL,
-                      ppszPkgsNotResolved,
+                      *pppszPkgsNotResolved,
                       queueGoal);
         BAIL_ON_TDNF_ERROR(dwError);
     }


### PR DESCRIPTION
## Summary
Fix a potential heap buffer overflow when resolving missing build dependencies.

## Details
In `TDNFResolve`, the `ppszPkgsNotResolved` array is initially allocated to hold exactly `nCmdCount` (the number of command-line arguments) pointers. However, when parsing a spec file for `build-dep`, the file can contain dozens of build dependencies. If multiple dependencies are missing, `TDNFAddNotResolved` appends them to this array, writing past its allocated bounds and causing a heap buffer overflow.

This PR fixes the issue by:
- Modifying `TDNFResolveBuildDependencies` to accept a pointer to the array (`char ***pppszPkgsNotResolved`).
- Dynamically reallocating the array using `TDNFReAllocateMemory` to `nCmdCount + qDeps.count + 1` before processing the dependencies.
- Zero-initializing the newly allocated memory so `TDNFAddNotResolved` can correctly find the end of the array.

## Test plan
- Ran the full `tdnf` test suite via `pytest pytests/tests/` inside the `photon/tdnf-build` container; all tests pass successfully.
- Verified `tdnf build-dep` on a spec file with multiple missing dependencies no longer crashes or corrupts memory.