### PR TITLE
fix: disable VSFlags signature/digest checks when gpgcheck is off

### DIFF
--- a/client/gpgcheck.c
+++ b/client/gpgcheck.c
@@ -243,6 +243,7 @@ TDNFGPGCheckPackage(
         }
         rpmtsSetVfyLevel(pTS->pTS, level);
     } else {
+        rpmtsSetVSFlags(pTS->pTS, rpmtsVSFlags(pTS->pTS) | RPMVSF_MASK_NOSIGNATURES | RPMVSF_MASK_NODIGESTS);
         rpmtsSetVfyLevel(pTS->pTS, RPMSIG_NONE_TYPE);
     }
 


### PR DESCRIPTION
`TDNFGPGCheckPackage` only cleared `rpmtsVfyLevel` when gpgcheck was disabled (via `--nogpgcheck` or repo `gpgcheck=0`), leaving VSFlags untouched. `rpmReadPackageFile()` still ran full signature verification as a result, so a package with a technically-invalid-but-otherwise-fine signature (e.g. "not alive yet" due to local clock skew) would still fail even with `--nogpgcheck`. Mirror the VSFlags masking already done in the enabled branch and in `rpmtrans.c`'s transaction-level check.