### PR TITLE
stable-3.6: Fix repoquery exit status on failure

### DIFF
--- a/client/api.c
+++ b/client/api.c
@@ -1603,7 +1603,10 @@ error:
     TDNFFreePackageInfo(pPkgInfo);
     if(dwError == ERROR_TDNF_NO_MATCH)
     {
-        dwError = ERROR_TDNF_NO_DATA;
+        if (pRepoqueryArgs->pszSpec)
+        {
+            pr_err("ERROR: No match found for: %s\n", pRepoqueryArgs->pszSpec);
+        }
     }
     goto cleanup;
 }

--- a/pytests/tests/test_repoquery.py
+++ b/pytests/tests/test_repoquery.py
@@ -351,3 +351,10 @@ def test_queryformat(utils):
 
     assert BASE_PKG in '\n'.join(ret['stdout'])
     assert '\n'.join(ret['stdout']).startswith("http://localhost:8080/photon-test")
+
+
+def test_package_not_found(utils):
+    pkg = "this-package-does-not-exist"
+    ret = utils.run(["tdnf", "repoquery", pkg])
+    assert f"ERROR: No match found for: {pkg}" in "\n".join(ret['stderr'])
+    assert ret['retval'] == 1011


### PR DESCRIPTION
Return with non zero exit status when repoquery is a miss.

This is a port of commit 3aefeaf3 from dev branch.

Original PR: https://github.com/vmware/tdnf/pull/584