### PR TITLE
stable-3.3: fix: skip printing problems filtered by --skipconflicts/--skipobsoletes

### DIFF
--- a/solv/tdnfpackage.c
+++ b/solv/tdnfpackage.c
@@ -1730,11 +1730,12 @@ SolvReportProblems(
             }
         }
 
-        if (!SkipBasedOnType(pSolv, type, dwSource, dwSkipProblem))
+        if (SkipBasedOnType(pSolv, type, dwSource, dwSkipProblem))
         {
-            dwError = ERROR_TDNF_SOLV_FAILED;
+            continue;
         }
 
+        dwError = ERROR_TDNF_SOLV_FAILED;
         pr_err("%u. %s\n", ++total_prblms, pszProblem);
     }
 


### PR DESCRIPTION
In SolvReportProblems, pr_err was unconditionally called after the SkipBasedOnType check, so skipped problems were still printed even though the exit code was correctly 0. Use continue to skip the entire problem (including the print) when SkipBasedOnType returns true.