### PR TITLE
fix: sort directory listings when discovering repos and local repo rpms

### DIFF
--- a/client/config.c
+++ b/client/config.c
@@ -797,6 +797,17 @@ cleanup:
         }
         free(ppDirEntries);
     }
+    if (pppszArrayList)
+    {
+        /* on error, entries already read from files (but not yet moved
+         * into ppszNewLines) still own their string arrays; free them.
+         * Stop before the appended *pppszLines entry, which the caller
+         * still owns when we bail out before it is replaced below. */
+        for (i = 0; pppszArrayList[i] && pppszArrayList[i] != *pppszLines; i++)
+        {
+            TDNF_SAFE_FREE_STRINGARRAY(pppszArrayList[i]);
+        }
+    }
     TDNF_SAFE_FREE_MEMORY(pppszArrayList);
     TDNF_SAFE_FREE_MEMORY(pszFile);
     return dwError;

--- a/client/config.c
+++ b/client/config.c
@@ -700,8 +700,9 @@ TDNFReadConfFilesFromDir(
     )
 {
     uint32_t dwError = 0;
-    DIR *pDir = NULL;
-    struct dirent *pEnt = NULL;
+    struct dirent **ppDirEntries = NULL;
+    int nDirEntries = -1;
+    int nDirIndex;
     char *pszFile = NULL;
     char **ppszNewLines = NULL;
     char ***pppszArrayList = NULL;
@@ -716,40 +717,39 @@ TDNFReadConfFilesFromDir(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    /* first, open directory and count all files match *.conf,
-     * so we know how much memory we need */
-    pDir = opendir(pszDir);
-    if (pDir == NULL)
+    /* read and sort the directory once, so drop-in *.conf files are
+     * applied in a predictable, filename-controllable order instead of
+     * raw filesystem readdir() order (which is not guaranteed stable) */
+    nDirEntries = scandir(pszDir, &ppDirEntries, NULL, alphasort);
+    if (nDirEntries < 0)
     {
         goto cleanup;
     }
 
-    while((pEnt = readdir(pDir)) != NULL)
+    /* count all files matching *.conf, so we know how much memory we need */
+    for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
     {
-        if (fnmatch("*.conf", pEnt->d_name, 0) != 0)
+        if (fnmatch("*.conf", ppDirEntries[nDirIndex]->d_name, 0) != 0)
         {
             continue;
         }
         nFileCount++;
     }
-    closedir(pDir);
-    pDir = NULL;
 
     /* allocate memory for our string array */
     dwError = TDNFAllocateMemory(nFileCount + 1, sizeof(char **), (void **)&pppszArrayList);
     BAIL_ON_TDNF_ERROR(dwError);
 
-    /* read directory again and the files, store content of each file
+    /* read the files in sorted order, store content of each file
      * temporarily in pppszArrayList[i] */
     i = 0;
-    pDir = opendir(pszDir);
-    while((pEnt = readdir(pDir)) != NULL && i < nFileCount)
+    for (nDirIndex = 0; nDirIndex < nDirEntries && i < nFileCount; nDirIndex++)
     {
-        if (fnmatch("*.conf", pEnt->d_name, 0) != 0)
+        if (fnmatch("*.conf", ppDirEntries[nDirIndex]->d_name, 0) != 0)
         {
             continue;
         }
-        dwError = TDNFJoinPath(&pszFile, pszDir, pEnt->d_name, NULL);
+        dwError = TDNFJoinPath(&pszFile, pszDir, ppDirEntries[nDirIndex]->d_name, NULL);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = TDNFReadFileToStringArray(pszFile, &pppszArrayList[i]);
@@ -759,8 +759,6 @@ TDNFReadConfFilesFromDir(
 
         i++;
     }
-    closedir(pDir);
-    pDir = NULL;
 
     /* append values that are already set */
     pppszArrayList[i] = *pppszLines;
@@ -791,9 +789,13 @@ TDNFReadConfFilesFromDir(
     *pppszLines = ppszNewLines;
 
 cleanup:
-    if (pDir)
+    if (ppDirEntries)
     {
-        closedir(pDir);
+        for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
+        {
+            free(ppDirEntries[nDirIndex]);
+        }
+        free(ppDirEntries);
     }
     TDNF_SAFE_FREE_MEMORY(pppszArrayList);
     TDNF_SAFE_FREE_MEMORY(pszFile);

--- a/client/plugins.c
+++ b/client/plugins.c
@@ -249,8 +249,9 @@ _TDNFLoadPluginConfigs(
     )
 {
     uint32_t dwError = 0;
-    DIR *pDir = NULL;
-    struct dirent *pEnt = NULL;
+    struct dirent **ppDirEntries = NULL;
+    int nDirEntries = -1;
+    int nDirIndex;
     int nExtLen = TDNF_PLUGIN_CONF_EXT_LEN;
     PTDNF_PLUGIN pPlugin = NULL;
     PTDNF_PLUGIN pPlugins = NULL;
@@ -263,18 +264,22 @@ _TDNFLoadPluginConfigs(
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    pDir = opendir(pTdnf->pConf->pszPluginConfPath);
-    if(pDir == NULL)
+    /* sort alphabetically so plugin load order (and thus event-dispatch
+       order for plugins sharing an event) does not depend on filesystem
+       readdir() order, which is not guaranteed stable */
+    nDirEntries = scandir(pTdnf->pConf->pszPluginConfPath, &ppDirEntries, NULL, alphasort);
+    if(nDirEntries < 0)
     {
         dwError = ERROR_TDNF_NO_PLUGIN_CONF_DIR;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    while((pEnt = readdir(pDir)) != NULL)
+    for(nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
     {
-        int nLen = strlen(pEnt->d_name);
+        const char *pszName = ppDirEntries[nDirIndex]->d_name;
+        int nLen = strlen(pszName);
         if (nLen <= nExtLen ||
-            strcmp(pEnt->d_name + nLen - nExtLen, TDNF_PLUGIN_CONF_EXT))
+            strcmp(pszName + nLen - nExtLen, TDNF_PLUGIN_CONF_EXT))
         {
             continue;
         }
@@ -282,14 +287,14 @@ _TDNFLoadPluginConfigs(
         dwError = TDNFJoinPath(
                       &pszPluginConfig,
                       pTdnf->pConf->pszPluginConfPath,
-                      pEnt->d_name,
+                      pszName,
                       NULL);
         BAIL_ON_TDNF_ERROR(dwError);
 
         dwError = _TDNFLoadPluginConfig(pszPluginConfig, &pPlugin);
         BAIL_ON_TDNF_ERROR(dwError);
 
-        dwError = TDNFAllocateStringN(pEnt->d_name, nLen - nExtLen, &pPlugin->pszName);
+        dwError = TDNFAllocateStringN(pszName, nLen - nExtLen, &pPlugin->pszName);
         BAIL_ON_TDNF_ERROR(dwError);
 
         TDNF_SAFE_FREE_MEMORY(pszPluginConfig);
@@ -309,9 +314,13 @@ _TDNFLoadPluginConfigs(
     *ppPlugins = pPlugins;
 
 cleanup:
-    if(pDir)
+    if (ppDirEntries)
     {
-        closedir(pDir);
+        for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
+        {
+            free(ppDirEntries[nDirIndex]);
+        }
+        free(ppDirEntries);
     }
     TDNF_SAFE_FREE_MEMORY(pszPluginConfig);
     return dwError;

--- a/client/repolist.c
+++ b/client/repolist.c
@@ -184,8 +184,9 @@ TDNFLoadRepoData(
     PTDNF_REPO_DATA pReposAll = NULL;
     PTDNF_REPO_DATA *ppRepoNext = NULL;
     PTDNF_CONF pConf = NULL;
-    DIR *pDir = NULL;
-    struct dirent *pEnt = NULL;
+    struct dirent **ppDirEntries = NULL;
+    int nDirEntries = -1;
+    int nDirIndex = 0;
     char **ppszUrlIdTuple = NULL;
     PTDNF_REPO_DATA pRepoParsePre = NULL;
     PTDNF_REPO_DATA pRepoParseNext = NULL;
@@ -245,19 +246,22 @@ TDNFLoadRepoData(
         }
     }
 
-    pDir = opendir(pConf->pszRepoDir);
-    if(pDir == NULL)
+    /* sort alphabetically so repo processing order does not depend on
+       filesystem readdir() order, which is not guaranteed stable */
+    nDirEntries = scandir(pConf->pszRepoDir, &ppDirEntries, NULL, alphasort);
+    if (nDirEntries < 0)
     {
         dwError = ERROR_TDNF_REPO_DIR_OPEN;
         BAIL_ON_TDNF_ERROR(dwError);
     }
 
-    while ((pEnt = readdir (pDir)) != NULL )
+    for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
     {
-        int nLen = strlen(pEnt->d_name);
+        const char *pszName = ppDirEntries[nDirIndex]->d_name;
+        int nLen = strlen(pszName);
         int nLenRepoExt = strlen(TDNF_REPO_EXT);
         if (nLen <= nLenRepoExt ||
-            strcmp(pEnt->d_name + nLen - nLenRepoExt, TDNF_REPO_EXT))
+            strcmp(pszName + nLen - nLenRepoExt, TDNF_REPO_EXT))
         {
             continue;
         }
@@ -265,7 +269,7 @@ TDNFLoadRepoData(
         dwError = TDNFJoinPath(
                       &pszRepoFilePath,
                       pConf->pszRepoDir,
-                      pEnt->d_name,
+                      pszName,
                       NULL);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -311,9 +315,13 @@ TDNFLoadRepoData(
 
     *ppReposAll = pReposAll;
 cleanup:
-    if(pDir)
+    if (ppDirEntries)
     {
-        closedir(pDir);
+        for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++)
+        {
+            free(ppDirEntries[nDirIndex]);
+        }
+        free(ppDirEntries);
     }
     TDNF_SAFE_FREE_MEMORY(pszRepoFilePath);
     TDNF_SAFE_FREE_STRINGARRAY(ppszUrlIdTuple);

--- a/pytests/tests/test_determinism.py
+++ b/pytests/tests/test_determinism.py
@@ -1,0 +1,147 @@
+import os
+import json
+import pytest
+
+
+# Regression tests for the directory-listing determinism fixes in
+# client/repolist.c, client/plugins.c and client/config.c: these switched
+# from raw opendir()/readdir() (whose order is filesystem-dependent and not
+# guaranteed stable) to scandir()+alphasort(), so repo config discovery,
+# plugin config discovery, and config drop-in ("*.d") discovery all process
+# entries in a fixed, alphabetically-sorted order.
+#
+# Each test below deliberately creates the "high" (zzz-ish) filename before
+# the "low" (aaa-ish) one, i.e. reverse-alphabetical creation order, so that
+# a regression back to unsorted readdir() would tend to surface the entries
+# in creation order (high before low) on filesystems that return readdir()
+# entries roughly in creation order for small directories - and thus be
+# caught by asserting the low entry is processed/observed first.
+
+REPO_LOW = 'aaa-determinism'
+REPO_HIGH = 'zzz-determinism'
+
+PLUGIN_LOW = 'aaa_plugin_determinism'
+PLUGIN_HIGH = 'zzz_plugin_determinism'
+
+
+@pytest.fixture(scope='function', autouse=True)
+def setup_test(utils):
+    yield
+    teardown_test(utils)
+
+
+def teardown_test(utils):
+    repo_dir = os.path.join(utils.config['repo_path'], 'yum.repos.d')
+    for repoid in (REPO_LOW, REPO_HIGH):
+        fn = os.path.join(repo_dir, '{}.repo'.format(repoid))
+        if os.path.isfile(fn):
+            os.remove(fn)
+
+    plugin_conf_path = os.path.join(utils.config['repo_path'], 'pluginconf.d')
+    for name in (PLUGIN_LOW, PLUGIN_HIGH):
+        fn = os.path.join(plugin_conf_path, name + '.conf')
+        if os.path.isfile(fn):
+            os.remove(fn)
+    utils.edit_config({'plugins': None, 'pluginconfpath': None})
+
+    locks_dir = os.path.join(utils.config['repo_path'], 'locks.d')
+    for name in ('zzz-determinism.conf', 'aaa-determinism.conf'):
+        fn = os.path.join(locks_dir, name)
+        if os.path.isfile(fn):
+            os.remove(fn)
+
+    utils.erase_package(utils.config['sglversion_pkgname'])
+    utils.erase_package(utils.config['sglversion2_pkgname'])
+
+
+def find_repo_index(repolist, repoid):
+    for i, repo in enumerate(repolist):
+        if repo['Repo'] == repoid:
+            return i
+    return None
+
+
+# client/repolist.c: TDNFLoadRepoData() must process *.repo files from
+# reposdir in alphabetical filename order, independent of on-disk order.
+def test_repolist_dir_order_is_alphabetical(utils):
+    repo_dir = os.path.join(utils.config['repo_path'], 'yum.repos.d')
+
+    for repoid in (REPO_HIGH, REPO_LOW):
+        utils.edit_config(
+            {
+                'name': repoid,
+                'enabled': '1',
+                'baseurl': 'http://pkgs.{}.org/repo'.format(repoid),
+            },
+            section=repoid,
+            filename=os.path.join(repo_dir, '{}.repo'.format(repoid)),
+        )
+
+    ret = utils.run(['tdnf', 'repolist', 'all', '-j'])
+    assert ret['retval'] == 0
+    repolist = json.loads('\n'.join(ret['stdout']))
+
+    idx_low = find_repo_index(repolist, REPO_LOW)
+    idx_high = find_repo_index(repolist, REPO_HIGH)
+    assert idx_low is not None
+    assert idx_high is not None
+    # tdnf repolist prints repos in the order they were loaded, with no
+    # further re-sorting (tools/cli/lib/api.c), so this directly reflects
+    # TDNFLoadRepoData()'s directory-scan order.
+    assert idx_low < idx_high
+
+
+# client/plugins.c: _TDNFLoadPluginConfigs() must process plugin *.conf
+# files in alphabetical filename order, independent of on-disk order.
+# Neither fake plugin has a matching .so, so tdnf attempts and fails to
+# load each one in turn, printing one "Error loading plugin: .../lib<name>.so"
+# line per plugin - in the order plugin configs were processed.
+def test_plugin_conf_dir_order_is_alphabetical(utils):
+    plugin_conf_path = os.path.join(utils.config['repo_path'], 'pluginconf.d')
+    os.makedirs(plugin_conf_path, exist_ok=True)
+
+    utils.edit_config({'plugins': '1', 'pluginconfpath': plugin_conf_path})
+
+    for name in (PLUGIN_HIGH, PLUGIN_LOW):
+        with open(os.path.join(plugin_conf_path, name + '.conf'), 'w') as f:
+            f.write('[main]\nenabled=1\n')
+
+    ret = utils.run(['tdnf', 'repolist'])
+    assert ret['retval'] == 0
+
+    load_errors = [line for line in ret['stderr'] if line.startswith('Error loading plugin')]
+    assert len(load_errors) == 2
+    assert PLUGIN_LOW in load_errors[0]
+    assert PLUGIN_HIGH in load_errors[1]
+
+
+# client/config.c: TDNFReadConfFilesFromDir() (used for locks.d,
+# minversions.d and protected.d) was rewritten from a fragile two-pass
+# opendir()/readdir() (count, then re-open and re-read - a TOCTOU risk if
+# the directory changed in between) to a single sorted scandir() pass.
+# This is a regression test for that rewrite: with multiple drop-in files
+# present, all of them must still be read and applied, regardless of
+# on-disk order or how many *.conf files exist in the directory.
+def test_locks_multiple_dropin_files_all_applied(utils):
+    dirname = os.path.join(utils.config['repo_path'], 'locks.d')
+    os.makedirs(dirname, exist_ok=True)
+
+    pkg1 = utils.config['sglversion_pkgname']
+    pkg2 = utils.config['sglversion2_pkgname']
+
+    with open(os.path.join(dirname, 'zzz-determinism.conf'), 'w') as f:
+        f.write(pkg1 + '\n')
+    with open(os.path.join(dirname, 'aaa-determinism.conf'), 'w') as f:
+        f.write(pkg2 + '\n')
+
+    utils.install_package(pkg1)
+    utils.install_package(pkg2)
+    assert utils.check_package(pkg1)
+    assert utils.check_package(pkg2)
+
+    utils.run(['tdnf', '-y', '--nogpgcheck', 'remove', pkg1])
+    utils.run(['tdnf', '-y', '--nogpgcheck', 'remove', pkg2])
+
+    # both locks must be honored, regardless of drop-in file processing order
+    assert utils.check_package(pkg1)
+    assert utils.check_package(pkg2)

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -315,7 +315,8 @@ readRpmsFromDir(
         if (isDir) {
             dwError = readRpmsFromDir(pRepo, pszPath);
             BAIL_ON_TDNF_ERROR(dwError);
-        } else if (strcmp(&pszName[strlen(pszName)-4], ".rpm") == 0) {
+        } else if (strlen(pszName) > 4 &&
+                   strcmp(&pszName[strlen(pszName)-4], ".rpm") == 0) {
             if(!repo_add_rpm(pRepo,
                              pszPath,
                              REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE)) {

--- a/solv/tdnfrepo.c
+++ b/solv/tdnfrepo.c
@@ -277,19 +277,23 @@ readRpmsFromDir(
 )
 {
     uint32_t dwError = 0;
-    DIR *pDir = NULL;
-    struct dirent *pEnt = NULL;
+    struct dirent **ppDirEntries = NULL;
+    int nDirEntries = -1;
+    int nDirIndex = 0;
     char *pszPath = NULL;
 
-    pDir = opendir(pszDir);
-    if(pDir == NULL) {
+    /* sort alphabetically so rpm processing order does not depend on
+       filesystem readdir() order, which is not guaranteed stable */
+    nDirEntries = scandir(pszDir, &ppDirEntries, NULL, alphasort);
+    if (nDirEntries < 0) {
         dwError = errno;
         BAIL_ON_TDNF_SYSTEM_ERROR(dwError);
     }
-    while ((pEnt = readdir (pDir)) != NULL ) {
+    for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++) {
+        const char *pszName = ppDirEntries[nDirIndex]->d_name;
         int isDir;
 
-        if (pEnt->d_name[0] == '.') {
+        if (pszName[0] == '.') {
             /* skip '.', '..', but also any dir name starting with '.' */
             continue;
         }
@@ -297,7 +301,7 @@ readRpmsFromDir(
         dwError = TDNFJoinPath(
                       &pszPath,
                       pszDir,
-                      pEnt->d_name,
+                      pszName,
                       NULL);
         BAIL_ON_TDNF_ERROR(dwError);
 
@@ -311,7 +315,7 @@ readRpmsFromDir(
         if (isDir) {
             dwError = readRpmsFromDir(pRepo, pszPath);
             BAIL_ON_TDNF_ERROR(dwError);
-        } else if (strcmp(&pEnt->d_name[strlen(pEnt->d_name)-4], ".rpm") == 0) {
+        } else if (strcmp(&pszName[strlen(pszName)-4], ".rpm") == 0) {
             if(!repo_add_rpm(pRepo,
                              pszPath,
                              REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE)) {
@@ -322,8 +326,11 @@ readRpmsFromDir(
         TDNF_SAFE_FREE_MEMORY(pszPath);
     }
 cleanup:
-    if(pDir) {
-        closedir(pDir);
+    if (ppDirEntries) {
+        for (nDirIndex = 0; nDirIndex < nDirEntries; nDirIndex++) {
+            free(ppDirEntries[nDirIndex]);
+        }
+        free(ppDirEntries);
     }
     TDNF_SAFE_FREE_MEMORY(pszPath);
 


### PR DESCRIPTION
`readdir()` order is filesystem-dependent and not guaranteed stable across runs, which made repo config discovery (`repolist.c`) and local directory-repo rpm discovery (`tdnfrepo.c`) a source of non-deterministic solvable-Id assignment. Switch both to `scandir()`+`alphasort()` so repo/rpm processing order is consistent regardless of underlying filesystem.