### PR TITLE
fix: include epoch in Evr field of JSON transaction output

### DIFF
--- a/pytests/repo/tdnf-test-epoch.spec
+++ b/pytests/repo/tdnf-test-epoch.spec
@@ -1,0 +1,29 @@
+#
+# tdnf-test-epoch spec file
+#
+Summary:    package with a non-zero epoch, for Evr/json tests.
+Name:       tdnf-test-epoch
+Epoch:      1
+Version:    1.0.1
+Release:    1
+Vendor:     VMware, Inc.
+Distribution:   Photon
+License:    VMware
+Url:        http://www.vmware.com
+Group:      Applications/tdnftest
+
+%description
+Part of tdnf test spec. Used to verify that the epoch is preserved
+in the Evr field of json output (see tdnf issue #602).
+
+%prep
+
+%build
+
+%install
+
+%files
+
+%changelog
+*   Fri Sep 4 2026 Oliver Kurth <oliver.kurth@broadcom.com> 1:1.0.1-1
+-   Initial build, with non-zero epoch for json Evr test.

--- a/pytests/tests/test_json.py
+++ b/pytests/tests/test_json.py
@@ -12,6 +12,8 @@ import os
 
 
 PKGNAME_VERBOSE_SCRIPTS = "tdnf-verbose-scripts"
+PKGNAME_EPOCH = "tdnf-test-epoch"
+PKGEVR_EPOCH = "1:1.0.1-1"
 
 
 @pytest.fixture(scope='function', autouse=True)
@@ -136,6 +138,41 @@ def test_erase_verbose(utils):
             pkg_found = True
             break
     assert pkg_found
+
+
+# regression test for https://github.com/vmware/tdnf/issues/602:
+# the Evr field of a solved transaction must include a non-zero epoch.
+def test_install_erase_evr_epoch(utils):
+    pkgname = PKGNAME_EPOCH
+    utils.erase_package(pkgname)
+
+    ret = utils.run(['tdnf',
+                     '-j', '-y', '--nogpgcheck',
+                     'install', pkgname])
+    assert utils.check_package(pkgname)
+    install_info = json.loads("\n".join(ret['stdout']))
+
+    pkg = None
+    for p in install_info["Install"]:
+        if p['Name'] == pkgname:
+            pkg = p
+            break
+    assert pkg is not None
+    assert pkg['Evr'] == PKGEVR_EPOCH
+
+    ret = utils.run(['tdnf',
+                     '-j', '-y', '--nogpgcheck',
+                     'erase', pkgname])
+    assert not utils.check_package(pkgname)
+    erase_info = json.loads("\n".join(ret['stdout']))
+
+    pkg = None
+    for p in erase_info["Remove"]:
+        if p['Name'] == pkgname:
+            pkg = p
+            break
+    assert pkg is not None
+    assert pkg['Evr'] == PKGEVR_EPOCH
 
 
 def test_check_update(utils):

--- a/tools/cli/lib/installcmd.c
+++ b/tools/cli/lib/installcmd.c
@@ -391,7 +391,7 @@ JDPkgList(
 
         CHECK_JD_RC(jd_map_add_string(jd_pkg, "Name", pPkgInfo->pszName));
         CHECK_JD_RC(jd_map_add_string(jd_pkg, "Arch", pPkgInfo->pszArch));
-        CHECK_JD_RC(jd_map_add_fmt(jd_pkg, "Evr", "%s-%s", pPkgInfo->pszVersion, pPkgInfo->pszRelease));
+        CHECK_JD_RC(jd_map_add_string(jd_pkg, "Evr", pPkgInfo->pszEVR));
         CHECK_JD_RC(jd_map_add_int(jd_pkg, "InstallSize", pPkgInfo->dwInstallSizeBytes));
         CHECK_JD_RC(jd_map_add_string(jd_pkg, "Repo", pPkgInfo->pszRepoName));
 


### PR DESCRIPTION
`JDPkgList()` built the "Evr" field from `pszVersion-pszRelease` only,
dropping the epoch for packages that have one non-zero. Other JSON
output call sites already use the pre-populated `pszEVR` field, which
includes epoch, so switch to that for consistency.

Fixes vmware/tdnf#602