### PR TITLE
fix a memory leak in an error case - use TDNFFreeRepos instead of TDN…

### DIFF
--- a/client/repolist.c
+++ b/client/repolist.c
@@ -726,7 +726,7 @@ error:
     {
         *ppRepos = NULL;
     }
-    TDNF_SAFE_FREE_MEMORY(pRepo);
+    TDNFFreeRepos(pRepo);
     if(pRepos)
     {
         TDNFFreeRepos(pRepos);


### PR DESCRIPTION
use `TDNFFreeRepos()` instead of `TDNF_SAFE_FREE_MEMORY()` to free struct members.